### PR TITLE
Fixed reader/writer not disposing on invalid cast exception

### DIFF
--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Parquet.Net" Version="3.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp.test/Program.cs
+++ b/csharp.test/Program.cs
@@ -18,11 +18,12 @@ namespace ParquetSharp.Test
 
                 AppDomain.CurrentDomain.UnhandledException += UncaughtExceptionHandler;
 
-                TestParquetFileWriter.TestReadWriteParquetMultipleTasks();
+                //TestParquetFileWriter.TestReadWriteParquetMultipleTasks();
                 //TestColumnReader.TestHasNext();
                 //TestLogicalTypeRoundtrip.TestReaderWriteTypes();
                 //TestPhysicalTypeRoundtrip.TestReaderWriteTypes();
                 //TestParquetFileReader.TestReadFileCreateByPython();
+                TestParquetFileReader.TestFileHandleHasBeenReleased();
 
                 // Ensure the finalizers are executed, so we can check whether they throw.
                 GC.Collect();

--- a/csharp/LogicalColumnReader.cs
+++ b/csharp/LogicalColumnReader.cs
@@ -23,7 +23,17 @@ namespace ParquetSharp
 
         internal static LogicalColumnReader<TElement> Create<TElement>(ColumnReader columnReader, int bufferLength)
         {
-            return (LogicalColumnReader<TElement>) Create(columnReader, bufferLength);
+            var reader = Create(columnReader, bufferLength);
+
+            try
+            {
+                return (LogicalColumnReader<TElement>) reader;
+            }
+            catch
+            {
+                reader.Dispose();
+                throw;
+            }
         }
 
         public bool HasNext => Source.HasNext;

--- a/csharp/LogicalColumnWriter.cs
+++ b/csharp/LogicalColumnWriter.cs
@@ -22,7 +22,17 @@ namespace ParquetSharp
 
         internal static LogicalColumnWriter<TElementType> Create<TElementType>(ColumnWriter columnWriter, int bufferLength = 4 * 1024)
         {
-            return (LogicalColumnWriter<TElementType>) Create(columnWriter, bufferLength);
+            var writer = Create(columnWriter, bufferLength);
+
+            try
+            {
+                return (LogicalColumnWriter<TElementType>) writer;
+            }
+            catch
+            {
+                writer.Dispose();
+                throw;
+            }
         }
 
         public abstract TReturn Apply<TReturn>(ILogicalColumnWriterVisitor<TReturn> visitor);


### PR DESCRIPTION
Fixed reader/writer not disposing on invalid cast exception when logical reader/writer are created.
Added Parquet.NET benchmark to TestParquetPerformance to give us one more point of reference.