### PR TITLE
Fixed regression of not throwing exception on unsupported column types

### DIFF
--- a/csharp.test/TestColumn.cs
+++ b/csharp.test/TestColumn.cs
@@ -49,6 +49,9 @@ namespace ParquetSharp.Test
         public static void TestUnsupportedType()
         {
             Assert.False(Column.IsSupported(typeof(TestColumn)));
+
+            var exception = Assert.Throws<ArgumentException>(() => new Column<object>("unsupported").CreateSchemaNode());
+            Assert.AreEqual("unsupported logical type System.Object", exception.Message);
         }
 
         [Test]

--- a/csharp.test/TestColumnWriter.cs
+++ b/csharp.test/TestColumnWriter.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using ParquetSharp.IO;
 
 namespace ParquetSharp.Test
@@ -32,6 +33,19 @@ namespace ParquetSharp.Test
 
                     Assert.AreEqual(new int?[] {1, null, 2}, results);
                 }
+            }
+        }
+
+        [Test]
+        public static void TestUnsupportedType()
+        {
+            using (var buffer = new ResizableBuffer())
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                var exception = Assert.Throws<ArgumentException>(() => 
+                    new ParquetFileWriter(outStream, new Column[] {new Column<object>("unsupported")}));
+
+                Assert.AreEqual("unsupported logical type System.Object", exception.Message);
             }
         }
     }

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -99,7 +99,7 @@ namespace ParquetSharp
                 }
             }
 
-            return null;
+            throw new ArgumentException($"unsupported logical type {type}");
         }
 
         private static (LogicalType LogicalType, PhysicalType PhysicalType) GetEntry(

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -10,7 +10,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1591;</NoWarn>
-    <Version>1.4.0.2</Version>
+    <Version>1.4.0.3</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>


### PR DESCRIPTION
Bumped release version to 1.4.0.3.
Fixed regression of not throwing exception on unsupported column types.
Simplified TestBigArrayRoundtrip().