### PR TITLE
Address multiple pending issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat text eol=crlf
+*.csproj text eol=crlf
+*.cs text eol=crlf
+*.sln text eol=crlf
+*.targets text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 # Declare files that will always have CRLF line endings on checkout.
 *.bat text eol=crlf
 *.csproj text eol=crlf
-*.cs text eol=crlf
 *.sln text eol=crlf
 *.targets text eol=crlf
 

--- a/cpp/BufferOutputStream.cpp
+++ b/cpp/BufferOutputStream.cpp
@@ -23,7 +23,7 @@ extern "C"
 		TRYCATCH(*output_stream = new std::shared_ptr<arrow::io::BufferOutputStream>(new arrow::io::BufferOutputStream(*resizableBuffer));)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* BufferOutputStream_GetBuffer(const std::shared_ptr<arrow::io::BufferOutputStream>* output_stream, std::shared_ptr<arrow::Buffer>** buffer)
+	PARQUETSHARP_EXPORT ExceptionInfo* BufferOutputStream_Finish(const std::shared_ptr<arrow::io::BufferOutputStream>* output_stream, std::shared_ptr<arrow::Buffer>** buffer)
 	{
 		TRYCATCH
 		(

--- a/csharp.test/TestBuffer.cs
+++ b/csharp.test/TestBuffer.cs
@@ -52,5 +52,35 @@ namespace ParquetSharp.Test
                 Assert.AreEqual(expected, allData);
             }
         }
+
+        [Test]
+        public static void TestBufferOutputStreamFinish()
+        {
+            var expected = Enumerable.Range(0, 100).ToArray();
+
+            using (var outStream = new BufferOutputStream())
+            {
+                // Write out a single column
+                using (var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<int>("int_field")}))
+                using (var rowGroupWriter = fileWriter.AppendRowGroup())
+                using (var colWriter = rowGroupWriter.NextColumn().LogicalWriter<int>())
+                {
+                    colWriter.WriteBatch(expected);
+                }
+
+                // Read it back
+                using (var buffer = outStream.Finish())
+                {
+                    using (var inStream = new BufferReader(buffer))
+                    using (var fileReader = new ParquetFileReader(inStream))
+                    using (var rowGroup = fileReader.RowGroup(0))
+                    using (var columnReader = rowGroup.Column(0).LogicalReader<int>())
+                    {
+                        var allData = columnReader.ReadAll((int) rowGroup.MetaData.NumRows);
+                        Assert.AreEqual(expected, allData);
+                    }
+                }
+            }
+        }
     }
 }

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -440,10 +440,10 @@ namespace ParquetSharp.Test
                     Name = "string_field",
                     PhysicalType = PhysicalType.ByteArray,
                     LogicalType = LogicalType.Utf8,
-                    Values = Enumerable.Range(0, NumRows).Select(i => i % 9 == 0 ? null : $"Hello, {i}!").ToArray(),
-                    NullCount = (NumRows + 8) / 9,
-                    NumValues = NumRows - (NumRows + 8) / 9,
-                    Min = "Hello, 1!",
+                    Values = Enumerable.Range(0, NumRows).Select(i => i % 9 == 0 ? i % 18 == 0 ? null : "" : $"Hello, {i}!").ToArray(),
+                    NullCount = (NumRows + 17) / 18,
+                    NumValues = NumRows - (NumRows + 17) / 18,
+                    Min = "",
                     Max = "Hello, 98!",
                     Converter = StringConverter
                 },
@@ -464,10 +464,10 @@ namespace ParquetSharp.Test
                 {
                     Name = "bytearray_field",
                     PhysicalType = PhysicalType.ByteArray,
-                    Values = Enumerable.Range(0, NumRows).Select(i => i % 3 == 0 ? null : BitConverter.GetBytes(i)).ToArray(),
-                    NullCount = (NumRows + 2) / 3,
-                    NumValues = NumRows - (NumRows + 2) / 3,
-                    Min = BitConverter.GetBytes(1),
+                    Values = Enumerable.Range(0, NumRows).Select(i => i % 3 == 0 ? i % 6 == 0 ? null : new byte[0] : BitConverter.GetBytes(i)).ToArray(),
+                    NullCount = (NumRows + 5) / 6,
+                    NumValues = NumRows - (NumRows + 5) / 6,
+                    Min = new byte[0],
                     Max = BitConverter.GetBytes(NumRows - 1),
                     Converter = ByteArrayConverter
                 },
