### PR TITLE
Added support from reading from C# byte arrays. Plus contribution policy clarification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,15 @@ We've successfully built ParquetSharp for Windows using the following dependenci
 - Visual Studio 2017 (15.7 or higher)
 - Apache Parquet C++ (apache-parquet-cpp 1.4.0)
 
-For building apache-parquet-cpp and its dependencies, we recommend using Microsoft's [vcpkg](https://github.com/Microsoft/vcpkg) (vcpkg install x64-windows-static:parquet).
+For building apache-parquet-cpp and its dependencies, we recommend using Microsoft's [vcpkg](https://github.com/Microsoft/vcpkg) (vcpkg install parquet:x64-windows-static).
 
 Then use CMake to generate the Visual Studio solution (Win64) by setting `CMAKE_PREFIX_PATH` to point CMake to apache-parquet-cpp's compiled libraries and dependencies. (We have had to write our own `FindPackage` macros for most of the dependencies to get us going - it clearly needs more love and attention and is likely to be redundant with some vcpkg helper tools.)
 
 Building on Linux is a work in progress: in theory it is possible, but we have yet to try it. (We wanted to share this library with the open-source community as soon as possible, even if not everything is quite ready for prime time.)
+
+## Contributing
+
+We welcome new contributors! We will happily receive PRs for bug fixes or small changes. If you're contemplating something larger please get in touch first by opening a GitHub Issue describing the problem and how you propose to solve it.
 
 ## License
 

--- a/cpp/Buffer.cpp
+++ b/cpp/Buffer.cpp
@@ -6,6 +6,11 @@
 
 extern "C"
 {
+	PARQUETSHARP_EXPORT ExceptionInfo* Buffer_MakeFromPointer(const uint8_t* data, int64_t size, std::shared_ptr<arrow::Buffer>** buffer)
+	{
+		TRYCATCH(*buffer = new std::shared_ptr<arrow::Buffer>(new arrow::Buffer(data, size));)
+	}
+
 	PARQUETSHARP_EXPORT void Buffer_Free(std::shared_ptr<arrow::Buffer>* buffer)
 	{
 		delete buffer;

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>ParquetSharp.Test</AssemblyName>
     <RootNamespace>ParquetSharp.Test</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp.test/TestBuffer.cs
+++ b/csharp.test/TestBuffer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ParquetSharp.Schema;
+using ParquetSharp.IO;
+using NUnit.Framework;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestBuffer
+    {
+        [Test]
+        public static unsafe void TestMemoryBufferRoundtrip()
+        {
+            var expected = Enumerable.Range(0, 100).Select(i => (byte) i).ToArray();
+
+            fixed (byte* data = expected)
+            using (var buffer = new IO.Buffer(new IntPtr(data), expected.Length))
+            {
+                Assert.AreEqual(expected, buffer.ToArray());
+            }
+        }
+
+        [Test]
+        public static unsafe void TestParquetReadFromBuffer()
+        {
+            var expected = Enumerable.Range(0, 100).ToArray();
+
+            // Write out a single column
+            byte[] parquetFileBytes;
+            using (var outBuffer = new ResizableBuffer())
+            {
+                using (var outStream = new BufferOutputStream(outBuffer))
+                using (var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<int>("int_field")}))
+                using (var rowGroupWriter = fileWriter.AppendRowGroup())
+                using (var colWriter = rowGroupWriter.NextColumn().LogicalWriter<int>())
+                {
+                    colWriter.WriteBatch(expected);
+                }
+
+                parquetFileBytes = outBuffer.ToArray();
+            }
+
+            // Read it back
+            fixed (byte* fixedBytes = parquetFileBytes)
+            using (var buffer = new IO.Buffer(new IntPtr(fixedBytes), parquetFileBytes.Length))
+            using (var inStream = new BufferReader(buffer))
+            using (var fileReader = new ParquetFileReader(inStream))
+            using (var rowGroup = fileReader.RowGroup(0))
+            using (var columnReader = rowGroup.Column(0).LogicalReader<int>())
+            {
+                var allData = columnReader.ReadAll((int) rowGroup.MetaData.NumRows);
+                Assert.AreEqual(expected, allData);
+            }
+        }
+    }
+}

--- a/csharp/IO/Buffer.cs
+++ b/csharp/IO/Buffer.cs
@@ -8,6 +8,11 @@ namespace ParquetSharp.IO
     /// </summary>
     public class Buffer : IDisposable
     {
+        public Buffer(IntPtr data, long size)
+            : this(Make(data, size))
+        {
+        }
+
         internal Buffer(IntPtr handle)
         {
             Handle = new ParquetHandle(handle, Buffer_Free);
@@ -28,6 +33,15 @@ namespace ParquetSharp.IO
             Marshal.Copy(Data, array, 0, array.Length);
             return array;
         }
+
+        private static IntPtr Make(IntPtr data, long size)
+        {
+            ExceptionInfo.Check(Buffer_MakeFromPointer(data, size, out var bufferHandle));
+            return bufferHandle;
+        }
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr Buffer_MakeFromPointer(IntPtr data, long size, out IntPtr buffer);
 
         [DllImport(ParquetDll.Name)]
         private static extern void Buffer_Free(IntPtr buffer);

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>ParquetSharp</AssemblyName>
     <RootNamespace>ParquetSharp</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>1.4.0.1-beta6</Version>
+    <Version>1.4.0.1-beta7</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>
@@ -33,6 +33,10 @@
     <Content Include="..\bin\Release\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Release'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Add support for reading from .NET byte array
* Added back support for .NET Framework 4.6.1, needed to correctly inject the dependency on ValueTuple in .NET Framework projects.
* Next release is beta7; beta6 is a GR internal release.
* Amend Readme with new guidelines for contributing.