### PR TITLE
Fixed compression argument being ignored by ParquetRowWriter.

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1591;</NoWarn>
-    <Version>2.0.2-beta3</Version>
+    <Version>2.0.2-beta4</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -45,7 +45,7 @@ namespace ParquetSharp.RowOriented
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(path, columns, writeDelegate);
+            return new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace ParquetSharp.RowOriented
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(outputStream, columns, writeDelegate);
+            return new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate);
         }
 
         private static ParquetRowReader<TTuple>.ReadAction GetOrCreateReadDelegate<TTuple>()

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -13,13 +13,23 @@ namespace ParquetSharp.RowOriented
     {
         internal delegate void WriteAction(ParquetRowWriter<TTuple> parquetRowWriter, TTuple[] rows, int length);
 
-        internal ParquetRowWriter(string path, Column[] columns, WriteAction writeAction)
-            : this(new ParquetFileWriter(path, columns), writeAction)
+        internal ParquetRowWriter(
+            string path, 
+            Column[] columns, 
+            Compression compression,
+            IReadOnlyDictionary<string, string> keyValueMetadata, 
+            WriteAction writeAction)
+            : this(new ParquetFileWriter(path, columns, compression, keyValueMetadata), writeAction)
         {
         }
 
-        internal ParquetRowWriter(OutputStream outputStream, Column[] columns, WriteAction writeAction)
-            : this(new ParquetFileWriter(outputStream, columns), writeAction)
+        internal ParquetRowWriter(
+            OutputStream outputStream, 
+            Column[] columns,
+            Compression compression,
+            IReadOnlyDictionary<string, string> keyValueMetadata, 
+            WriteAction writeAction)
+            : this(new ParquetFileWriter(outputStream, columns, compression, keyValueMetadata), writeAction)
         {
         }
 


### PR DESCRIPTION
KeyValueMetaData was also being ignored.