@@ -622,14 +622,19 @@ namespace ParquetSharp.Test
         {
             var byteArray = (ByteArray) v;
             var array = new byte[byteArray.Length];
-            Marshal.Copy(byteArray.Pointer, array, 0, array.Length);
+            if (byteArray.Length != 0)
+            {
+                Marshal.Copy(byteArray.Pointer, array, 0, array.Length);
+            }
             return array;
         }
 
         private static unsafe object StringConverter(object v)
         {
             var byteArray = (ByteArray) v;
-            return System.Text.Encoding.UTF8.GetString((byte*) byteArray.Pointer, byteArray.Length);
+            return byteArray.Length == 0
+                ? string.Empty
+                : System.Text.Encoding.UTF8.GetString((byte*) byteArray.Pointer, byteArray.Length);
         }
 
         private sealed class ExpectedColumn

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -37,20 +37,6 @@ namespace ParquetSharp.Test
         {
             TestRoundtrip(new[]
             {
-                new Row1 {A = 123, B = 3.14f, C = new DateTime(1981, 06, 10)},
-                new Row1 {A = 456, B = 1.27f, C = new DateTime(1987, 03, 16)},
-                new Row1 {A = 789, B = 6.66f, C = new DateTime(2018, 05, 02)}
-            });
-
-            TestRoundtrip(new[]
-            {
-                new Row2 {A = 123, B = 3.14f, C = new DateTime(1981, 06, 10)},
-                new Row2 {A = 456, B = 1.27f, C = new DateTime(1987, 03, 16)},
-                new Row2 {A = 789, B = 6.66f, C = new DateTime(2018, 05, 02)}
-            });
-
-            TestRoundtrip(new[]
-            {
                 (123, 3.14f, new DateTime(1981, 06, 10)),
                 (456, 1.27f, new DateTime(1987, 03, 16)),
                 (789, 6.66f, new DateTime(2018, 05, 02))
@@ -61,6 +47,20 @@ namespace ParquetSharp.Test
                 Tuple.Create(123, 3.14f, new DateTime(1981, 06, 10)),
                 Tuple.Create(456, 1.27f, new DateTime(1987, 03, 16)),
                 Tuple.Create(789, 6.66f, new DateTime(2018, 05, 02))
+            });
+
+            TestRoundtrip(new[]
+            {
+                new Row1 {A = 123, B = 3.14f, C = new DateTime(1981, 06, 10), D = 123.1M},
+                new Row1 {A = 456, B = 1.27f, C = new DateTime(1987, 03, 16), D = 456.12M},
+                new Row1 {A = 789, B = 6.66f, C = new DateTime(2018, 05, 02), D = 789.123M}
+            });
+
+            TestRoundtrip(new[]
+            {
+                new Row2 {A = 123, B = 3.14f, C = new DateTime(1981, 06, 10), D = 123.1M},
+                new Row2 {A = 456, B = 1.27f, C = new DateTime(1987, 03, 16), D = 456.12M},
+                new Row2 {A = 789, B = 6.66f, C = new DateTime(2018, 05, 02), D = 789.123M}
             });
         }
 
@@ -90,11 +90,14 @@ namespace ParquetSharp.Test
             public float B;
             public DateTime C;
 
+            [ParquetDecimalScale(3)]
+            public decimal D;
+
             public bool Equals(Row1 other)
             {
                 if (ReferenceEquals(null, other)) return false;
                 if (ReferenceEquals(this, other)) return true;
-                return A == other.A && B.Equals(other.B) && C.Equals(other.C);
+                return A == other.A && B.Equals(other.B) && C.Equals(other.C) && D.Equals(other.D);
             }
         }
 
@@ -103,6 +106,9 @@ namespace ParquetSharp.Test
             public int A { get; set; }
             public float B { get; set; }
             public DateTime C { get; set; }
+
+            [ParquetDecimalScale(3)]
+            public decimal D { get; set; }
         }
 
 #if DUMP_EXPRESSION_TREES

--- a/csharp/IO/BufferOutputStream.cs
+++ b/csharp/IO/BufferOutputStream.cs
@@ -40,7 +40,6 @@ namespace ParquetSharp.IO
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr BufferOutputStream_Create(out IntPtr outputStream);
 
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr BufferOutputStream_Create_From_ResizableBuffer(IntPtr resizableBuffer, out IntPtr outputStream);
 

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -261,13 +261,18 @@ namespace ParquetSharp
 
         private static unsafe string ToString(ByteArray byteArray)
         {
-            return System.Text.Encoding.UTF8.GetString((byte*) byteArray.Pointer, byteArray.Length);
+            return byteArray.Length == 0
+                ? string.Empty
+                : System.Text.Encoding.UTF8.GetString((byte*) byteArray.Pointer, byteArray.Length);
         }
 
         private static byte[] ToByteArray(ByteArray byteArray)
         {
             var array = new byte[byteArray.Length];
-            Marshal.Copy(byteArray.Pointer, array, 0, array.Length);
+            if (byteArray.Length != 0)
+            {
+                Marshal.Copy(byteArray.Pointer, array, 0, array.Length);
+            }
             return array;
         }
 

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1591;</NoWarn>
-    <Version>1.5.1.1-beta1</Version>
+    <Version>1.5.1.1-beta2</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/RowOriented/ParquetDecimalScale.cs
+++ b/csharp/RowOriented/ParquetDecimalScale.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ParquetSharp.RowOriented
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ParquetDecimalScaleAttribute : Attribute
+    {
+        public ParquetDecimalScaleAttribute(int scale)
+        {
+            Scale = scale;
+        }
+
+        public readonly int Scale;
+    }
+}

--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -1,4 +1,4 @@
-mkdir build || goto :error
+mkdir build
 cd build || goto :error
 git clone https://github.com/Microsoft/vcpkg.git vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error


### PR DESCRIPTION
Updated to 1.5.1.1-beta2

Fixed handling of empty strings and ByteArrayConverter[] that could lead to null reference exceptions.

 Added support for Decimal in RowOriented API (tuples are not currently supported, due to the need for an attribute).

Fixed BufferOutputStream.Finish(). 

Added gitattributes.