### PR TITLE
Upgrade to Arrow 0.15.1

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,6 +3,7 @@ include(GenerateExportHeader)
 find_package(Arrow REQUIRED)
 find_package(Boost COMPONENTS filesystem regex system REQUIRED)
 find_package(Brotli REQUIRED)
+find_package(double-conversion REQUIRED)
 find_package(Gflags REQUIRED)
 find_package(Glog REQUIRED)
 find_package(Lz4 REQUIRED)
@@ -78,6 +79,7 @@ target_link_libraries(ParquetSharpNative
 	${Arrow_LIBRARIES} 
 	${Boost_LIBRARIES}
 	${Brotli_LIBRARIES}
+	double-conversion::double-conversion
 	${Glog_LIBRARIES}
 	${Gflags_LIBRARIES}
 	${Lz4_LIBRARIES}

--- a/cpp/ManagedOutputStream.cpp
+++ b/cpp/ManagedOutputStream.cpp
@@ -19,6 +19,11 @@ class ManagedOutputStream final : public arrow::io::OutputStream
 {
 public:
 
+	ManagedOutputStream(const ManagedOutputStream&) = delete;
+	ManagedOutputStream(ManagedOutputStream&&) = delete;
+	ManagedOutputStream& operator = (const ManagedOutputStream&) = delete;
+	ManagedOutputStream& operator = (ManagedOutputStream&&) = delete;
+
 	ManagedOutputStream(
 		const WriteFunc write,
 		const TellFunc tell,
@@ -33,15 +38,16 @@ public:
 	{
 	}
 
-	~ManagedOutputStream()
+	~ManagedOutputStream() override
 	{
-		arrow::Status st = this->Close();
-		if (!st.ok()) {
+		const Status st = this->Close();
+		if (!st.ok()) 
+		{
 			ARROW_LOG(ERROR) << "Error ignored when destroying ManagedOutputStream: " << st;
 		}
 	}
 
-	Status Write(const void* data, int64_t nbytes) override
+	Status Write(const void* const data, const int64_t nbytes) override
 	{
 		const char* exception = nullptr;
 		const auto statusCode = write_(data, nbytes, &exception);
@@ -62,7 +68,7 @@ public:
 		return GetStatus(statusCode, exception);
 	}
 
-	Status Tell(int64_t* position) const override
+	Status Tell(int64_t* const position) const override
 	{
 		const char* exception = nullptr;
 		const auto statusCode = tell_(position, &exception);

--- a/cpp/ManagedRandomAccessFile.cpp
+++ b/cpp/ManagedRandomAccessFile.cpp
@@ -21,6 +21,11 @@ class ManagedRandomAccessFile final : public arrow::io::RandomAccessFile
 {
 public:
 
+	ManagedRandomAccessFile(const ManagedRandomAccessFile&) = delete;
+	ManagedRandomAccessFile(ManagedRandomAccessFile&&) = delete;
+	ManagedRandomAccessFile& operator = (const ManagedRandomAccessFile&) = delete;
+	ManagedRandomAccessFile& operator = (ManagedRandomAccessFile&&) = delete;
+
 	ManagedRandomAccessFile(
 		const ReadFunc read,
 		const CloseFunc close,
@@ -37,22 +42,23 @@ public:
 	{
 	}
 
-	~ManagedRandomAccessFile()
+	~ManagedRandomAccessFile() override
 	{
-		arrow::Status st = this->Close();
-		if (!st.ok()) {
+		const Status st = this->Close();
+		if (!st.ok()) 
+		{
 			ARROW_LOG(ERROR) << "Error ignored when destroying ManagedRandomAccessFile: " << st;
 		}
 	}
 
-	Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override
+	Status Read(const int64_t nbytes, int64_t* bytes_read, void* out) override
 	{
 		const char* exception = nullptr;
 		const auto statusCode = read_(nbytes, bytes_read, out, &exception);
 		return GetStatus(statusCode, exception);
 	}
 
-	Status Read(int64_t nbytes, std::shared_ptr<arrow::Buffer>* out) override
+	Status Read(const int64_t nbytes, std::shared_ptr<arrow::Buffer>* out) override
 	{
 		std::shared_ptr<arrow::ResizableBuffer> buffer;
 		RETURN_NOT_OK(arrow::AllocateResizableBuffer(nbytes, &buffer));

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -77,6 +77,11 @@ extern "C"
 		TRYCATCH(*compression = (*writerProperties)->compression(*path);)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Compression_Level(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, int32_t* compression_level)
+	{
+		TRYCATCH(*compression_level = (*writerProperties)->compression_level(*path);)
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Enabled(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, bool* enabled)
 	{
 		TRYCATCH(*enabled = (*writerProperties)->dictionary_enabled(*path);)

--- a/cpp/WriterPropertiesBuilder.cpp
+++ b/cpp/WriterPropertiesBuilder.cpp
@@ -105,6 +105,21 @@ extern "C"
 		TRYCATCH(builder->compression(*path, codec);)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Compression_Level(WriterProperties::Builder* builder, int32_t compression_level)
+	{
+		TRYCATCH(builder->compression_level(compression_level);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Compression_Level_By_Path(WriterProperties::Builder* builder, const char* path, int32_t compression_level)
+	{
+		TRYCATCH(builder->compression_level(path, compression_level);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Compression_Level_By_ColumnPath(WriterProperties::Builder* builder, const std::shared_ptr<schema::ColumnPath>* path, int32_t compression_level)
+	{
+		TRYCATCH(builder->compression_level(*path, compression_level);)
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Created_By(WriterProperties::Builder* builder, const char* created_by)
 	{
 		TRYCATCH(builder->created_by(created_by);)

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">netcoreapp2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)'=='Unix'">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'=='Unix'">netcoreapp3.0</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>ParquetSharp.Test</AssemblyName>
     <RootNamespace>ParquetSharp.Test</RootNamespace>
@@ -13,10 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Parquet.Net" Version="3.3.9" />
+    <PackageReference Include="Parquet.Net" Version="3.3.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -72,7 +72,7 @@ namespace ParquetSharp.Test
             {
                 // Write using ParquetSharp
                 using (var outStream = new BufferOutputStream(buffer))
-                using (var fileWriter = new ParquetFileWriter(outStream, columns))
+                using (var fileWriter = new ParquetFileWriter(outStream, columns, Compression.Snappy))
                 using (var rowGroupWriter = fileWriter.AppendRowGroup())
                 using (var columnWriter = rowGroupWriter.NextColumn().LogicalWriter<decimal>())
                 {

--- a/csharp.test/TestManagedRandomAccessFile.cs
+++ b/csharp.test/TestManagedRandomAccessFile.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using NUnit.Framework;
 using ParquetSharp.IO;
 
@@ -17,7 +16,7 @@ namespace ParquetSharp.Test
             using (var buffer = new MemoryStream())
             {
                 // Write test data.
-                using (var output = new ManagedOutputStream(buffer, true))
+                using (var output = new ManagedOutputStream(buffer, leaveOpen: true))
                 using (var writer = new ParquetFileWriter(output, new Column[] { new Column<int>("ids") }))
                 using (var group = writer.AppendRowGroup())
                 using (var column = group.NextColumn().LogicalWriter<int>())
@@ -29,7 +28,7 @@ namespace ParquetSharp.Test
                 buffer.Seek(0, SeekOrigin.Begin);
 
                 // Read test data.
-                using (var input = new ManagedRandomAccessFile(buffer, true))
+                using (var input = new ManagedRandomAccessFile(buffer, leaveOpen: true))
                 using (var reader = new ParquetFileReader(input))
                 using (var group = reader.RowGroup(0))
                 using (var column = group.Column(0).LogicalReader<int>())
@@ -90,10 +89,9 @@ namespace ParquetSharp.Test
 
             var exception = Assert.Throws<ParquetException>(() =>
             {
-
                 using (var buffer = new ErroneousReaderStream())
                 {
-                    using (var output = new ManagedOutputStream(buffer, true))
+                    using (var output = new ManagedOutputStream(buffer, leaveOpen: true))
                     using (var writer = new ParquetFileWriter(output, new Column[] {new Column<int>("ids")}))
                     using (var group = writer.AppendRowGroup())
                     using (var column = group.NextColumn().LogicalWriter<int>())

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -106,7 +106,7 @@ namespace ParquetSharp.Test
         {
             var builder = new WriterPropertiesBuilder();
 
-            builder.Compression(Compression.Snappy);
+            builder.Compression(Compression.Lz4);
 
             return builder.Build();
         }
@@ -171,7 +171,7 @@ namespace ParquetSharp.Test
             public int TypeScale = -1;
 
             public Encoding[] Encodings = {Encoding.Plain, Encoding.Rle};
-            public Compression Compression = Compression.Snappy;
+            public Compression Compression = Compression.Lz4;
         }
 
         private const int NumRows = 72;

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using ParquetSharp.Schema;
 
 namespace ParquetSharp.Test
 {
@@ -12,6 +13,8 @@ namespace ParquetSharp.Test
             var p = WriterProperties.GetDefaultWriterProperties();
 
             Assert.AreEqual("parquet-cpp version 1.5.1-SNAPSHOT", p.CreatedBy);
+            Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
+            Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024*1024, p.DataPageSize);
             Assert.AreEqual(Encoding.PlainDictionary, p.DictionaryIndexEncoding);
             Assert.AreEqual(Encoding.PlainDictionary, p.DictionaryPageEncoding);
@@ -28,6 +31,7 @@ namespace ParquetSharp.Test
 
             builder
                 .Compression(Compression.Snappy)
+                .CompressionLevel(3)
                 .CreatedBy("Meeeee!!!")
                 .DataPagesize(123)
                 .DictionaryPagesizeLimit(456)
@@ -40,6 +44,8 @@ namespace ParquetSharp.Test
             var p = builder.Build();
 
             Assert.AreEqual("Meeeee!!!", p.CreatedBy);
+            Assert.AreEqual(Compression.Snappy, p.Compression(new ColumnPath("anypath")));
+            Assert.AreEqual(3, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(123, p.DataPageSize);
             Assert.AreEqual(Encoding.PlainDictionary, p.DictionaryIndexEncoding);
             Assert.AreEqual(Encoding.PlainDictionary, p.DictionaryPageEncoding);
@@ -47,33 +53,6 @@ namespace ParquetSharp.Test
             Assert.AreEqual(789, p.MaxRowGroupLength);
             Assert.AreEqual(ParquetVersion.PARQUET_1_0, p.Version);
             Assert.AreEqual(666, p.WriteBatchSize);
-
-            /*
-        public WriterPropertiesBuilder DisableDictionary()
-        public WriterPropertiesBuilder DisableDictionary(string path)
-        public WriterPropertiesBuilder EnableDictionary()
-        public WriterPropertiesBuilder EnableDictionary(string path)
-
-        // Statistics enable/disable
-
-        public WriterPropertiesBuilder DisableStatistics()
-        public WriterPropertiesBuilder DisableStatistics(string path)
-        public WriterPropertiesBuilder EnableStatistics()
-        public WriterPropertiesBuilder EnableStatistics(string path)
-
-        // Other properties
-
-        public WriterPropertiesBuilder Compression(Compression codec)
-        public WriterPropertiesBuilder Compression(string path, Compression codec)
-        public WriterPropertiesBuilder CreatedBy(string createdBy)
-        public WriterPropertiesBuilder DataPagesize(long pageSize)
-        public WriterPropertiesBuilder DictionaryPagesizeLimit(long dictionaryPagesizeLimit)
-        public WriterPropertiesBuilder Encoding(Encoding encoding)
-        public WriterPropertiesBuilder Encoding(string path, Encoding encoding)
-        public WriterPropertiesBuilder MaxRowGroupLength(long maxRowGroupLength)
-        public WriterPropertiesBuilder Version(ParquetVersion version)
-        public WriterPropertiesBuilder WriteBatchSize(long writeBatchSize)
-             */
         }
     }
 }

--- a/csharp/IO/ManagedOutputStream.cs
+++ b/csharp/IO/ManagedOutputStream.cs
@@ -9,12 +9,12 @@ namespace ParquetSharp.IO
     /// </summary>
     public sealed class ManagedOutputStream : OutputStream
     {
-        public ManagedOutputStream(System.IO.Stream stream)
+        public ManagedOutputStream(Stream stream)
             : this(stream, false)
         {
         }
 
-        public ManagedOutputStream(System.IO.Stream stream, bool leaveOpen)
+        public ManagedOutputStream(Stream stream, bool leaveOpen)
         {
             _stream = stream;
             _leaveOpen = leaveOpen;
@@ -105,10 +105,11 @@ namespace ParquetSharp.IO
         {
             try
             {
-                if (!this._leaveOpen)
+                if (!_leaveOpen)
                 {
                     _stream.Close();
                 }
+
                 exception = null;
                 return 0;
             }

--- a/csharp/IO/ManagedRandomAccessFile.cs
+++ b/csharp/IO/ManagedRandomAccessFile.cs
@@ -14,7 +14,7 @@ namespace ParquetSharp.IO
         {
         }
 
-        public ManagedRandomAccessFile(System.IO.Stream stream, bool leaveOpen)
+        public ManagedRandomAccessFile(Stream stream, bool leaveOpen)
         {
             _stream = stream;
             _leaveOpen = leaveOpen;
@@ -69,10 +69,11 @@ namespace ParquetSharp.IO
         {
             try
             {
-                if(!this._leaveOpen)
+                if(!_leaveOpen)
                 {
                     _stream.Close();
                 }
+
                 exception = null;
                 return 0;
             }

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -10,7 +10,7 @@ namespace ParquetSharp
     {
         public ParquetFileWriter(
             string path, Column[] columns, 
-            Compression compression = Compression.Snappy, 
+            Compression compression = Compression.Lz4, 
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             using (var schema = Column.CreateSchemaNode(columns))
@@ -22,7 +22,7 @@ namespace ParquetSharp
 
         public ParquetFileWriter(
             OutputStream outputStream, Column[] columns, 
-            Compression compression = Compression.Snappy, 
+            Compression compression = Compression.Lz4, 
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             using (var schema = Column.CreateSchemaNode(columns))

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1591;</NoWarn>
-    <Version>2.0.2-beta1</Version>
+    <Version>2.0.2-beta2</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -41,7 +41,7 @@ namespace ParquetSharp.RowOriented
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             string path, 
             string[] columnNames = null, 
-            Compression compression = Compression.Snappy, 
+            Compression compression = Compression.Lz4, 
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
@@ -54,7 +54,7 @@ namespace ParquetSharp.RowOriented
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             OutputStream outputStream,
             string[] columnNames = null,
-            Compression compression = Compression.Snappy,
+            Compression compression = Compression.Lz4,
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -35,6 +35,11 @@ namespace ParquetSharp
             return ExceptionInfo.Return<Compression>(Handle, path.Handle, WriterProperties_Compression);
         }
 
+        public int CompressionLevel(ColumnPath path)
+        {
+            return ExceptionInfo.Return<int>(Handle, path.Handle, WriterProperties_Compression_Level);
+        }
+
         public bool DictionaryEnabled(ColumnPath path)
         {
             return ExceptionInfo.Return<bool>(Handle, path.Handle, WriterProperties_Dictionary_Enabled);
@@ -95,6 +100,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterProperties_Compression(IntPtr writerProperties, IntPtr path, out Compression compression);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterProperties_Compression_Level(IntPtr writerProperties, IntPtr path, out int compressionLevel);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterProperties_Dictionary_Enabled(IntPtr writerProperties, IntPtr path, [MarshalAs(UnmanagedType.I1)] out bool enabled);

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -137,6 +137,28 @@ namespace ParquetSharp
             return this;
         }
 
+        public WriterPropertiesBuilder CompressionLevel(int compressionLevel)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Compression_Level(_handle.IntPtr, compressionLevel));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public WriterPropertiesBuilder CompressionLevel(string path, int compressionLevel)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Compression_Level_By_Path(_handle.IntPtr, path, compressionLevel));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public WriterPropertiesBuilder CompressionLevel(ColumnPath path, int compressionLevel)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Compression_Level_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr, compressionLevel));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
+            return this;
+        }
+
         public WriterPropertiesBuilder CreatedBy(string createdBy)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Created_By(_handle.IntPtr, createdBy));
@@ -259,6 +281,15 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Compression_By_ColumnPath(IntPtr builder, IntPtr path, Compression codec);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Compression_Level(IntPtr builder, int compressionLevel);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr WriterPropertiesBuilder_Compression_Level_By_Path(IntPtr builder, string path, int compressionLevel);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Compression_Level_By_ColumnPath(IntPtr builder, IntPtr path, int compressionLevel);
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
         private static extern IntPtr WriterPropertiesBuilder_Created_By(IntPtr builder, string createdBy);

--- a/vcpkg_linux.sh
+++ b/vcpkg_linux.sh
@@ -5,7 +5,7 @@ mkdir -p build
 cd build
 git clone https://github.com/microsoft/vcpkg.git vcpkg.linux
 cd vcpkg.linux
-git checkout 2019.09
+git checkout 2019.10
 ./bootstrap-vcpkg.sh
 
 ./vcpkg install arrow:x64-linux

--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -2,7 +2,7 @@ mkdir build
 cd build || goto :error
 git clone https://github.com/microsoft/vcpkg.git vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error
-git checkout 2019.09 || goto :error
+git checkout 2019.10 || goto :error
 call bootstrap-vcpkg.bat || goto :error
 
 vcpkg.exe install arrow:x64-windows-static || goto :error


### PR DESCRIPTION
- Version 2.0.2 Beta 2
- Upgraded to Arrow 0.15.1.
- Exposed CompressionLevel (new feature from Arrow).
- Use Lz4 by default instead of Snappy (empirically shown to be faster and compress better).
- Merged PR #76 (close streams when managed stream wrapper classes are closed).