### PR TITLE
ManagedRandomAccessFile/OutputStream to read/write to .Net IO.Streams

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(ParquetSharpNative SHARED
 	GroupNode.cpp
 	KeyValueMetadata.cpp
 	LogicalType.cpp
+	ManagedRandomAccessFile.cpp
+	ManagedOutputStream.cpp
 	Node.cpp
 	OutputStream.cpp
 	ParquetFileReader.cpp

--- a/cpp/ManagedOutputStream.cpp
+++ b/cpp/ManagedOutputStream.cpp
@@ -1,0 +1,101 @@
+
+#include "cpp/ParquetSharpExport.h"
+#include "ExceptionInfo.h"
+
+#include <arrow/status.h>
+#include <arrow/io/interfaces.h>
+
+class ManagedOutputStream : public arrow::io::OutputStream
+{
+private:
+	arrow::StatusCode (*write)(const void*, int64_t, char**);
+	arrow::StatusCode (*tell)(int64_t*, char**);
+	arrow::StatusCode (*flush)(char**);
+	arrow::StatusCode (*close)(char**);
+	bool (*_closed)();
+
+public:
+
+	ManagedOutputStream(
+		arrow::StatusCode (*write)(const void*, int64_t, char**),
+		arrow::StatusCode (*tell)(int64_t*, char**),
+		arrow::StatusCode (*flush)(char**),
+		arrow::StatusCode (*close)(char**),
+		bool (*closed)())
+	{
+		this->write = write;
+		this->tell = tell;
+		this->flush = flush;
+		this->close = close;
+		this->_closed = closed;
+	}
+
+	~ManagedOutputStream() {}
+
+	arrow::Status Write(const void* data, int64_t nbytes)
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->write(data, nbytes, &exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	arrow::Status Flush()
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->flush(&exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	arrow::Status Close()
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->close(&exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	arrow::Status Tell(int64_t* position) const
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->tell(position, &exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	bool closed() const
+	{
+		return this->_closed();
+	}
+};
+
+extern "C"
+{
+	PARQUETSHARP_EXPORT ExceptionInfo* ManagedOutputStream_Create(
+		arrow::StatusCode (*write)(const void*, int64_t, char**),
+		arrow::StatusCode (*tell)(int64_t*, char**),
+		arrow::StatusCode (*flush)(char**),
+		arrow::StatusCode (*close)(char**),
+		bool (*closed)(),
+		std::shared_ptr<ManagedOutputStream>** stream)
+	{
+		TRYCATCH(*stream = new std::shared_ptr<ManagedOutputStream>(new ManagedOutputStream(write, tell, flush, close, closed));)
+	}
+}

--- a/cpp/ManagedRandomAccessFile.cpp
+++ b/cpp/ManagedRandomAccessFile.cpp
@@ -1,0 +1,133 @@
+
+#include "cpp/ParquetSharpExport.h"
+#include "ExceptionInfo.h"
+
+#include <arrow/status.h>
+#include <arrow/buffer.h>
+#include <arrow/io/interfaces.h>
+
+class ManagedRandomAccessFile : public arrow::io::RandomAccessFile
+{
+private:
+	arrow::StatusCode (*read)(int64_t, int64_t*, void*, char**);
+	arrow::StatusCode (*close)(char**);
+	arrow::StatusCode (*getSize)(int64_t*, char**);
+	arrow::StatusCode (*tell)(int64_t*, char**);
+	arrow::StatusCode (*seek)(int64_t, char**);
+	bool (*_closed)();
+
+public:
+
+	ManagedRandomAccessFile(
+		arrow::StatusCode (*read)(int64_t, int64_t*, void*, char**),
+		arrow::StatusCode (*close)(char**),
+		arrow::StatusCode (*getSize)(int64_t*, char**),
+		arrow::StatusCode (*tell)(int64_t*, char**),
+		arrow::StatusCode (*seek)(int64_t, char**),
+		bool (*closed)())
+	{
+		this->read = read;
+		this->close = close;
+		this->getSize = getSize;
+		this->tell = tell;
+		this->seek = seek;
+		this->_closed = closed;
+	}
+
+	~ManagedRandomAccessFile() {}
+
+	arrow::Status Read(int64_t nbytes, int64_t* bytes_read, void* out)
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->read(nbytes, bytes_read, out, &exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	arrow::Status Read(int64_t nbytes, std::shared_ptr<arrow::Buffer>* out)
+	{
+		std::shared_ptr<arrow::ResizableBuffer> buffer;
+		RETURN_NOT_OK(arrow::AllocateResizableBuffer(nbytes, &buffer));
+
+		int64_t bytes_read = 0;
+		RETURN_NOT_OK(Read(nbytes, &bytes_read, buffer->mutable_data()));
+		if (bytes_read < nbytes) {
+			RETURN_NOT_OK(buffer->Resize(bytes_read));
+			buffer->ZeroPadding();
+		}
+		*out = buffer;
+		return arrow::Status::OK();
+	}
+
+	arrow::Status Close()
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->close(&exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	arrow::Status Tell(int64_t* position) const
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->tell(position, &exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	arrow::Status Seek(int64_t position)
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->seek(position, &exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	arrow::Status GetSize(int64_t* size)
+	{
+		char* exception = NULL;
+		arrow::StatusCode statusCode = this->getSize(size, &exception);
+		if (statusCode == arrow::StatusCode::OK) {
+			return arrow::Status::OK();
+		} else {
+			return arrow::Status(statusCode, exception);
+			delete exception;
+		}
+	}
+
+	bool closed() const
+	{
+		return this->_closed();
+	}
+};
+
+extern "C"
+{
+	PARQUETSHARP_EXPORT ExceptionInfo* ManagedRandomAccessFile_Create(
+		arrow::StatusCode (*read)(int64_t, int64_t*, void*, char**),
+		arrow::StatusCode (*close)(char**),
+		arrow::StatusCode (*getSize)(int64_t*, char**),
+		arrow::StatusCode (*tell)(int64_t*, char**),
+		arrow::StatusCode (*seek)(int64_t, char**),
+		bool (*closed)(),
+		std::shared_ptr<ManagedRandomAccessFile>** stream)
+	{
+		TRYCATCH(*stream = new std::shared_ptr<ManagedRandomAccessFile>(new ManagedRandomAccessFile(read, close, getSize, tell, seek, closed));)
+	}
+}

--- a/csharp.test/TestParquetFileReader.cs
+++ b/csharp.test/TestParquetFileReader.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using NUnit.Framework;
+using ParquetSharp.IO;
 
 namespace ParquetSharp.Test
 {
@@ -156,6 +157,57 @@ namespace ParquetSharp.Test
             }
 
             return value.ToString();
+        }
+
+        [Test]
+        public static void TestFileRoundTrip()
+        {
+            try
+            {
+                using (var writer = new ParquetFileWriter("file.parquet", new Column[] {new Column<int>("ids")}))
+                using (var group = writer.AppendRowGroup())
+                using (var column = group.NextColumn().LogicalWriter<int>())
+                {
+                    column.WriteBatch(new[] {1, 2, 3});
+                }
+
+                using (var reader = new ParquetFileReader("file.parquet"))
+                using (var group = reader.RowGroup(0))
+                using (var column = group.Column(0).LogicalReader<int>())
+                {
+                    Assert.AreEqual(new[] {1, 2, 3}, column.ReadAll(3));
+                }
+            }
+            finally
+            {
+                File.Delete("file.parquet");
+            }
+        }
+
+        [Test]
+        public static void TestInMemmoryRoundTrip()
+        {
+            using (var buffer = new System.IO.MemoryStream())
+            {
+                using (var output = new ManagedOutputStream(buffer))
+                using (var writer = new ParquetFileWriter(output, new Column[] {new Column<int>("ids")}))
+                using (var group = writer.AppendRowGroup())
+                using (var column = group.NextColumn().LogicalWriter<int>())
+                {
+                    column.WriteBatch(new[] {1, 2, 3});
+                }
+
+                // Seek back to start
+                buffer.Seek(0, SeekOrigin.Begin);
+
+                using (var input = new ManagedRandomAccessFile(buffer))
+                using (var reader = new ParquetFileReader(input))
+                using (var group = reader.RowGroup(0))
+                using (var column = group.Column(0).LogicalReader<int>())
+                {
+                    Assert.AreEqual(new[] {1, 2, 3}, column.ReadAll(3));
+                }
+            }
         }
     }
 }

--- a/csharp.test/TestParquetPerformance.cs
+++ b/csharp.test/TestParquetPerformance.cs
@@ -154,6 +154,90 @@ namespace ParquetSharp.Test
 
             Console.WriteLine("Saved to Parquet.RowOriented ({0:N0} bytes) in {1:N2} sec", new FileInfo("float_timeseries.parquet.roworiented").Length, timer.Elapsed.TotalSeconds);
             Console.WriteLine();
+            Console.WriteLine("Saving to Parquet.FileStream");
+
+            timer.Restart();
+
+            using (var writer = new ParquetSharp.IO.ManagedOutputStream(File.Create("float_timeseries.parquet.filestream")))
+            using (var fileWriter = new ParquetFileWriter(writer, CreateFloatColumns()))
+            using (var rowGroupWriter = fileWriter.AppendRowGroup())
+            {
+                using (var dateTimeWriter = rowGroupWriter.NextColumn().LogicalWriter<DateTime>())
+                {
+                    for (int i = 0; i != dates.Length; ++i)
+                    {
+                        dateTimeWriter.WriteBatch(Enumerable.Repeat(dates[i], objectIds.Length).ToArray());
+                    }
+                }
+
+                using (var objectIdWriter = rowGroupWriter.NextColumn().LogicalWriter<int>())
+                {
+                    for (int i = 0; i != dates.Length; ++i)
+                    {
+                        objectIdWriter.WriteBatch(objectIds);
+                    }
+                }
+
+                using (var valueWriter = rowGroupWriter.NextColumn().LogicalWriter<float>())
+                {
+                    for (int i = 0; i != dates.Length; ++i)
+                    {
+                        valueWriter.WriteBatch(values[i]);
+                    }
+                }
+            }
+
+            Console.WriteLine("Saved to Parquet.FileStream ({0:N0} bytes) in {1:N2} sec", new FileInfo("float_timeseries.parquet.filestream").Length, timer.Elapsed.TotalSeconds);
+            Console.WriteLine();
+            Console.WriteLine("Saving to Parquet.Chunked.FileStream (by date)");
+
+            timer.Restart();
+
+            using (var writer = new ParquetSharp.IO.ManagedOutputStream(File.Create("float_timeseries.parquet.chunked.filestream")))
+            using (var fileWriter = new ParquetFileWriter(writer, CreateFloatColumns()))
+            {
+                for (int i = 0; i != dates.Length; ++i)
+                {
+                    using (var rowGroupWriter = fileWriter.AppendRowGroup())
+                    {
+                        using (var dateTimeWriter = rowGroupWriter.NextColumn().LogicalWriter<DateTime>())
+                        {
+                            dateTimeWriter.WriteBatch(Enumerable.Repeat(dates[i], objectIds.Length).ToArray());
+                        }
+
+                        using (var objectIdWriter = rowGroupWriter.NextColumn().LogicalWriter<int>())
+                        {
+                            objectIdWriter.WriteBatch(objectIds);
+                        }
+
+                        using (var valueWriter = rowGroupWriter.NextColumn().LogicalWriter<float>())
+                        {
+                            valueWriter.WriteBatch(values[i]);
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine("Saved to Parquet.Chunked.FileStream ({0:N0} bytes) in {1:N2} sec", new FileInfo("float_timeseries.parquet.chunked.filestream").Length, timer.Elapsed.TotalSeconds);
+            Console.WriteLine();
+            Console.WriteLine("Saving to Parquet.RowOriented.FileStream");
+
+            timer.Restart();
+
+            using (var writer = new ParquetSharp.IO.ManagedOutputStream(File.Create("float_timeseries.parquet.roworiented.filestream")))
+            using (var rowWriter = ParquetFile.CreateRowWriter<(DateTime, int, float)>(writer, new[] {"DateTime", "ObjectId", "Value"}))
+            {
+                for (int i = 0; i != dates.Length; ++i)
+                {
+                    for (int j = 0; j != objectIds.Length; ++j)
+                    {
+                        rowWriter.WriteRow((dates[i], objectIds[j], values[i][j]));
+                    }
+                }
+            }
+
+            Console.WriteLine("Saved to Parquet.RowOriented.FileStream ({0:N0} bytes) in {1:N2} sec", new FileInfo("float_timeseries.parquet.roworiented.filestream").Length, timer.Elapsed.TotalSeconds);
+            Console.WriteLine();
             Console.WriteLine("Saving to Parquet.NET");
 
             timer.Restart();

--- a/csharp/IO/BufferReader.cs
+++ b/csharp/IO/BufferReader.cs
@@ -14,6 +14,6 @@ namespace ParquetSharp.IO
         }
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr BufferReader_Create(IntPtr buffer, out IntPtr inputStream);
+        private static extern IntPtr BufferReader_Create(IntPtr buffer, out IntPtr bufferReader);
     }
 }

--- a/csharp/IO/ManagedOutputStream.cs
+++ b/csharp/IO/ManagedOutputStream.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp.IO
+{
+    /// <summary>
+    /// Wrapper around arrow::io::OutputStream, implemented in C#
+    /// </summary>
+    public sealed class ManagedOutputStream : OutputStream
+    {
+        private System.IO.Stream Stream;
+
+        private delegate byte WriteDelegate(IntPtr buffer, long nbyte, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private WriteDelegate _write;
+        private delegate byte TellDelegate(IntPtr position, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private TellDelegate _tell;
+        private delegate byte FlushDelegate([MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private FlushDelegate _flush;
+        private delegate byte CloseDelegate([MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private CloseDelegate _close;
+        private delegate bool ClosedDelegate();
+        private ClosedDelegate _closed;
+
+        public ManagedOutputStream(System.IO.Stream stream)
+        {
+            this.Stream = stream;
+
+            this._write = (WriteDelegate)this.Write;
+            this._tell = (TellDelegate)this.Tell;
+            this._flush = (FlushDelegate)this.Flush;
+            this._close = (CloseDelegate)this.Close;
+            this._closed = (ClosedDelegate)this.Closed;
+
+            ExceptionInfo.Check(ManagedOutputStream_Create(
+                this._write, this._tell, this._flush, this._close, this._closed, out var handle));
+
+            this.Handle = new ParquetHandle(handle, OutputStream.OutputStream_Free);
+        }
+
+        private byte Write(IntPtr src, long nbytes, out string exception)
+        {
+            try {
+                #if !NETSTANDARD20
+                byte[] buffer = new byte[(int)nbytes];
+                #endif
+
+                while (nbytes > 0)
+                {
+                    int ibytes = (int)nbytes;
+
+                    #if NETSTANDARD20
+                    unsafe
+                    {
+                        Stream.Write(new Span<byte>(src.ToPointer(), ibytes));
+                    }
+                    #else
+                    Marshal.Copy(src, buffer, 0, ibytes);
+                    Stream.Write(buffer, 0, ibytes);
+                    #endif
+
+                    nbytes -= ibytes;
+                    src = IntPtr.Add(src, ibytes);
+                }
+
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private byte Tell(IntPtr position, out string exception)
+        {
+            try {
+                Marshal.WriteInt64(position, Stream.Position);
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private byte Flush(out string exception)
+        {
+            try {
+                Stream.Flush();
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private byte Close(out string exception)
+        {
+            try {
+                Stream.Close();
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private bool Closed()
+        {
+            try {
+                return !Stream.CanWrite;
+            } catch {
+                return true;
+            }
+        }
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ManagedOutputStream_Create(
+            WriteDelegate write,
+            TellDelegate tell,
+            FlushDelegate flush,
+            CloseDelegate close,
+            ClosedDelegate closed,
+             out IntPtr outputStream);
+    }
+}

--- a/csharp/IO/ManagedRandomAccessFile.cs
+++ b/csharp/IO/ManagedRandomAccessFile.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp.IO
+{
+    /// <summary>
+    /// Wrapper around arrow::io::RandomAccessFile, implemented in C#
+    /// </summary>
+    public sealed class ManagedRandomAccessFile : RandomAccessFile
+    {
+        private System.IO.Stream Stream;
+
+        private delegate byte ReadDelegate(long nbyte, IntPtr bytes_read, IntPtr dest, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private ReadDelegate _read;
+        private delegate byte CloseDelegate([MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private CloseDelegate _close;
+        private delegate byte GetSizeDelegate(IntPtr size, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private GetSizeDelegate _getSize;
+        private delegate byte TellDelegate(IntPtr position, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private TellDelegate _tell;
+        private delegate byte SeekDelegate(long position, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private SeekDelegate _seek;
+        private delegate bool ClosedDelegate();
+        private ClosedDelegate _closed;
+
+        public ManagedRandomAccessFile(System.IO.Stream stream)
+        {
+            this.Stream = stream;
+
+            this._read = (ReadDelegate)this.Read;
+            this._close = (CloseDelegate)this.Close;
+            this._getSize = (GetSizeDelegate)this.GetSize;
+            this._tell = (TellDelegate)this.Tell;
+            this._seek = (SeekDelegate)this.Seek;
+            this._closed = (ClosedDelegate)this.Closed;
+
+            ExceptionInfo.Check(ManagedRandomAccessFile_Create(
+                this._read, this._close, this._getSize, this._tell, this._seek, this._closed, out var handle));
+
+            this.Handle = new ParquetHandle(handle, RandomAccessFile.RandomAccessFile_Free);
+        }
+
+        private byte Read(long nbytes, IntPtr bytes_read, IntPtr dest, out string exception)
+        {
+            try {
+                #if NETSTANDARD20
+                unsafe
+                {
+                    var read = Stream.Read(new Span<byte>(dest.ToPointer(), (int)nbytes));
+                    Marshal.WriteInt64(bytes_read, read);
+                }
+                #else
+                byte[] buffer = new byte[(int)nbytes];
+                var read = Stream.Read(buffer, 0, (int)nbytes);
+                Marshal.Copy(buffer, 0, dest, read);
+                Marshal.WriteInt64(bytes_read, read);
+                #endif
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private byte Close(out string exception)
+        {
+            try {
+                Stream.Close();
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private byte GetSize(IntPtr size, out string exception)
+        {
+            try {
+                Marshal.WriteInt64(size, Stream.Length);
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private byte Tell(IntPtr position, out string exception)
+        {
+            try {
+                Marshal.WriteInt64(position, Stream.Position);
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private byte Seek(long position, out string exception)
+        {
+            try {
+                Stream.Position = position;
+                exception = null;
+                return 0;
+            } catch (OutOfMemoryException) {
+                exception = null;
+                return 1;
+            } catch (Exception exc) {
+                exception = exc.ToString();
+                return 9;
+            }
+        }
+
+        private bool Closed()
+        {
+            try {
+                return !Stream.CanRead;
+            } catch {
+                return true;
+            }
+        }
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ManagedRandomAccessFile_Create(
+            ReadDelegate read,
+            CloseDelegate close,
+            GetSizeDelegate getSize,
+            TellDelegate tell,
+            SeekDelegate seek,
+            ClosedDelegate closed,
+            out IntPtr randomAccessFile);
+    }
+}

--- a/csharp/IO/OutputStream.cs
+++ b/csharp/IO/OutputStream.cs
@@ -13,14 +13,19 @@ namespace ParquetSharp.IO
             Handle = new ParquetHandle(handle, OutputStream_Free);
         }
 
+        /// Unsafe constructor for allocating superclasses
+        internal OutputStream() {
+            Handle = new ParquetHandle(IntPtr.Zero, null);
+        }
+
         public void Dispose()
         {
             Handle.Dispose();
         }
 
         [DllImport(ParquetDll.Name)]
-        private static extern void OutputStream_Free(IntPtr outputStream);
+        internal static extern void OutputStream_Free(IntPtr outputStream);
 
-        internal readonly ParquetHandle Handle;
+        internal ParquetHandle Handle;
     }
 }

--- a/csharp/IO/RandomAccessFile.cs
+++ b/csharp/IO/RandomAccessFile.cs
@@ -13,14 +13,19 @@ namespace ParquetSharp.IO
             Handle = new ParquetHandle(handle, RandomAccessFile_Free);
         }
 
+        /// Unsafe constructor for allocating superclasses
+        internal RandomAccessFile() {
+            Handle = new ParquetHandle(IntPtr.Zero, null);
+        }
+
         public void Dispose()
         {
             Handle.Dispose();
         }
 
         [DllImport(ParquetDll.Name)]
-        private static extern void RandomAccessFile_Free(IntPtr randomAccessFile);
+        internal static extern void RandomAccessFile_Free(IntPtr randomAccessFile);
 
-        internal readonly ParquetHandle Handle;
+        internal ParquetHandle Handle;
     }
 }


### PR DESCRIPTION
Adds ManagedRandomAccessFile and ManagedOutputStream, implementations of
the RandomAccessFile and OutputStream C++ interfaces that call back into
C# to read/write to a .Net IO.Stream.

This seems to be on par with performance from letting the C++ side
manage the file itself, that is pinvoke overhead appears minimal
relative to IO costs. The TestFloatTimeSeries benchmark has been updated
to write out by passing a filepath to C++, and by using
ManagedOutputStream.

Example output of TestFloatTimeSeries (with a slightly larger data size
than default):

 Generating data...
 Generated 31,200,000 rows in 0.78 sec

 Saving to CSV
 Saved to CSV (1,262,808,034 bytes) in 43.87 sec

 Saving to CSV.GZ
 Saved to CSV (317,658,548 bytes) in 92.55 sec

 Saving to Parquet
 Saved to Parquet (168,610,125 bytes) in 1.06 sec

 Saving to Parquet.Chunked (by date)
 Saved to Parquet.Chunked (361,316,340 bytes) in 6.74 sec

 Saving to Parquet.RowOriented
 Saved to Parquet.RowOriented (168,510,739 bytes) in 1.98 sec

 Saving to Parquet.FileStream
 Saved to Parquet.FileStream (168,609,640 bytes) in 1.05 sec

 Saving to Parquet.Chunked.FileStream (by date)
 Saved to Parquet.Chunked.FileStream (361,316,332 bytes) in 5.14 sec

 Saving to Parquet.RowOriented.FileStream
 Saved to Parquet.RowOriented.FileStream (168,510,254 bytes) in 2.02 sec

 Saving to Parquet.NET
 Saved to Parquet.NET (261,420,477 bytes) in 11.60 sec

As can be seen the FileStream tests are on par with using C++ directly,
and are all much faster than Parquet.NET.