### PR TITLE
Spans, IEnumerable and minor fixes.

### DIFF
--- a/csharp.test/LogicalColumnReaderToArray.cs
+++ b/csharp.test/LogicalColumnReaderToArray.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Linq;
+
+namespace ParquetSharp.Test
+{
+    internal sealed class LogicalColumnReaderToArray : ILogicalColumnReaderVisitor<Array>
+    {
+        public Array OnLogicalColumnReader<TValue>(LogicalColumnReader<TValue> columnReader)
+        {
+            return columnReader.ToArray();
+        }
+    }
+}

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Parquet.Net" Version="3.0.5" />
+    <PackageReference Include="Parquet.Net" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp.test/TestColumnWriter.cs
+++ b/csharp.test/TestColumnWriter.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+using ParquetSharp.IO;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestColumnWriter
+    {
+        [Test]
+        public static void TestWriteBatchWithNullOptionalField()
+        {
+            using (var buffer = new ResizableBuffer())
+            {
+                using (var outStream = new BufferOutputStream(buffer))
+                using (var writer = new ParquetFileWriter(outStream, new Column[] {new Column<int?>("int32?")}))
+                using (var rowGroupWriter = writer.AppendRowGroup())
+                using (var colWriter = (ColumnWriter<int>) rowGroupWriter.NextColumn())
+                {
+                    var defLevels = new short[] {1, 0, 1};
+                    var values = new[] {1, 2};
+
+                    colWriter.WriteBatch(defLevels.Length, defLevels, null, values);
+                }
+
+                using (var inStream = new BufferReader(buffer))
+                using (var reader = new ParquetFileReader(inStream))
+                using (var rowGroupReader = reader.RowGroup(0))
+                using (var colReader = rowGroupReader.Column(0).LogicalReader<int?>())
+                {
+                    var results = new int?[3];
+                    colReader.ReadBatch(results, 0, 3);
+
+                    Assert.AreEqual(new int?[] {1, null, 2}, results);
+                }
+            }
+        }
+    }
+}

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -84,7 +84,7 @@ namespace ParquetSharp.Test
                 using (var fileReader = new ParquetReader(memoryStream))
                 using (var rowGroupReader = fileReader.OpenRowGroupReader(0))
                 {
-                    var read = (decimal[]) rowGroupReader.ReadColumn(fileReader.Schema.DataFieldAt(0)).Data;
+                    var read = (decimal[]) rowGroupReader.ReadColumn(fileReader.Schema.GetDataFields()[0]).Data;
 
                     Assert.AreEqual(values, read);
                 }

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -59,9 +59,11 @@ namespace ParquetSharp.Test
 
                         for (int c = 0; c != fileMetaData.NumColumns; ++c)
                         {
+                            var expected = expectedColumns[c];
+
+                            // Test properties, and read methods.
                             using (var columnReader = rowGroupReader.Column(c).LogicalReader(readBufferLength))
                             {
-                                var expected = expectedColumns[c];
                                 var descr = columnReader.ColumnDescriptor;
                                 var chunkMetaData = rowGroupMetaData.GetColumnChunkMetaData(c);
                                 var statistics = chunkMetaData.Statistics;
@@ -93,6 +95,12 @@ namespace ParquetSharp.Test
                                 {
                                     Assert.IsNull(statistics);
                                 }
+                            }
+
+                            // Test IEnumerable interface
+                            using (var columnReader = rowGroupReader.Column(c).LogicalReader(readBufferLength))
+                            {
+                                Assert.AreEqual(expected.Values, columnReader.Apply(new LogicalColumnReaderToArray()));
                             }
                         }
                     }

--- a/csharp.test/TestParquetPerformance.cs
+++ b/csharp.test/TestParquetPerformance.cs
@@ -166,7 +166,7 @@ namespace ParquetSharp.Test
 
                 using (var stream = File.Create("float_timeseries.parquet.net"))
                 using (var parquetWriter = new ParquetWriter(schema, stream))
-                using (var groupWriter = parquetWriter.CreateRowGroup(dates.Length*objectIds.Length))
+                using (var groupWriter = parquetWriter.CreateRowGroup())
                 {
                     var dateTimeColumn = new DataColumn(dateTimeField,
                         dates.SelectMany(d => Enumerable.Repeat(new DateTimeOffset(d), objectIds.Length)).ToArray());
@@ -227,7 +227,7 @@ namespace ParquetSharp.Test
 
                 using (var stream = File.Create("decimal_timeseries.parquet.net"))
                 using (var parquetWriter = new ParquetWriter(schema, stream))
-                using (var groupWriter = parquetWriter.CreateRowGroup(values.Length))
+                using (var groupWriter = parquetWriter.CreateRowGroup())
                 {
                     groupWriter.WriteColumn(new DataColumn(valueField, values));
                 }

--- a/csharp/ColumnWriter.cs
+++ b/csharp/ColumnWriter.cs
@@ -181,7 +181,6 @@ namespace ParquetSharp
         public unsafe void WriteBatch(long numValues, ReadOnlySpan<short> defLevels, ReadOnlySpan<short> repLevels, ReadOnlySpan<TValue> values)
         {
             if (values == null) throw new ArgumentNullException(nameof(values));
-            if (values.Length < numValues) throw new ArgumentOutOfRangeException(nameof(values), "numValues is larger than length of values");
             if (defLevels != null && defLevels.Length < numValues) throw new ArgumentOutOfRangeException(nameof(defLevels), "numValues is larger than length of defLevels");
             if (repLevels != null && repLevels.Length < numValues) throw new ArgumentOutOfRangeException(nameof(repLevels), "numValues is larger than length of repLevels");
 

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -75,7 +75,7 @@ namespace ParquetSharp.RowOriented
 
         internal void WriteColumn<TValue>(TValue[] values, int length)
         {
-            using (var columnWriter = LogicalColumnWriter.Create<TValue>(_rowGroupWriter.NextColumn()))
+            using (var columnWriter = _rowGroupWriter.NextColumn().LogicalWriter<TValue>())
             {
                 columnWriter.WriteBatch(values, 0, length);
             }


### PR DESCRIPTION
* Added test for ColumnWriter.WriteBatch() with optional values.
Fixed precondition check.

* Added Span and ReadOnlySpan overload to LogicalColumnReader/Writer.

* Removed old API usage.

* Added IEnumerable<TElement> interface to LogicalColumnReader.
Upgraded nuget dependencies.