### PR TITLE
Refactored and audited code for GC.KeepAlive

### DIFF
--- a/cpp/ColumnChunkMetaData.cpp
+++ b/cpp/ColumnChunkMetaData.cpp
@@ -56,7 +56,7 @@ extern "C"
 	{
 		TRYCATCH
 		(
-			auto s = column_chunk_meta_data->statistics();
+			const auto s = column_chunk_meta_data->statistics();
 			*statistics = s ? new std::shared_ptr<RowGroupStatistics>(s) : nullptr;
 		)
 	}

--- a/csharp/ColumnReader.cs
+++ b/csharp/ColumnReader.cs
@@ -227,57 +227,65 @@ namespace ParquetSharp
             {
                 if (type == typeof(bool))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Bool(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Bool(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (bool*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
                 if (type == typeof(int))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Int32(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Int32(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (int*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
                 if (type == typeof(long))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Int64(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Int64(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (long*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
                 if (type == typeof(Int96))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Int96(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Int96(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (Int96*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
                 if (type == typeof(float))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Float(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Float(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (float*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
                 if (type == typeof(double))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Double(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_Double(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (double*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
                 if (type == typeof(ByteArray))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_ByteArray(Handle,
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_ByteArray(Handle.IntPtr,
                         batchSize, pDefLevels, pRepLevels, (ByteArray*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
                 if (type == typeof(FixedLenByteArray))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_FixedLenByteArray(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatch_FixedLenByteArray(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (FixedLenByteArray*) pValues, out valuesRead, out var levelsRead));
+                    GC.KeepAlive(Handle);
                     return levelsRead;
                 }
 
@@ -307,65 +315,73 @@ namespace ParquetSharp
             {
                 if (type == typeof(bool))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Bool(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Bool(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (bool*) pValues, pValidBits, validBitsOffset, 
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
                 if (type == typeof(int))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Int32(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Int32(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (int*) pValues, pValidBits, validBitsOffset,
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
                 if (type == typeof(long))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Int64(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Int64(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (long*) pValues, pValidBits, validBitsOffset, 
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
                 if (type == typeof(Int96))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Int96(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Int96(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (Int96*) pValues, pValidBits, validBitsOffset, 
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
                 if (type == typeof(float))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Float(Handle,
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Float(Handle.IntPtr,
                         batchSize, pDefLevels, pRepLevels, (float*) pValues, pValidBits, validBitsOffset, 
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
                 if (type == typeof(double))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Double(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_Double(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (double*) pValues, pValidBits, validBitsOffset, 
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
                 if (type == typeof(ByteArray))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_ByteArray(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_ByteArray(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (ByteArray*) pValues, pValidBits, validBitsOffset, 
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
                 if (type == typeof(FixedLenByteArray))
                 {
-                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_FixedLenByteArray(Handle, 
+                    ExceptionInfo.Check(TypedColumnReader_ReadBatchSpaced_FixedLenByteArray(Handle.IntPtr, 
                         batchSize, pDefLevels, pRepLevels, (FixedLenByteArray*) pValues, pValidBits, validBitsOffset, 
                         out levelsRead, out valuesRead, out nullCount, out var returnValue));
+                    GC.KeepAlive(Handle);
                     return returnValue;
                 }
 
@@ -379,50 +395,42 @@ namespace ParquetSharp
 
             if (type == typeof(bool))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_Bool(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_Bool);
             }
 
             if (type == typeof(int))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_Int32(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_Int32);
             }
 
             if (type == typeof(long))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_Int64(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_Int64);
             }
 
             if (type == typeof(Int96))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_Int96(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_Int96);
             }
 
             if (type == typeof(float))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_Float(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_Float);
             }
 
             if (type == typeof(double))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_Double(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_Double);
             }
 
             if (type == typeof(ByteArray))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_ByteArray(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_ByteArray);
             }
 
             if (type == typeof(FixedLenByteArray))
             {
-                ExceptionInfo.Check(TypedColumnReader_Skip_FixedLenByteArray(Handle, numRowsToSkip, out var levelsSkipped));
-                return levelsSkipped;
+                return ExceptionInfo.Return<long, long>(Handle, numRowsToSkip, TypedColumnReader_Skip_FixedLenByteArray);
             }
 
             throw new NotSupportedException($"type {type} is not supported");

--- a/csharp/IO/BufferOutputStream.cs
+++ b/csharp/IO/BufferOutputStream.cs
@@ -9,32 +9,18 @@ namespace ParquetSharp.IO
     public sealed class BufferOutputStream : OutputStream
     {
         public BufferOutputStream() 
-            : base(Create())
+            : base(ExceptionInfo.Return<IntPtr>(BufferOutputStream_Create))
         {
         }
 
         public BufferOutputStream(ResizableBuffer resizableBuffer)
-            : base(Create(resizableBuffer))
+            : base(ExceptionInfo.Return<IntPtr>(resizableBuffer.Handle, BufferOutputStream_Create_From_ResizableBuffer))
         {
         }
 
         public Buffer Finish()
         {
-            ExceptionInfo.Check(BufferOutputStream_Finish(Handle, out var buffer));
-            return new Buffer(buffer);
-        }
-
-        private static IntPtr Create()
-        {
-            ExceptionInfo.Check(BufferOutputStream_Create(out var outputStream));
-            return outputStream;
-        }
-
-        private static IntPtr Create(ResizableBuffer buffer)
-        {
-            ExceptionInfo.Check(BufferOutputStream_Create_From_ResizableBuffer(buffer.Handle, out var outputStream));
-            GC.KeepAlive(buffer);
-            return outputStream;
+            return new Buffer(ExceptionInfo.Return<IntPtr>(Handle, BufferOutputStream_Finish));
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/IO/BufferReader.cs
+++ b/csharp/IO/BufferReader.cs
@@ -9,15 +9,8 @@ namespace ParquetSharp.IO
     public sealed class BufferReader : InputStream
     {
         public BufferReader(Buffer buffer)
-            : base(Create(buffer))
+            : base(ExceptionInfo.Return<IntPtr>(buffer.Handle, BufferReader_Create))
         {
-        }
-
-        private static IntPtr Create(Buffer buffer)
-        {
-            ExceptionInfo.Check(BufferReader_Create(buffer.Handle, out var outputStream));
-            GC.KeepAlive(buffer);
-            return outputStream;
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/IO/ResizableBuffer.cs
+++ b/csharp/IO/ResizableBuffer.cs
@@ -10,14 +10,8 @@ namespace ParquetSharp.IO
     public sealed class ResizableBuffer : Buffer
     {
         public ResizableBuffer()
-            : base(Create())
+            : base(ExceptionInfo.Return<IntPtr>(ResizableBuffer_Create))
         {
-        }
-
-        private static IntPtr Create()
-        {
-            ExceptionInfo.Check(ResizableBuffer_Create(out var resizableBuffer));
-            return resizableBuffer;
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/KeyValueMetadata.cs
+++ b/csharp/KeyValueMetadata.cs
@@ -25,7 +25,7 @@ namespace ParquetSharp
 
         public unsafe IReadOnlyDictionary<string, string> ToDictionary()
         {
-            ExceptionInfo.Check(KeyValueMetadata_Get_Entries(Handle, out var keys, out var values));
+            ExceptionInfo.Check(KeyValueMetadata_Get_Entries(Handle.IntPtr, out var keys, out var values));
 
             try
             {
@@ -47,7 +47,8 @@ namespace ParquetSharp
 
             finally
             {
-                KeyValueMetadata_Free_Entries(Handle, keys, values);
+                KeyValueMetadata_Free_Entries(Handle.IntPtr, keys, values);
+                GC.KeepAlive(Handle);
             }
         }
 

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -8,15 +8,17 @@ namespace ParquetSharp
     {
         public ParquetFileReader(string path)
         {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+
             ExceptionInfo.Check(ParquetFileReader_OpenFile(path, out var reader));
             _handle = new ParquetHandle(reader, ParquetFileReader_Free);
         }
 
         public ParquetFileReader(InputStream inputStream)
         {
-            ExceptionInfo.Check(ParquetFileReader_Open(inputStream.Handle, out var reader));
-            GC.KeepAlive(inputStream);
-            _handle = new ParquetHandle(reader, ParquetFileReader_Free);
+            if (inputStream == null) throw new ArgumentNullException(nameof(inputStream));
+
+            _handle = new ParquetHandle(ExceptionInfo.Return<IntPtr>(inputStream.Handle, ParquetFileReader_Open), ParquetFileReader_Free);
         }
 
         public void Dispose()
@@ -31,8 +33,7 @@ namespace ParquetSharp
 
         public RowGroupReader RowGroup(int i)
         {
-            ExceptionInfo.Check(ParquetFileReader_RowGroup(_handle, i, out var rowGroupReader));
-            return new RowGroupReader(rowGroupReader);
+            return new RowGroupReader(ExceptionInfo.Return<int, IntPtr>(_handle, i, ParquetFileReader_RowGroup));
         }
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using ParquetSharp.IO;
 using ParquetSharp.Schema;
@@ -73,7 +72,7 @@ namespace ParquetSharp
             using (var kvm = keyValueMetadata == null ? null : new KeyValueMetadata(keyValueMetadata))
             {
                 ExceptionInfo.Check(ParquetFileWriter_OpenFile(
-                    path, schema.Handle, writerProperties.Handle, kvm?.Handle ?? IntPtr.Zero, out var writer));
+                    path, schema.Handle.IntPtr, writerProperties.Handle.IntPtr, kvm?.Handle?.IntPtr ?? IntPtr.Zero, out var writer));
 
                 // Keep alive schema and writerProperties until this point, otherwise the GC might kick in while we're in OpenFile().
                 GC.KeepAlive(schema);
@@ -94,7 +93,7 @@ namespace ParquetSharp
             using (var kvm = keyValueMetadata == null ? null : new KeyValueMetadata(keyValueMetadata))
             {
                 ExceptionInfo.Check(ParquetFileWriter_Open(
-                    outputStream.Handle, schema.Handle, writerProperties.Handle, kvm?.Handle ?? IntPtr.Zero, out var writer));
+                    outputStream.Handle.IntPtr, schema.Handle.IntPtr, writerProperties.Handle.IntPtr, kvm?.Handle?.IntPtr ?? IntPtr.Zero, out var writer));
 
                 // Keep alive schema and writerProperties until this point, otherwise the GC might kick in while we're in Open().
                 GC.KeepAlive(schema);

--- a/csharp/ParquetHandle.cs
+++ b/csharp/ParquetHandle.cs
@@ -33,16 +33,19 @@ namespace ParquetSharp
             }
         }
 
-        public static implicit operator IntPtr (ParquetHandle handle)
+        public IntPtr IntPtr
         {
-            // Check the handle is not null. 
-            // This situation Usually happens when the parent class has already been disposed.
-            if (handle._handle == IntPtr.Zero)
+            get
             {
-                throw new NullReferenceException("null native handle");
-            }
+                // Check the handle is not null. 
+                // This situation Usually happens when the parent class has already been disposed.
+                if (_handle == IntPtr.Zero)
+                {
+                    throw new NullReferenceException("null native handle");
+                }
 
-            return handle._handle;
+                return _handle;
+            }
         }
 
         private IntPtr _handle;

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1591;</NoWarn>
-    <Version>1.5.1.1-beta3</Version>
+    <Version>1.5.1.1-beta4</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/Schema/ColumnPath.cs
+++ b/csharp/Schema/ColumnPath.cs
@@ -37,17 +37,12 @@ namespace ParquetSharp.Schema
 
         public string ToDotString()
         {
-            ExceptionInfo.Check(ColumnPath_ToDotString(Handle, out var cstr));
-
-            var dotString = Marshal.PtrToStringAnsi(cstr);
-            ColumnPath_ToDotString_Free(cstr);
-
-            return dotString;
+            return ExceptionInfo.ReturnString(Handle, ColumnPath_ToDotString, ColumnPath_ToDotString_Free);
         }
 
         public unsafe string[] ToDotVector()
         {
-            ExceptionInfo.Check(ColumnPath_ToDotVector(Handle, out var dotVector, out var length));
+            ExceptionInfo.Check(ColumnPath_ToDotVector(Handle.IntPtr, out var dotVector, out var length));
 
             var strings = new string[length];
             var cstrings = (IntPtr*) dotVector.ToPointer();
@@ -58,6 +53,7 @@ namespace ParquetSharp.Schema
             }
 
             ColumnPath_ToDotVector_Free(dotVector, length);
+            GC.KeepAlive(Handle);
 
             return strings;
         }
@@ -78,8 +74,7 @@ namespace ParquetSharp.Schema
 
         private static IntPtr Make(Node node)
         {
-            ExceptionInfo.Check(ColumnPath_MakeFromNode(node.Handle, out var handle));
-            return handle;
+            return ExceptionInfo.Return<IntPtr>(node.Handle, ColumnPath_MakeFromNode);
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -32,9 +32,7 @@ namespace ParquetSharp.Schema
 
         public int FieldIndex(Node node)
         {
-            var index = ExceptionInfo.Return<IntPtr, int>(Handle, node.Handle, GroupNode_Field_Index_By_Node);
-            GC.KeepAlive(node);
-            return index;
+            return ExceptionInfo.Return<int>(Handle, node.Handle, GroupNode_Field_Index_By_Node);
         }
 
         public override Node DeepClone()
@@ -58,7 +56,7 @@ namespace ParquetSharp.Schema
 
         private static unsafe IntPtr Make(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType logicalType)
         {
-            var handles = fields.Select(f => (IntPtr) f.Handle).ToArray();
+            var handles = fields.Select(f => f.Handle.IntPtr).ToArray();
 
             fixed (IntPtr* pHandles = handles)
             {

--- a/csharp/SchemaDescriptor.cs
+++ b/csharp/SchemaDescriptor.cs
@@ -23,7 +23,7 @@ namespace ParquetSharp
 
         public int ColumnIndex(Node node)
         {
-            var index = ExceptionInfo.Return<IntPtr, int>(_handle, node.Handle, SchemaDescriptor_ColumnIndex_ByNode);
+            var index = ExceptionInfo.Return<IntPtr, int>(_handle, node.Handle.IntPtr, SchemaDescriptor_ColumnIndex_ByNode);
             GC.KeepAlive(node);
             return index;
         }

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -8,8 +8,7 @@ namespace ParquetSharp
     {
         public static WriterProperties GetDefaultWriterProperties()
         {
-            ExceptionInfo.Check(WriterProperties_Get_Default_Writer_Properties(out var writerProperties));
-            return new WriterProperties(writerProperties);
+            return new WriterProperties(ExceptionInfo.Return<IntPtr>(WriterProperties_Get_Default_Writer_Properties));
         }
 
         internal WriterProperties(IntPtr handle)
@@ -22,19 +21,7 @@ namespace ParquetSharp
             Handle.Dispose();
         }
 
-        public string CreatedBy
-        {
-            get
-            {
-                ExceptionInfo.Check(WriterProperties_Created_By(Handle, out var cstr));
-
-                var createdBy = Marshal.PtrToStringAnsi(cstr);
-                WriterProperties_Created_By_Free(cstr);
-
-                return createdBy;
-            }
-        }
-
+        public string CreatedBy => ExceptionInfo.ReturnString(Handle, WriterProperties_Created_By, WriterProperties_Created_By_Free);
         public long DataPageSize => ExceptionInfo.Return<long>(Handle, WriterProperties_Data_Pagesize);
         public Encoding DictionaryIndexEncoding => ExceptionInfo.Return<Encoding>(Handle, WriterProperties_Dictionary_Index_Encoding);
         public Encoding DictionaryPageEncoding => ExceptionInfo.Return<Encoding>(Handle, WriterProperties_Dictionary_Page_Encoding);
@@ -45,27 +32,27 @@ namespace ParquetSharp
 
         public Compression Compression(ColumnPath path)
         {
-            return ExceptionInfo.Return<IntPtr, Compression>(Handle, path.Handle, WriterProperties_Compression);
+            return ExceptionInfo.Return<Compression>(Handle, path.Handle, WriterProperties_Compression);
         }
 
         public bool DictionaryEnabled(ColumnPath path)
         {
-            return ExceptionInfo.Return<IntPtr, bool>(Handle, path.Handle, WriterProperties_Dictionary_Enabled);
+            return ExceptionInfo.Return<bool>(Handle, path.Handle, WriterProperties_Dictionary_Enabled);
         }
 
         public Encoding Encoding(ColumnPath path)
         {
-            return ExceptionInfo.Return<IntPtr, Encoding>(Handle, path.Handle, WriterProperties_Encoding);
+            return ExceptionInfo.Return<Encoding>(Handle, path.Handle, WriterProperties_Encoding);
         }
 
         public bool StatisticsEnabled(ColumnPath path)
         {
-            return ExceptionInfo.Return<IntPtr, bool>(Handle, path.Handle, WriterProperties_Statistics_Enabled);
+            return ExceptionInfo.Return<bool>(Handle, path.Handle, WriterProperties_Statistics_Enabled);
         }
 
         public ulong MaxStatisticsSize(ColumnPath path)
         {
-            return ExceptionInfo.Return<IntPtr, ulong>(Handle, path.Handle, WriterProperties_Max_Statistics_Size);
+            return ExceptionInfo.Return<ulong>(Handle, path.Handle, WriterProperties_Max_Statistics_Size);
         }
 
         internal readonly ParquetHandle Handle;

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -19,45 +19,51 @@ namespace ParquetSharp
 
         public WriterProperties Build()
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Build(_handle, out var writerProperties));
-            return new WriterProperties(writerProperties);
+            return new WriterProperties(ExceptionInfo.Return<IntPtr>(_handle, WriterPropertiesBuilder_Build));
         }
 
         // Dictionary enable/disable
 
         public WriterPropertiesBuilder DisableDictionary()
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary(_handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary(_handle.IntPtr));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder DisableDictionary(string path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary_By_Path(_handle, path));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary_By_Path(_handle.IntPtr, path));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder DisableDictionary(ColumnPath path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary_By_ColumnPath(_handle, path.Handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
             return this;
         }
 
         public WriterPropertiesBuilder EnableDictionary()
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary(_handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary(_handle.IntPtr));
             return this;
         }
 
         public WriterPropertiesBuilder EnableDictionary(string path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary_By_Path(_handle, path));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary_By_Path(_handle.IntPtr, path));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder EnableDictionary(ColumnPath path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary_By_ColumnPath(_handle, path.Handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
             return this;
         }
 
@@ -65,37 +71,45 @@ namespace ParquetSharp
 
         public WriterPropertiesBuilder DisableStatistics()
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics(_handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics(_handle.IntPtr));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder DisableStatistics(string path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics_By_Path(_handle, path));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics_By_Path(_handle.IntPtr, path));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder DisableStatistics(ColumnPath path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics_By_ColumnPath(_handle, path.Handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
             return this;
         }
 
         public WriterPropertiesBuilder EnableStatistics()
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics(_handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics(_handle.IntPtr));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder EnableStatistics(string path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics_By_Path(_handle, path));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics_By_Path(_handle.IntPtr, path));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder EnableStatistics(ColumnPath path)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics_By_ColumnPath(_handle, path.Handle));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
             return this;
         }
 
@@ -103,73 +117,86 @@ namespace ParquetSharp
 
         public WriterPropertiesBuilder Compression(Compression codec)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Compression(_handle, codec));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Compression(_handle.IntPtr, codec));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder Compression(string path, Compression codec)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Compression_By_Path(_handle, path, codec));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Compression_By_Path(_handle.IntPtr, path, codec));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder Compression(ColumnPath path, Compression codec)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Compression_By_ColumnPath(_handle, path.Handle, codec));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Compression_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr, codec));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
             return this;
         }
 
         public WriterPropertiesBuilder CreatedBy(string createdBy)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Created_By(_handle, createdBy));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Created_By(_handle.IntPtr, createdBy));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder DataPagesize(long pageSize)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Data_Pagesize(_handle, pageSize));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Data_Pagesize(_handle.IntPtr, pageSize));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder DictionaryPagesizeLimit(long dictionaryPagesizeLimit)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Dictionary_Pagesize_Limit(_handle, dictionaryPagesizeLimit));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Dictionary_Pagesize_Limit(_handle.IntPtr, dictionaryPagesizeLimit));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder Encoding(Encoding encoding)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Encoding(_handle, encoding));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Encoding(_handle.IntPtr, encoding));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder Encoding(string path, Encoding encoding)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Encoding_By_Path(_handle, path, encoding));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Encoding_By_Path(_handle.IntPtr, path, encoding));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder Encoding(ColumnPath path, Encoding encoding)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Encoding_By_ColumnPath(_handle, path.Handle, encoding));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Encoding_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr, encoding));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
             return this;
         }
 
         public WriterPropertiesBuilder MaxRowGroupLength(long maxRowGroupLength)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Max_Row_Group_Length(_handle, maxRowGroupLength));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Max_Row_Group_Length(_handle.IntPtr, maxRowGroupLength));
             return this;
         }
 
         public WriterPropertiesBuilder Version(ParquetVersion version)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Version(_handle, version));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Version(_handle.IntPtr, version));
+            GC.KeepAlive(_handle);
             return this;
         }
 
         public WriterPropertiesBuilder WriteBatchSize(long writeBatchSize)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Write_Batch_Size(_handle, writeBatchSize));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Write_Batch_Size(_handle.IntPtr, writeBatchSize));
+            GC.KeepAlive(_handle);
             return this;
         }
 


### PR DESCRIPTION
Bumped version to 1.5.1.1-beta4
Removed implicit conversion from ParquetHandle to IntPtr.
Added GC.KeepAlive to all ExceptionInfo.Return taking a ParquetHandle as argument.
Audited the code for more GC.KeepAlive when directly using IntPtr handles.