### PR TITLE
Added Parquet encryption support.

### DIFF
--- a/cpp/AesKey.h
+++ b/cpp/AesKey.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+class AesKey final
+{
+public:
+
+	AesKey() = default;
+	
+	explicit AesKey(const std::string& parquet_key)
+	{
+		std::copy(parquet_key.begin(), parquet_key.end(), reinterpret_cast<char*>(key_));
+		size_ = parquet_key.size();
+	}
+
+	std::string ToParquetKey() const
+	{
+		return std::string(reinterpret_cast<const char*>(key_), size_);
+	}
+
+private:
+
+	std::uint64_t key_[4]{};
+	std::uint32_t size_{};
+};

--- a/cpp/AesKey.h
+++ b/cpp/AesKey.h
@@ -12,7 +12,7 @@ public:
 	explicit AesKey(const std::string& parquet_key)
 	{
 		std::copy(parquet_key.begin(), parquet_key.end(), reinterpret_cast<char*>(key_));
-		size_ = parquet_key.size();
+		size_ = static_cast<uint32_t>(parquet_key.size());
 	}
 
 	std::string ToParquetKey() const

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(ParquetSharpNative SHARED
 	ParquetFileWriter.cpp
 	PrimitiveNode.cpp
 	RandomAccessFile.cpp
+	ReaderProperties.cpp
 	ResizableBuffer.cpp
 	RowGroupMetaData.cpp
 	RowGroupReader.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(ParquetSharpNative SHARED
 	CString.h
 	ExceptionInfo.h
 	ExceptionInfo.cpp
+	FileDecryptionProperties.cpp
+	FileDecryptionPropertiesBuilder.cpp
 	FileEncryptionProperties.cpp
 	FileEncryptionPropertiesBuilder.cpp
 	FileMetaData.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(ParquetSharpNative SHARED
 	GroupNode.cpp
 	KeyValueMetadata.cpp
 	LogicalType.cpp
+	ManagedAadPrefixVerifier.h
 	ManagedDecryptionKeyRetriever.h
 	ManagedOutputStream.cpp
 	ManagedRandomAccessFile.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -25,6 +25,7 @@ if (UNIX)
 endif ()
 
 add_library(ParquetSharpNative SHARED 
+	AesKey.h
 	Buffer.cpp
 	BufferReader.cpp
 	BufferOutputStream.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(ParquetSharpNative SHARED
 	CString.h
 	ExceptionInfo.h
 	ExceptionInfo.cpp
+	FileEncryptionProperties.cpp
+	FileEncryptionPropertiesBuilder.cpp
 	FileMetaData.cpp
 	GroupNode.cpp
 	KeyValueMetadata.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -29,7 +29,11 @@ add_library(ParquetSharpNative SHARED
 	BufferReader.cpp
 	BufferOutputStream.cpp
 	ColumnChunkMetaData.cpp
+	ColumnDecryptionProperties.cpp
+	ColumnDecryptionPropertiesBuilder.cpp
 	ColumnDescriptor.cpp
+	ColumnEncryptionProperties.cpp
+	ColumnEncryptionPropertiesBuilder.cpp
 	ColumnPath.cpp
 	ColumnReader.cpp
 	ColumnWriter.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,8 +48,9 @@ add_library(ParquetSharpNative SHARED
 	GroupNode.cpp
 	KeyValueMetadata.cpp
 	LogicalType.cpp
-	ManagedRandomAccessFile.cpp
+	ManagedDecryptionKeyRetriever.h
 	ManagedOutputStream.cpp
+	ManagedRandomAccessFile.cpp
 	Node.cpp
 	OutputStream.cpp
 	ParquetFileReader.cpp

--- a/cpp/ColumnDecryptionProperties.cpp
+++ b/cpp/ColumnDecryptionProperties.cpp
@@ -1,0 +1,40 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionProperties_Deep_Clone(const std::shared_ptr<ColumnDecryptionProperties>* properties, std::shared_ptr<ColumnDecryptionProperties>** clone)
+    {
+        TRYCATCH(*clone = new std::shared_ptr<ColumnDecryptionProperties>((*properties)->DeepClone());)
+    }
+	
+    PARQUETSHARP_EXPORT void ColumnDecryptionProperties_Free(const std::shared_ptr<const ColumnDecryptionProperties>* properties)
+    {
+        delete properties;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionProperties_Column_Path(const std::shared_ptr<const ColumnDecryptionProperties>* properties, const char** column_path)
+    {
+        TRYCATCH(*column_path = AllocateCString((*properties)->column_path());)
+    }
+
+    PARQUETSHARP_EXPORT void ColumnDecryptionProperties_Column_Path_Free(const char* column_path)
+    {
+        FreeCString(column_path);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionProperties_Key(const std::shared_ptr<const ColumnDecryptionProperties>* properties, const char** key)
+    {
+        TRYCATCH(*key = AllocateCString((*properties)->key());)
+    }
+
+    PARQUETSHARP_EXPORT void ColumnDecryptionProperties_Key_Free(const char* key)
+    {
+        FreeCString(key);
+    }
+}

--- a/cpp/ColumnDecryptionProperties.cpp
+++ b/cpp/ColumnDecryptionProperties.cpp
@@ -1,4 +1,5 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 
@@ -28,13 +29,8 @@ extern "C"
         FreeCString(column_path);
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionProperties_Key(const std::shared_ptr<const ColumnDecryptionProperties>* properties, const char** key)
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionProperties_Key(const std::shared_ptr<const ColumnDecryptionProperties>* properties, AesKey* key)
     {
-        TRYCATCH(*key = AllocateCString((*properties)->key());)
-    }
-
-    PARQUETSHARP_EXPORT void ColumnDecryptionProperties_Key_Free(const char* key)
-    {
-        FreeCString(key);
+        TRYCATCH(*key = AesKey((*properties)->key());)
     }
 }

--- a/cpp/ColumnDecryptionPropertiesBuilder.cpp
+++ b/cpp/ColumnDecryptionPropertiesBuilder.cpp
@@ -1,4 +1,5 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 
@@ -23,9 +24,9 @@ extern "C"
         delete builder;
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionPropertiesBuilder_Key(ColumnDecryptionProperties::Builder* builder, const char* key)
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionPropertiesBuilder_Key(ColumnDecryptionProperties::Builder* builder, const AesKey* key)
     {
-        TRYCATCH(builder->key(key);)
+        TRYCATCH(builder->key(key->ToParquetKey());)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionPropertiesBuilder_Build(ColumnDecryptionProperties::Builder* builder, std::shared_ptr<ColumnDecryptionProperties>** properties)

--- a/cpp/ColumnDecryptionPropertiesBuilder.cpp
+++ b/cpp/ColumnDecryptionPropertiesBuilder.cpp
@@ -1,0 +1,35 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionPropertiesBuilder_Create(const char* name, ColumnDecryptionProperties::Builder** builder)
+    {
+        TRYCATCH(*builder = new ColumnDecryptionProperties::Builder(name);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionPropertiesBuilder_Create_From_Column_Path(const std::shared_ptr<schema::ColumnPath>* path, ColumnDecryptionProperties::Builder** builder)
+    {
+        TRYCATCH(*builder = new ColumnDecryptionProperties::Builder(*path);)
+    }
+	
+    PARQUETSHARP_EXPORT void ColumnDecryptionPropertiesBuilder_Free(ColumnDecryptionProperties::Builder* builder)
+    {
+        delete builder;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionPropertiesBuilder_Key(ColumnDecryptionProperties::Builder* builder, const char* key)
+    {
+        TRYCATCH(builder->key(key);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionPropertiesBuilder_Build(ColumnDecryptionProperties::Builder* builder, std::shared_ptr<ColumnDecryptionProperties>** properties)
+    {
+        TRYCATCH(*properties = new std::shared_ptr<ColumnDecryptionProperties>(builder->build());)
+    }
+}

--- a/cpp/ColumnEncryptionProperties.cpp
+++ b/cpp/ColumnEncryptionProperties.cpp
@@ -1,0 +1,60 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Deep_Clone(const std::shared_ptr<ColumnEncryptionProperties>* properties, std::shared_ptr<ColumnEncryptionProperties>** clone)
+    {
+        TRYCATCH(*clone = new std::shared_ptr<ColumnEncryptionProperties>((*properties)->DeepClone());)
+    }
+	
+    PARQUETSHARP_EXPORT void ColumnEncryptionProperties_Free(const std::shared_ptr<const ColumnEncryptionProperties>* properties)
+    {
+        delete properties;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Column_Path(const std::shared_ptr<const ColumnEncryptionProperties>* properties, const char** column_path)
+    {
+        TRYCATCH(*column_path = AllocateCString((*properties)->column_path());)
+    }
+
+    PARQUETSHARP_EXPORT void ColumnEncryptionProperties_Column_Path_Free(const char* column_path)
+    {
+        FreeCString(column_path);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Is_Encrypted(const std::shared_ptr<const ColumnEncryptionProperties>* properties, bool* is_encrypted)
+    {
+        TRYCATCH(*is_encrypted = (*properties)->is_encrypted();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Is_Encrypted_With_Footer_Key(const std::shared_ptr<const ColumnEncryptionProperties>* properties, bool* is_encrypted_with_footer_key)
+    {
+        TRYCATCH(*is_encrypted_with_footer_key = (*properties)->is_encrypted_with_footer_key();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Key(const std::shared_ptr<const ColumnEncryptionProperties>* properties, const char** key)
+    {
+        TRYCATCH(*key = AllocateCString((*properties)->key());)
+    }
+
+    PARQUETSHARP_EXPORT void ColumnEncryptionProperties_Key_Free(const char* key)
+    {
+        FreeCString(key);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Key_Metadata(const std::shared_ptr<const ColumnEncryptionProperties>* properties, const char** key_metadata)
+    {
+        TRYCATCH(*key_metadata = AllocateCString((*properties)->key_metadata());)
+    }
+
+    PARQUETSHARP_EXPORT void ColumnEncryptionProperties_Key_Metadata_Free(const char* key_metadata)
+    {
+        FreeCString(key_metadata);
+    }
+}

--- a/cpp/ColumnEncryptionProperties.cpp
+++ b/cpp/ColumnEncryptionProperties.cpp
@@ -1,4 +1,5 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 
@@ -38,14 +39,9 @@ extern "C"
         TRYCATCH(*is_encrypted_with_footer_key = (*properties)->is_encrypted_with_footer_key();)
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Key(const std::shared_ptr<const ColumnEncryptionProperties>* properties, const char** key)
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Key(const std::shared_ptr<const ColumnEncryptionProperties>* properties, AesKey* key)
     {
-        TRYCATCH(*key = AllocateCString((*properties)->key());)
-    }
-
-    PARQUETSHARP_EXPORT void ColumnEncryptionProperties_Key_Free(const char* key)
-    {
-        FreeCString(key);
+        TRYCATCH(*key = AesKey((*properties)->key());)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Key_Metadata(const std::shared_ptr<const ColumnEncryptionProperties>* properties, const char** key_metadata)

--- a/cpp/ColumnEncryptionPropertiesBuilder.cpp
+++ b/cpp/ColumnEncryptionPropertiesBuilder.cpp
@@ -1,0 +1,45 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Create(const char* name, ColumnEncryptionProperties::Builder** builder)
+    {
+        TRYCATCH(*builder = new ColumnEncryptionProperties::Builder(name);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Create_From_Column_Path(const std::shared_ptr<schema::ColumnPath>* path, ColumnEncryptionProperties::Builder** builder)
+    {
+        TRYCATCH(*builder = new ColumnEncryptionProperties::Builder(*path);)
+    }
+	
+    PARQUETSHARP_EXPORT void ColumnEncryptionPropertiesBuilder_Free(ColumnEncryptionProperties::Builder* builder)
+    {
+        delete builder;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Key(ColumnEncryptionProperties::Builder* builder, const char* key)
+    {
+        TRYCATCH(builder->key(key);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Key_Metadata(ColumnEncryptionProperties::Builder* builder, const char* key_metadata)
+    {
+        TRYCATCH(builder->key_metadata(key_metadata);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Key_Id(ColumnEncryptionProperties::Builder* builder, const char* key_id)
+    {
+        TRYCATCH(builder->key_id(key_id);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Build(ColumnEncryptionProperties::Builder* builder, std::shared_ptr<ColumnEncryptionProperties>** properties)
+    {
+        TRYCATCH(*properties = new std::shared_ptr<ColumnEncryptionProperties>(builder->build());)
+    }
+}

--- a/cpp/ColumnEncryptionPropertiesBuilder.cpp
+++ b/cpp/ColumnEncryptionPropertiesBuilder.cpp
@@ -1,4 +1,5 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 
@@ -23,9 +24,9 @@ extern "C"
         delete builder;
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Key(ColumnEncryptionProperties::Builder* builder, const char* key)
+    PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Key(ColumnEncryptionProperties::Builder* builder, const AesKey* key)
     {
-        TRYCATCH(builder->key(key);)
+        TRYCATCH(builder->key(key->ToParquetKey());)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionPropertiesBuilder_Key_Metadata(ColumnEncryptionProperties::Builder* builder, const char* key_metadata)

--- a/cpp/FileDecryptionProperties.cpp
+++ b/cpp/FileDecryptionProperties.cpp
@@ -1,0 +1,70 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Deep_Clone(const std::shared_ptr<FileDecryptionProperties>* properties, std::shared_ptr<FileDecryptionProperties>** clone)
+    {
+        TRYCATCH(*clone = new std::shared_ptr<FileDecryptionProperties>((*properties)->DeepClone());)
+    }
+	
+    PARQUETSHARP_EXPORT void FileDecryptionProperties_Free(const std::shared_ptr<const FileDecryptionProperties>* properties)
+    {
+        delete properties;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Column_Key(const std::shared_ptr<const FileDecryptionProperties>* properties, const char* column_path, const char** column_key)
+    {
+        TRYCATCH(*column_key = AllocateCString((*properties)->column_key(column_path));)
+    }
+
+    PARQUETSHARP_EXPORT void FileDecryptionProperties_Column_Key_Free(const char* column_key)
+    {
+        FreeCString(column_key);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Footer_Key(const std::shared_ptr<const FileDecryptionProperties>* properties, const char** footer_key)
+    {
+        TRYCATCH(*footer_key = AllocateCString((*properties)->footer_key());)
+    }
+
+    PARQUETSHARP_EXPORT void FileDecryptionProperties_Footer_Key_Free(const char* footer_key)
+    {
+        FreeCString(footer_key);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Aad_Prefix(const std::shared_ptr<const FileDecryptionProperties>* properties, const char** aad_prefix)
+    {
+        TRYCATCH(*aad_prefix = AllocateCString((*properties)->aad_prefix());)
+    }
+
+    PARQUETSHARP_EXPORT void FileDecryptionProperties_Aad_Prefix_Free(const char* aad_prefix)
+    {
+        FreeCString(aad_prefix);
+    }
+
+	PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Key_Retriever(const std::shared_ptr<const FileDecryptionProperties>* properties, std::shared_ptr<DecryptionKeyRetriever>** key_retriever)
+    {
+        TRYCATCH(*key_retriever = new std::shared_ptr<DecryptionKeyRetriever>((*properties)->key_retriever());)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Check_Plaintext_Footer_Integrity(const std::shared_ptr<const FileDecryptionProperties>* properties, bool* check_plaintext_footer_integrity)
+    {
+        TRYCATCH(*check_plaintext_footer_integrity = (*properties)->check_plaintext_footer_integrity();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Plaintext_Files_Allowed(const std::shared_ptr<const FileDecryptionProperties>* properties, bool* plaintext_files_allowed)
+    {
+        TRYCATCH(*plaintext_files_allowed = (*properties)->plaintext_files_allowed();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Aad_Prefix_Verifier(const std::shared_ptr<const FileDecryptionProperties>* properties, std::shared_ptr<AADPrefixVerifier>** aad_prefix_verifier)
+    {
+        TRYCATCH(*aad_prefix_verifier = new std::shared_ptr<AADPrefixVerifier>((*properties)->aad_prefix_verifier());)
+    }
+}

--- a/cpp/FileDecryptionProperties.cpp
+++ b/cpp/FileDecryptionProperties.cpp
@@ -1,4 +1,5 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 #include "ManagedAadPrefixVerifier.h"
@@ -20,24 +21,14 @@ extern "C"
         delete properties;
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Column_Key(const std::shared_ptr<const FileDecryptionProperties>* properties, const char* column_path, const char** column_key)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Column_Key(const std::shared_ptr<const FileDecryptionProperties>* properties, const char* column_path, AesKey* column_key)
     {
-        TRYCATCH(*column_key = AllocateCString((*properties)->column_key(column_path));)
+        TRYCATCH(*column_key = AesKey((*properties)->column_key(column_path));)
     }
 
-    PARQUETSHARP_EXPORT void FileDecryptionProperties_Column_Key_Free(const char* column_key)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Footer_Key(const std::shared_ptr<const FileDecryptionProperties>* properties, AesKey* footer_key)
     {
-        FreeCString(column_key);
-    }
-
-    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Footer_Key(const std::shared_ptr<const FileDecryptionProperties>* properties, const char** footer_key)
-    {
-        TRYCATCH(*footer_key = AllocateCString((*properties)->footer_key());)
-    }
-
-    PARQUETSHARP_EXPORT void FileDecryptionProperties_Footer_Key_Free(const char* footer_key)
-    {
-        FreeCString(footer_key);
+        TRYCATCH(*footer_key = AesKey((*properties)->footer_key());)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Aad_Prefix(const std::shared_ptr<const FileDecryptionProperties>* properties, const char** aad_prefix)

--- a/cpp/FileDecryptionProperties.cpp
+++ b/cpp/FileDecryptionProperties.cpp
@@ -43,7 +43,11 @@ extern "C"
 
 	PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Key_Retriever(const std::shared_ptr<const FileDecryptionProperties>* properties, void** key_retriever)
     {
-        TRYCATCH(*key_retriever = dynamic_cast<ManagedDecryptionKeyRetriever&>(*(*properties)->key_retriever()).Handle;)
+        TRYCATCH
+        (
+            const auto r = (*properties)->key_retriever();
+            *key_retriever = r ? dynamic_cast<ManagedDecryptionKeyRetriever&>(*r).Handle : nullptr;
+        )
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Check_Plaintext_Footer_Integrity(const std::shared_ptr<const FileDecryptionProperties>* properties, bool* check_plaintext_footer_integrity)
@@ -58,6 +62,10 @@ extern "C"
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Aad_Prefix_Verifier(const std::shared_ptr<const FileDecryptionProperties>* properties, void** aad_prefix_verifier)
     {
-        TRYCATCH(*aad_prefix_verifier = dynamic_cast<ManagedAadPrefixVerifier&>(*(*properties)->aad_prefix_verifier()).Handle;)
+        TRYCATCH
+        (
+            const auto v = (*properties)->aad_prefix_verifier();
+            *aad_prefix_verifier = v ? dynamic_cast<ManagedAadPrefixVerifier&>(*v).Handle : nullptr;
+        )
     }
 }

--- a/cpp/FileDecryptionProperties.cpp
+++ b/cpp/FileDecryptionProperties.cpp
@@ -1,6 +1,7 @@
 #include "cpp/ParquetSharpExport.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
+#include "ManagedDecryptionKeyRetriever.h"
 
 #include <parquet/encryption.h>
 
@@ -48,9 +49,9 @@ extern "C"
         FreeCString(aad_prefix);
     }
 
-	PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Key_Retriever(const std::shared_ptr<const FileDecryptionProperties>* properties, std::shared_ptr<DecryptionKeyRetriever>** key_retriever)
+	PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Key_Retriever(const std::shared_ptr<const FileDecryptionProperties>* properties, void** key_retriever)
     {
-        TRYCATCH(*key_retriever = new std::shared_ptr<DecryptionKeyRetriever>((*properties)->key_retriever());)
+        TRYCATCH(*key_retriever = dynamic_cast<ManagedDecryptionKeyRetriever&>(*(*properties)->key_retriever()).Handle;)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Check_Plaintext_Footer_Integrity(const std::shared_ptr<const FileDecryptionProperties>* properties, bool* check_plaintext_footer_integrity)

--- a/cpp/FileDecryptionProperties.cpp
+++ b/cpp/FileDecryptionProperties.cpp
@@ -1,6 +1,7 @@
 #include "cpp/ParquetSharpExport.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
+#include "ManagedAadPrefixVerifier.h"
 #include "ManagedDecryptionKeyRetriever.h"
 
 #include <parquet/encryption.h>
@@ -64,8 +65,8 @@ extern "C"
         TRYCATCH(*plaintext_files_allowed = (*properties)->plaintext_files_allowed();)
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Aad_Prefix_Verifier(const std::shared_ptr<const FileDecryptionProperties>* properties, std::shared_ptr<AADPrefixVerifier>** aad_prefix_verifier)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Aad_Prefix_Verifier(const std::shared_ptr<const FileDecryptionProperties>* properties, void** aad_prefix_verifier)
     {
-        TRYCATCH(*aad_prefix_verifier = new std::shared_ptr<AADPrefixVerifier>((*properties)->aad_prefix_verifier());)
+        TRYCATCH(*aad_prefix_verifier = dynamic_cast<ManagedAadPrefixVerifier&>(*(*properties)->aad_prefix_verifier()).Handle;)
     }
 }

--- a/cpp/FileDecryptionPropertiesBuilder.cpp
+++ b/cpp/FileDecryptionPropertiesBuilder.cpp
@@ -1,9 +1,9 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 #include "ManagedAadPrefixVerifier.h"
 #include "ManagedDecryptionKeyRetriever.h"
-
 
 #include <parquet/encryption.h>
 
@@ -21,9 +21,9 @@ extern "C"
         delete builder;
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Footer_Key(FileDecryptionProperties::Builder* builder, const char* footer_key)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Footer_Key(FileDecryptionProperties::Builder* builder, const AesKey* footer_key)
     {
-        TRYCATCH(builder->footer_key(footer_key);)
+        TRYCATCH(builder->footer_key(footer_key->ToParquetKey());)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Column_Keys(FileDecryptionProperties::Builder* builder, const std::shared_ptr<ColumnDecryptionProperties>** column_decryption_properties, int32_t num_properties)
@@ -45,10 +45,9 @@ extern "C"
         FileDecryptionProperties::Builder* builder, 
         void* const handle,
         const ManagedDecryptionKeyRetriever::FreeGcHandleFunc free_gc_handle,
-        const ManagedDecryptionKeyRetriever::GetKeyFunc get_key,
-        const ManagedDecryptionKeyRetriever::FreeKeyFunc free_key)
+        const ManagedDecryptionKeyRetriever::GetKeyFunc get_key)
     {
-        TRYCATCH(builder->key_retriever(std::make_shared<ManagedDecryptionKeyRetriever>(handle, free_gc_handle, get_key, free_key));)
+        TRYCATCH(builder->key_retriever(std::make_shared<ManagedDecryptionKeyRetriever>(handle, free_gc_handle, get_key));)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Disable_Footer_Signature_Verification(FileDecryptionProperties::Builder* builder)

--- a/cpp/FileDecryptionPropertiesBuilder.cpp
+++ b/cpp/FileDecryptionPropertiesBuilder.cpp
@@ -1,6 +1,7 @@
 #include "cpp/ParquetSharpExport.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
+#include "ManagedAadPrefixVerifier.h"
 #include "ManagedDecryptionKeyRetriever.h"
 
 
@@ -43,9 +44,9 @@ extern "C"
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Key_Retriever(
         FileDecryptionProperties::Builder* builder, 
         void* const handle,
-        const FreeGcHandleFunc free_gc_handle,
-        const GetKeyFunc get_key,
-        const FreeKeyFunc free_key)
+        const ManagedDecryptionKeyRetriever::FreeGcHandleFunc free_gc_handle,
+        const ManagedDecryptionKeyRetriever::GetKeyFunc get_key,
+        const ManagedDecryptionKeyRetriever::FreeKeyFunc free_key)
     {
         TRYCATCH(builder->key_retriever(std::make_shared<ManagedDecryptionKeyRetriever>(handle, free_gc_handle, get_key, free_key));)
     }
@@ -60,9 +61,14 @@ extern "C"
         TRYCATCH(builder->aad_prefix(aad_prefix);)
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Aad_Prefix_Verifier(FileDecryptionProperties::Builder* builder, const std::shared_ptr<AADPrefixVerifier>* aad_prefix_verifier)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Aad_Prefix_Verifier(
+        FileDecryptionProperties::Builder* builder,
+        void* const handle,
+        const ManagedAadPrefixVerifier::FreeGcHandleFunc free_gc_handle,
+        const ManagedAadPrefixVerifier::VerifyFunc verify,
+        const ManagedAadPrefixVerifier::FreeExceptionFunc free_exception)
     {
-        TRYCATCH(builder->aad_prefix_verifier(*aad_prefix_verifier);)
+        TRYCATCH(builder->aad_prefix_verifier(std::make_shared<ManagedAadPrefixVerifier>(handle, free_gc_handle, verify, free_exception));)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Plaintext_Files_Allowed(FileDecryptionProperties::Builder* builder)

--- a/cpp/FileDecryptionPropertiesBuilder.cpp
+++ b/cpp/FileDecryptionPropertiesBuilder.cpp
@@ -1,6 +1,8 @@
 #include "cpp/ParquetSharpExport.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
+#include "ManagedDecryptionKeyRetriever.h"
+
 
 #include <parquet/encryption.h>
 
@@ -38,9 +40,14 @@ extern "C"
         )
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Key_Retriever(FileDecryptionProperties::Builder* builder, const std::shared_ptr<DecryptionKeyRetriever>* key_retriever)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Key_Retriever(
+        FileDecryptionProperties::Builder* builder, 
+        void* const handle,
+        const FreeGcHandleFunc free_gc_handle,
+        const GetKeyFunc get_key,
+        const FreeKeyFunc free_key)
     {
-        TRYCATCH(builder->key_retriever(*key_retriever);)
+        TRYCATCH(builder->key_retriever(std::make_shared<ManagedDecryptionKeyRetriever>(handle, free_gc_handle, get_key, free_key));)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Disable_Footer_Signature_Verification(FileDecryptionProperties::Builder* builder)

--- a/cpp/FileDecryptionPropertiesBuilder.cpp
+++ b/cpp/FileDecryptionPropertiesBuilder.cpp
@@ -64,10 +64,9 @@ extern "C"
         FileDecryptionProperties::Builder* builder,
         void* const handle,
         const ManagedAadPrefixVerifier::FreeGcHandleFunc free_gc_handle,
-        const ManagedAadPrefixVerifier::VerifyFunc verify,
-        const ManagedAadPrefixVerifier::FreeExceptionFunc free_exception)
+        const ManagedAadPrefixVerifier::VerifyFunc verify)
     {
-        TRYCATCH(builder->aad_prefix_verifier(handle ? std::make_shared<ManagedAadPrefixVerifier>(handle, free_gc_handle, verify, free_exception) : nullptr);)
+        TRYCATCH(builder->aad_prefix_verifier(handle ? std::make_shared<ManagedAadPrefixVerifier>(handle, free_gc_handle, verify) : nullptr);)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Plaintext_Files_Allowed(FileDecryptionProperties::Builder* builder)

--- a/cpp/FileDecryptionPropertiesBuilder.cpp
+++ b/cpp/FileDecryptionPropertiesBuilder.cpp
@@ -47,7 +47,7 @@ extern "C"
         const ManagedDecryptionKeyRetriever::FreeGcHandleFunc free_gc_handle,
         const ManagedDecryptionKeyRetriever::GetKeyFunc get_key)
     {
-        TRYCATCH(builder->key_retriever(std::make_shared<ManagedDecryptionKeyRetriever>(handle, free_gc_handle, get_key));)
+        TRYCATCH(builder->key_retriever(handle ? std::make_shared<ManagedDecryptionKeyRetriever>(handle, free_gc_handle, get_key) : nullptr);)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Disable_Footer_Signature_Verification(FileDecryptionProperties::Builder* builder)
@@ -67,7 +67,7 @@ extern "C"
         const ManagedAadPrefixVerifier::VerifyFunc verify,
         const ManagedAadPrefixVerifier::FreeExceptionFunc free_exception)
     {
-        TRYCATCH(builder->aad_prefix_verifier(std::make_shared<ManagedAadPrefixVerifier>(handle, free_gc_handle, verify, free_exception));)
+        TRYCATCH(builder->aad_prefix_verifier(handle ? std::make_shared<ManagedAadPrefixVerifier>(handle, free_gc_handle, verify, free_exception) : nullptr);)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Plaintext_Files_Allowed(FileDecryptionProperties::Builder* builder)

--- a/cpp/FileDecryptionPropertiesBuilder.cpp
+++ b/cpp/FileDecryptionPropertiesBuilder.cpp
@@ -1,0 +1,70 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Create(FileDecryptionProperties::Builder** builder)
+    {
+        TRYCATCH(*builder = new FileDecryptionProperties::Builder();)
+    }
+	
+    PARQUETSHARP_EXPORT void FileDecryptionPropertiesBuilder_Free(FileDecryptionProperties::Builder* builder)
+    {
+        delete builder;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Footer_Key(FileDecryptionProperties::Builder* builder, const char* footer_key)
+    {
+        TRYCATCH(builder->footer_key(footer_key);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Column_Keys(FileDecryptionProperties::Builder* builder, const std::shared_ptr<ColumnDecryptionProperties>** column_decryption_properties, int32_t num_properties)
+    {
+        TRYCATCH
+        (
+            ColumnPathToDecryptionPropertiesMap m;
+
+	        for (int32_t i = 0; i != num_properties; ++i)
+	        {
+	            m.insert(std::make_pair((*column_decryption_properties[i])->column_path(), (*column_decryption_properties[i])));
+	        }
+
+	        builder->column_keys(m);
+        )
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Key_Retriever(FileDecryptionProperties::Builder* builder, const std::shared_ptr<DecryptionKeyRetriever>* key_retriever)
+    {
+        TRYCATCH(builder->key_retriever(*key_retriever);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Disable_Footer_Signature_Verification(FileDecryptionProperties::Builder* builder)
+    {
+        TRYCATCH(builder->disable_footer_signature_verification();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Aad_Prefix(FileDecryptionProperties::Builder* builder, const char* aad_prefix)
+    {
+        TRYCATCH(builder->aad_prefix(aad_prefix);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Aad_Prefix_Verifier(FileDecryptionProperties::Builder* builder, const std::shared_ptr<AADPrefixVerifier>* aad_prefix_verifier)
+    {
+        TRYCATCH(builder->aad_prefix_verifier(*aad_prefix_verifier);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Plaintext_Files_Allowed(FileDecryptionProperties::Builder* builder)
+    {
+        TRYCATCH(builder->plaintext_files_allowed();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionPropertiesBuilder_Build(FileDecryptionProperties::Builder* builder, std::shared_ptr<FileDecryptionProperties>** properties)
+    {
+        TRYCATCH(*properties = new std::shared_ptr<FileDecryptionProperties>(builder->build());)
+    }
+}

--- a/cpp/FileEncryptionProperties.cpp
+++ b/cpp/FileEncryptionProperties.cpp
@@ -1,4 +1,5 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 
@@ -28,14 +29,9 @@ extern "C"
         TRYCATCH(*algorithm = (*properties)->algorithm();)
     }
 
-    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Footer_Key(const std::shared_ptr<const FileEncryptionProperties>* properties, const char** footer_key)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Footer_Key(const std::shared_ptr<const FileEncryptionProperties>* properties, AesKey* footer_key)
     {
-        TRYCATCH(*footer_key = AllocateCString((*properties)->footer_key());)
-    }
-	
-    PARQUETSHARP_EXPORT void FileEncryptionProperties_Footer_Key_Free(const char* footer_key)
-    {
-        FreeCString(footer_key);
+        TRYCATCH(*footer_key = AesKey((*properties)->footer_key());)
     }
 
     PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Footer_Key_Metadata(const std::shared_ptr<const FileEncryptionProperties>* properties, const char** footer_key_metadata)

--- a/cpp/FileEncryptionProperties.cpp
+++ b/cpp/FileEncryptionProperties.cpp
@@ -1,0 +1,71 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Deep_Clone(const std::shared_ptr<FileEncryptionProperties>* properties, std::shared_ptr<FileEncryptionProperties>** clone)
+    {
+        TRYCATCH(*clone = new std::shared_ptr<FileEncryptionProperties>((*properties)->DeepClone());)
+    }
+	
+    PARQUETSHARP_EXPORT void FileEncryptionProperties_Free(const std::shared_ptr<const FileEncryptionProperties>* properties)
+    {
+        delete properties;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Encrypted_Footer(const std::shared_ptr<const FileEncryptionProperties>* properties, bool* encrypted_footer)
+    {
+        TRYCATCH(*encrypted_footer = (*properties)->encrypted_footer();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Algorithm(const std::shared_ptr<const FileEncryptionProperties>* properties, EncryptionAlgorithm* algorithm)
+    {
+        TRYCATCH(*algorithm = (*properties)->algorithm();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Footer_Key(const std::shared_ptr<const FileEncryptionProperties>* properties, const char** footer_key)
+    {
+        TRYCATCH(*footer_key = AllocateCString((*properties)->footer_key());)
+    }
+	
+    PARQUETSHARP_EXPORT void FileEncryptionProperties_Footer_Key_Free(const char* footer_key)
+    {
+        FreeCString(footer_key);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Footer_Key_Metadata(const std::shared_ptr<const FileEncryptionProperties>* properties, const char** footer_key_metadata)
+    {
+        TRYCATCH(*footer_key_metadata = AllocateCString((*properties)->footer_key_metadata());)
+    }
+
+    PARQUETSHARP_EXPORT void FileEncryptionProperties_Footer_Key_Metadata_Free(const char* footer_key_metadata)
+    {
+        FreeCString(footer_key_metadata);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_File_Aad(const std::shared_ptr<const FileEncryptionProperties>* properties, const char** file_aad)
+    {
+        TRYCATCH(*file_aad = AllocateCString((*properties)->file_aad());)
+    }
+
+    PARQUETSHARP_EXPORT void FileEncryptionProperties_File_Aad_Free(const char* file_aad)
+    {
+        FreeCString(file_aad);
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Column_Encryption_Properties(const std::shared_ptr<FileEncryptionProperties>* properties, const char* column_path, std::shared_ptr<ColumnEncryptionProperties>* column_encryption_properties)
+    {
+        TRYCATCH(*column_encryption_properties = (*properties)->column_encryption_properties(column_path);)
+    }
+
+	// TODO: do we really need this?
+    //PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Encrypted_Columns(const std::shared_ptr<const FileEncryptionProperties>* properties, bool* is_encrypted_with_footer_key)
+    //{
+    //    TRYCATCH(*encrypted_columns = (*properties)->encrypted_columns();)
+    //}
+}

--- a/cpp/FileEncryptionPropertiesBuilder.cpp
+++ b/cpp/FileEncryptionPropertiesBuilder.cpp
@@ -1,4 +1,5 @@
 #include "cpp/ParquetSharpExport.h"
+#include "AesKey.h"
 #include "CString.h"
 #include "ExceptionInfo.h"
 
@@ -8,9 +9,9 @@ using namespace parquet;
 
 extern "C"
 {
-    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Create(const char* footer_key, FileEncryptionProperties::Builder** builder)
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Create(const AesKey* footer_key, FileEncryptionProperties::Builder** builder)
     {
-        TRYCATCH(*builder = new FileEncryptionProperties::Builder(footer_key);)
+        TRYCATCH(*builder = new FileEncryptionProperties::Builder(footer_key->ToParquetKey());)
     }
 	
     PARQUETSHARP_EXPORT void FileEncryptionPropertiesBuilder_Free(FileEncryptionProperties::Builder* builder)

--- a/cpp/FileEncryptionPropertiesBuilder.cpp
+++ b/cpp/FileEncryptionPropertiesBuilder.cpp
@@ -1,0 +1,70 @@
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+extern "C"
+{
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Create(const char* footer_key, FileEncryptionProperties::Builder** builder)
+    {
+        TRYCATCH(*builder = new FileEncryptionProperties::Builder(footer_key);)
+    }
+	
+    PARQUETSHARP_EXPORT void FileEncryptionPropertiesBuilder_Free(FileEncryptionProperties::Builder* builder)
+    {
+        delete builder;
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Set_Plaintext_Footer(FileEncryptionProperties::Builder* builder)
+    {
+        TRYCATCH(builder->set_plaintext_footer();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Algorithm(FileEncryptionProperties::Builder* builder, ParquetCipher::type parquet_cipher)
+    {
+        TRYCATCH(builder->algorithm(parquet_cipher);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Footer_Key_Id(FileEncryptionProperties::Builder* builder, const char* footer_key_id)
+    {
+        TRYCATCH(builder->footer_key_id(footer_key_id);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Footer_Key_Metadata(FileEncryptionProperties::Builder* builder, const char* footer_key_metadata)
+    {
+        TRYCATCH(builder->footer_key_metadata(footer_key_metadata);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Aad_Prefix(FileEncryptionProperties::Builder* builder, const char* aad_prefix)
+    {
+        TRYCATCH(builder->aad_prefix(aad_prefix);)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Disable_Aad_Prefix_Storage(FileEncryptionProperties::Builder* builder)
+    {
+        TRYCATCH(builder->disable_aad_prefix_storage();)
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Encrypted_Columns(FileEncryptionProperties::Builder* builder, const std::shared_ptr<ColumnEncryptionProperties>** column_encryption_properties, int32_t num_properties)
+    {
+        TRYCATCH
+    	(
+            ColumnPathToEncryptionPropertiesMap m;
+
+			for (int32_t i = 0; i != num_properties; ++i)
+			{
+                m.insert(std::make_pair((*column_encryption_properties[i])->column_path(), (*column_encryption_properties[i])));
+			}
+
+            builder->encrypted_columns(m);
+        )
+    }
+
+    PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionPropertiesBuilder_Build(FileEncryptionProperties::Builder* builder, std::shared_ptr<FileEncryptionProperties>** properties)
+    {
+        TRYCATCH(*properties = new std::shared_ptr<FileEncryptionProperties>(builder->build());)
+    }
+}

--- a/cpp/ManagedAadPrefixVerifier.h
+++ b/cpp/ManagedAadPrefixVerifier.h
@@ -1,0 +1,59 @@
+
+#pragma once
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+// Derived AADPrefixVerifier that can callback into managed code.
+// This class maintains a GC reference, such that the managed instance cannot get collected if this class is still alive.
+class ManagedAadPrefixVerifier final : public AADPrefixVerifier
+{
+public:
+
+	typedef void (*FreeGcHandleFunc) (void* handle);
+	typedef const char* (*VerifyFunc) (void* handle, const char* aad_prefix);
+	typedef void (*FreeExceptionFunc) (const char* exception);
+
+	ManagedAadPrefixVerifier(const ManagedAadPrefixVerifier&) = delete;
+	ManagedAadPrefixVerifier(ManagedAadPrefixVerifier&&) = delete;
+	ManagedAadPrefixVerifier& operator = (const ManagedAadPrefixVerifier&) = delete;
+	ManagedAadPrefixVerifier& operator = (ManagedAadPrefixVerifier&&) = delete;
+
+	ManagedAadPrefixVerifier(
+		void* const handle,
+		const FreeGcHandleFunc free_gc_handle,
+		const VerifyFunc verify,
+		const FreeExceptionFunc free_exception) :
+		Handle(handle),
+		free_gc_handle_(free_gc_handle),
+		verify_(verify),
+		free_exception_(free_exception)
+	{
+	}
+
+	~ManagedAadPrefixVerifier() override
+	{
+		free_gc_handle_(Handle);
+	}
+
+	void Verify(const std::string& aad_prefix) override
+	{
+		const char* const exception = verify_(Handle, aad_prefix.c_str());
+		if (exception)
+		{
+			const std::string msg(exception);
+			free_exception_(exception);
+
+			throw ParquetException("AADPrefixVerifier: " + msg);
+		}
+	}
+
+	void* const Handle;
+
+private:	
+
+	const FreeGcHandleFunc free_gc_handle_;
+	const VerifyFunc verify_;
+	const FreeExceptionFunc free_exception_;
+};

--- a/cpp/ManagedDecryptionKeyRetriever.h
+++ b/cpp/ManagedDecryptionKeyRetriever.h
@@ -5,15 +5,15 @@
 
 using namespace parquet;
 
-typedef void (*FreeGcHandleFunc) (void* handle);
-typedef const char* (*GetKeyFunc) (void* handle, const char* key_metadata);
-typedef void (*FreeKeyFunc) (const char* key);
-
 // Derived DecryptionKeyRetriever that can callback into managed code.
 // This class maintains a GC reference, such that the managed instance cannot get collected if this class is still alive.
 class ManagedDecryptionKeyRetriever final : public DecryptionKeyRetriever
 {
 public:
+
+	typedef void (*FreeGcHandleFunc) (void* handle);
+	typedef const char* (*GetKeyFunc) (void* handle, const char* key_metadata);
+	typedef void (*FreeKeyFunc) (const char* key);
 
 	ManagedDecryptionKeyRetriever(const ManagedDecryptionKeyRetriever&) = delete;
 	ManagedDecryptionKeyRetriever(ManagedDecryptionKeyRetriever&&) = delete;

--- a/cpp/ManagedDecryptionKeyRetriever.h
+++ b/cpp/ManagedDecryptionKeyRetriever.h
@@ -1,0 +1,58 @@
+
+#pragma once
+
+#include <parquet/encryption.h>
+
+using namespace parquet;
+
+typedef const char* key_t;
+typedef void (*FreeGcHandleFunc) (void* handle);
+typedef key_t (*GetKeyFunc) (void* handle, const char* key_metadata);
+typedef void (*FreeKeyFunc) (key_t key);
+
+// Derived DecryptionKeyRetriever that can callback into managed code.
+// This class maintains a GC reference, such that the managed instance cannot get collected if this class is still alive.
+class ManagedDecryptionKeyRetriever final : public DecryptionKeyRetriever
+{
+public:
+
+	ManagedDecryptionKeyRetriever(const ManagedDecryptionKeyRetriever&) = delete;
+	ManagedDecryptionKeyRetriever(ManagedDecryptionKeyRetriever&&) = delete;
+	ManagedDecryptionKeyRetriever& operator = (const ManagedDecryptionKeyRetriever&) = delete;
+	ManagedDecryptionKeyRetriever& operator = (ManagedDecryptionKeyRetriever&&) = delete;
+
+	ManagedDecryptionKeyRetriever(
+		void* const handle,
+		const FreeGcHandleFunc free_gc_handle,
+		const GetKeyFunc get_key,
+		const FreeKeyFunc free_key) :
+		Handle(handle),
+		free_gc_handle_(free_gc_handle),
+		get_key_(get_key),
+		free_key_(free_key)
+	{
+	}
+
+	~ManagedDecryptionKeyRetriever() override
+	{
+		free_gc_handle_(Handle);
+	}
+
+	std::string GetKey(const std::string& key_metadata) const override
+	{
+		const key_t key = get_key_(Handle, key_metadata.c_str());
+		const std::string key_str(key);
+
+		free_key_(key);
+
+		return key_str;
+	}
+
+	void* const Handle;
+
+private:	
+
+	const FreeGcHandleFunc free_gc_handle_;
+	const GetKeyFunc get_key_;
+	const FreeKeyFunc free_key_;
+};

--- a/cpp/ManagedDecryptionKeyRetriever.h
+++ b/cpp/ManagedDecryptionKeyRetriever.h
@@ -5,10 +5,9 @@
 
 using namespace parquet;
 
-typedef const char* key_t;
 typedef void (*FreeGcHandleFunc) (void* handle);
-typedef key_t (*GetKeyFunc) (void* handle, const char* key_metadata);
-typedef void (*FreeKeyFunc) (key_t key);
+typedef const char* (*GetKeyFunc) (void* handle, const char* key_metadata);
+typedef void (*FreeKeyFunc) (const char* key);
 
 // Derived DecryptionKeyRetriever that can callback into managed code.
 // This class maintains a GC reference, such that the managed instance cannot get collected if this class is still alive.
@@ -40,7 +39,7 @@ public:
 
 	std::string GetKey(const std::string& key_metadata) const override
 	{
-		const key_t key = get_key_(Handle, key_metadata.c_str());
+		const char* const key = get_key_(Handle, key_metadata.c_str());
 		const std::string key_str(key);
 
 		free_key_(key);

--- a/cpp/ParquetFileReader.cpp
+++ b/cpp/ParquetFileReader.cpp
@@ -8,14 +8,20 @@ using namespace parquet;
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* ParquetFileReader_OpenFile(const char* const path, ParquetFileReader** reader)
+	PARQUETSHARP_EXPORT ExceptionInfo* ParquetFileReader_OpenFile(
+		const char* const path,
+		const ReaderProperties* reader_properties,
+		ParquetFileReader** reader)
 	{
-		TRYCATCH(*reader = ParquetFileReader::OpenFile(path, false).release();)
+		TRYCATCH(*reader = ParquetFileReader::OpenFile(path, false, *reader_properties).release();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ParquetFileReader_Open(std::shared_ptr<arrow::io::RandomAccessFile>* readable_file_interface, ParquetFileReader** reader)
+	PARQUETSHARP_EXPORT ExceptionInfo* ParquetFileReader_Open(
+		std::shared_ptr<arrow::io::RandomAccessFile>* readable_file_interface, 
+		const ReaderProperties* reader_properties,
+		ParquetFileReader** reader)
 	{
-		TRYCATCH(*reader = ParquetFileReader::Open(*readable_file_interface).release();)
+		TRYCATCH(*reader = ParquetFileReader::Open(*readable_file_interface, *reader_properties).release();)
 	}
 
 	PARQUETSHARP_EXPORT void ParquetFileReader_Free(ParquetFileReader* reader)

--- a/cpp/ReaderProperties.cpp
+++ b/cpp/ReaderProperties.cpp
@@ -46,7 +46,7 @@ extern "C"
 
 	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Set_File_Decryption_Properties(ReaderProperties* reader_properties, const std::shared_ptr<FileDecryptionProperties>* file_decryption_properties)
 	{
-		TRYCATCH(reader_properties->file_decryption_properties(*file_decryption_properties);)
+		TRYCATCH(reader_properties->file_decryption_properties(file_decryption_properties ? *file_decryption_properties : nullptr);)
 	}
 
 	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_File_Decryption_Properties(ReaderProperties* reader_properties, std::shared_ptr<FileDecryptionProperties>** file_decryption_properties)

--- a/cpp/ReaderProperties.cpp
+++ b/cpp/ReaderProperties.cpp
@@ -1,0 +1,60 @@
+
+#include "cpp/ParquetSharpExport.h"
+#include "CString.h"
+#include "ExceptionInfo.h"
+
+#include <parquet/properties.h>
+
+using namespace parquet;
+
+extern "C"
+{
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_Default_Reader_Properties(ReaderProperties** reader_properties)
+	{
+		TRYCATCH(*reader_properties = new ReaderProperties(default_reader_properties());)
+	}
+
+	PARQUETSHARP_EXPORT void ReaderProperties_Free(ReaderProperties* reader_properties)
+	{
+		delete reader_properties;
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Is_Buffered_Stream_Enabled(const ReaderProperties* reader_properties, bool* is_buffered_stream_enabled)
+	{
+		TRYCATCH(*is_buffered_stream_enabled = reader_properties->is_buffered_stream_enabled();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Enable_Buffered_Stream(ReaderProperties* reader_properties)
+	{
+		TRYCATCH(reader_properties->enable_buffered_stream();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Disable_Buffered_Stream(ReaderProperties* reader_properties)
+	{
+		TRYCATCH(reader_properties->disable_buffered_stream();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Set_Buffer_Size(ReaderProperties* reader_properties, int64_t buffer_size)
+	{
+		TRYCATCH(reader_properties->set_buffer_size(buffer_size);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_Buffer_Size(const ReaderProperties* reader_properties, int64_t* buffer_size)
+	{
+		TRYCATCH(*buffer_size = reader_properties->buffer_size();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Set_File_Decryption_Properties(ReaderProperties* reader_properties, const std::shared_ptr<FileDecryptionProperties>* file_decryption_properties)
+	{
+		TRYCATCH(reader_properties->file_decryption_properties(*file_decryption_properties);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_File_Decryption_Properties(ReaderProperties* reader_properties, std::shared_ptr<FileDecryptionProperties>** file_decryption_properties)
+	{
+		TRYCATCH
+		(
+			const auto p = reader_properties->file_decryption_properties();
+			*file_decryption_properties = p ? new std::shared_ptr<FileDecryptionProperties>(p, [](const FileDecryptionProperties* ptr) {}) : nullptr;
+		)
+	}
+}

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -91,6 +91,11 @@ extern "C"
 		TRYCATCH(*encoding = (*writerProperties)->encoding(*path);)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_File_Encryption_Properties(const std::shared_ptr<WriterProperties>* writerProperties, std::shared_ptr<FileEncryptionProperties>** file_encryption_properties)
+	{
+		TRYCATCH(*file_encryption_properties = new std::shared_ptr<FileEncryptionProperties>((*writerProperties)->file_encryption_properties());)
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Statistics_Enabled(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, bool* enabled)
 	{
 		TRYCATCH(*enabled = (*writerProperties)->statistics_enabled(*path);)

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -9,19 +9,19 @@ using namespace parquet;
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Get_Default_Writer_Properties(std::shared_ptr<WriterProperties>** writerProperties)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Get_Default_Writer_Properties(std::shared_ptr<WriterProperties>** writer_properties)
 	{
-		TRYCATCH(*writerProperties = new std::shared_ptr<WriterProperties>(default_writer_properties());)
+		TRYCATCH(*writer_properties = new std::shared_ptr<WriterProperties>(default_writer_properties());)
 	}
 
-	PARQUETSHARP_EXPORT void WriterProperties_Free(std::shared_ptr<WriterProperties>* writerProperties)
+	PARQUETSHARP_EXPORT void WriterProperties_Free(std::shared_ptr<WriterProperties>* writer_properties)
 	{
-		delete writerProperties;
+		delete writer_properties;
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Created_By(const std::shared_ptr<WriterProperties>* writerProperties, const char** created_by)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Created_By(const std::shared_ptr<WriterProperties>* writer_properties, const char** created_by)
 	{
-		TRYCATCH(*created_by = AllocateCString((*writerProperties)->created_by());)
+		TRYCATCH(*created_by = AllocateCString((*writer_properties)->created_by());)
 	}
 
 	PARQUETSHARP_EXPORT void WriterProperties_Created_By_Free(const char* cstr)
@@ -29,80 +29,80 @@ extern "C"
 		FreeCString(cstr);
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Data_Pagesize(const std::shared_ptr<WriterProperties>* writerProperties, int64_t* dataPageSize)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Data_Pagesize(const std::shared_ptr<WriterProperties>* writer_properties, int64_t* dataPageSize)
 	{
-		TRYCATCH(*dataPageSize = (*writerProperties)->data_pagesize();)
+		TRYCATCH(*dataPageSize = (*writer_properties)->data_pagesize();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Index_Encoding(const std::shared_ptr<WriterProperties>* writerProperties, Encoding::type* encoding)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Index_Encoding(const std::shared_ptr<WriterProperties>* writer_properties, Encoding::type* encoding)
 	{
-		TRYCATCH(*encoding = (*writerProperties)->dictionary_index_encoding();)
+		TRYCATCH(*encoding = (*writer_properties)->dictionary_index_encoding();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Page_Encoding(const std::shared_ptr<WriterProperties>* writerProperties, Encoding::type* encoding)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Page_Encoding(const std::shared_ptr<WriterProperties>* writer_properties, Encoding::type* encoding)
 	{
-		TRYCATCH(*encoding = (*writerProperties)->dictionary_page_encoding();)
+		TRYCATCH(*encoding = (*writer_properties)->dictionary_page_encoding();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Pagesize_Limit(const std::shared_ptr<WriterProperties>* writerProperties, int64_t* pagesizeLimit)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Pagesize_Limit(const std::shared_ptr<WriterProperties>* writer_properties, int64_t* pagesizeLimit)
 	{
-		TRYCATCH(*pagesizeLimit = (*writerProperties)->dictionary_pagesize_limit();)
+		TRYCATCH(*pagesizeLimit = (*writer_properties)->dictionary_pagesize_limit();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Max_Row_Group_Length(const std::shared_ptr<WriterProperties>* writerProperties, int64_t* length)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Max_Row_Group_Length(const std::shared_ptr<WriterProperties>* writer_properties, int64_t* length)
 	{
-		TRYCATCH(*length = (*writerProperties)->max_row_group_length();)
+		TRYCATCH(*length = (*writer_properties)->max_row_group_length();)
 	}
 	
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Version(const std::shared_ptr<WriterProperties>* writerProperties, ParquetVersion::type* version)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Version(const std::shared_ptr<WriterProperties>* writer_properties, ParquetVersion::type* version)
 	{
-		TRYCATCH(*version = (*writerProperties)->version();)
+		TRYCATCH(*version = (*writer_properties)->version();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Write_Batch_Size(const std::shared_ptr<WriterProperties>* writerProperties, int64_t* size)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Write_Batch_Size(const std::shared_ptr<WriterProperties>* writer_properties, int64_t* size)
 	{
-		TRYCATCH(*size = (*writerProperties)->write_batch_size();)
+		TRYCATCH(*size = (*writer_properties)->write_batch_size();)
 	}
 
 	// ColumnPath taking methods.
 
-	//PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Column_Properties(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, const ColumnProperties** columnProperties)
+	//PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Column_Properties(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, const ColumnProperties** columnProperties)
 	//{
-	//	TRYCATCH(*columnProperties = &(*writerProperties)->column_properties(*path);)
+	//	TRYCATCH(*columnProperties = &(*writer_properties)->column_properties(*path);)
 	//}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Compression(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, Compression::type* compression)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Compression(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, Compression::type* compression)
 	{
-		TRYCATCH(*compression = (*writerProperties)->compression(*path);)
+		TRYCATCH(*compression = (*writer_properties)->compression(*path);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Compression_Level(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, int32_t* compression_level)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Compression_Level(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, int32_t* compression_level)
 	{
-		TRYCATCH(*compression_level = (*writerProperties)->compression_level(*path);)
+		TRYCATCH(*compression_level = (*writer_properties)->compression_level(*path);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Enabled(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, bool* enabled)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Dictionary_Enabled(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, bool* enabled)
 	{
-		TRYCATCH(*enabled = (*writerProperties)->dictionary_enabled(*path);)
+		TRYCATCH(*enabled = (*writer_properties)->dictionary_enabled(*path);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Encoding(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, Encoding::type* encoding)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Encoding(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, Encoding::type* encoding)
 	{
-		TRYCATCH(*encoding = (*writerProperties)->encoding(*path);)
+		TRYCATCH(*encoding = (*writer_properties)->encoding(*path);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_File_Encryption_Properties(const std::shared_ptr<WriterProperties>* writerProperties, std::shared_ptr<FileEncryptionProperties>** file_encryption_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_File_Encryption_Properties(const std::shared_ptr<WriterProperties>* writer_properties, std::shared_ptr<FileEncryptionProperties>** file_encryption_properties)
 	{
-		TRYCATCH(*file_encryption_properties = new std::shared_ptr<FileEncryptionProperties>((*writerProperties)->file_encryption_properties());)
+		TRYCATCH(*file_encryption_properties = new std::shared_ptr<FileEncryptionProperties>((*writer_properties)->file_encryption_properties());)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Statistics_Enabled(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, bool* enabled)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Statistics_Enabled(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, bool* enabled)
 	{
-		TRYCATCH(*enabled = (*writerProperties)->statistics_enabled(*path);)
+		TRYCATCH(*enabled = (*writer_properties)->statistics_enabled(*path);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Max_Statistics_Size(const std::shared_ptr<WriterProperties>* writerProperties, const std::shared_ptr<schema::ColumnPath>* path, size_t* max_statistics_size)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Max_Statistics_Size(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, size_t* max_statistics_size)
 	{
-		TRYCATCH(*max_statistics_size = (*writerProperties)->max_statistics_size(*path);)
+		TRYCATCH(*max_statistics_size = (*writer_properties)->max_statistics_size(*path);)
 	}
 }

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -3,7 +3,6 @@
 #include "CString.h"
 #include "ExceptionInfo.h"
 
-#include <arrow/io/file.h>
 #include <parquet/properties.h>
 
 using namespace parquet;

--- a/cpp/WriterPropertiesBuilder.cpp
+++ b/cpp/WriterPropertiesBuilder.cpp
@@ -150,9 +150,9 @@ extern "C"
 		TRYCATCH(builder->encoding(*path, encoding_type);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Encryption(WriterProperties::Builder* builder, const std::shared_ptr<FileEncryptionProperties> file_encryption_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Encryption(WriterProperties::Builder* builder, const std::shared_ptr<FileEncryptionProperties>* file_encryption_properties)
 	{
-		TRYCATCH(builder->encryption(file_encryption_properties);)
+		TRYCATCH(builder->encryption(file_encryption_properties ? *file_encryption_properties : nullptr);)
 	}
 
 	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Max_Row_Group_Length(WriterProperties::Builder* builder, int64_t max_row_group_length)

--- a/cpp/WriterPropertiesBuilder.cpp
+++ b/cpp/WriterPropertiesBuilder.cpp
@@ -150,6 +150,11 @@ extern "C"
 		TRYCATCH(builder->encoding(*path, encoding_type);)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Encryption(WriterProperties::Builder* builder, const std::shared_ptr<FileEncryptionProperties> file_encryption_properties)
+	{
+		TRYCATCH(builder->encryption(file_encryption_properties);)
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Max_Row_Group_Length(WriterProperties::Builder* builder, int64_t max_row_group_length)
 	{
 		TRYCATCH(builder->max_row_group_length(max_row_group_length);)

--- a/csharp.test/Program.cs
+++ b/csharp.test/Program.cs
@@ -27,7 +27,8 @@ namespace ParquetSharp.Test
                 //TestParquetFileReader.TestFileHandleHasBeenReleased();
                 //TestParquetFileWriter.TestWriteLongString();
                 //TestManagedRandomAccessFile.TestWriteException();
-                TestAadPrefixVerifier.TestOwnership();
+                //TestAadPrefixVerifier.TestOwnership();
+                TestEncryption.TestEncryptAllSameKey();
 
                 // Ensure the finalizers are executed, so we can check whether they throw.
                 GC.Collect();

--- a/csharp.test/Program.cs
+++ b/csharp.test/Program.cs
@@ -26,7 +26,8 @@ namespace ParquetSharp.Test
                 //TestParquetFileReader.TestReadFileCreateByPython();
                 //TestParquetFileReader.TestFileHandleHasBeenReleased();
                 //TestParquetFileWriter.TestWriteLongString();
-                TestManagedRandomAccessFile.TestWriteException();
+                //TestManagedRandomAccessFile.TestWriteException();
+                TestAadPrefixVerifier.TestOwnership();
 
                 // Ensure the finalizers are executed, so we can check whether they throw.
                 GC.Collect();

--- a/csharp.test/Program.cs
+++ b/csharp.test/Program.cs
@@ -28,7 +28,7 @@ namespace ParquetSharp.Test
                 //TestParquetFileWriter.TestWriteLongString();
                 //TestManagedRandomAccessFile.TestWriteException();
                 //TestAadPrefixVerifier.TestOwnership();
-                TestEncryption.TestEncryptAllSameKey();
+                TestEncryption.TestNoMatchingKeyMetadata();
 
                 // Ensure the finalizers are executed, so we can check whether they throw.
                 GC.Collect();

--- a/csharp.test/TestAadPrefixVerifier.cs
+++ b/csharp.test/TestAadPrefixVerifier.cs
@@ -39,7 +39,7 @@ namespace ParquetSharp.Test
         {
             using (var builder = new FileDecryptionPropertiesBuilder())
             {
-                builder.FooterKey("bogus-footer-key");
+                builder.FooterKey(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
                 builder.AadPrefixVerifier(new TestVerifier("HelloWorld Exception!"));
                 return builder.Build();
             }

--- a/csharp.test/TestAadPrefixVerifier.cs
+++ b/csharp.test/TestAadPrefixVerifier.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestAadPrefixVerifier
+    {
+        [Test]
+        public static void TestOwnership()
+        {
+            // The FileDecryptionPropertiesBuilder and FileDecryptionProperties own a std::shared_ptr on our aad-prefix-verifier.
+            // Assert that the partial transfer of ownership of the aad-prefix-verifier from C# to C++ is successful.
+
+            var weakRef = AssertOwnership();
+
+            GC.Collect();
+
+            Assert.IsFalse(weakRef.IsAlive, "weak reference should not be alive anymore");
+        }
+
+        private static WeakReference AssertOwnership()
+        {
+            using (var properties = CreateProperties())
+            {
+                GC.Collect();
+
+                // At this point C# has no reference to the key-receiver. And yet we can still get it back from C++.
+                var aadPrefixVerifier = properties.AadPrefixVerifier;
+
+                Assert.AreEqual("HelloWorld Exception!", aadPrefixVerifier.Verify("not-used"));
+
+                // But after we return, both C# and C++ will lose all references and the aad-prefix-verifier should get GCed. 
+                return new WeakReference(aadPrefixVerifier);
+            }
+        }
+
+        private static FileDecryptionProperties CreateProperties()
+        {
+            using (var builder = new FileDecryptionPropertiesBuilder())
+            {
+                builder.FooterKey("bogus-footer-key");
+                builder.AadPrefixVerifier(new TestVerifier("HelloWorld Exception!"));
+                return builder.Build();
+            }
+        }
+
+        private sealed class TestVerifier : AadPrefixVerifier
+        {
+            public TestVerifier(string exception)
+            {
+                _exception = exception;
+            }
+
+            public override string Verify(string aadPrefix) => _exception;
+
+            private readonly string _exception;
+        }
+    }
+}

--- a/csharp.test/TestAadPrefixVerifier.cs
+++ b/csharp.test/TestAadPrefixVerifier.cs
@@ -26,9 +26,9 @@ namespace ParquetSharp.Test
                 GC.Collect();
 
                 // At this point C# has no reference to the key-receiver. And yet we can still get it back from C++.
-                var aadPrefixVerifier = properties.AadPrefixVerifier;
+                var aadPrefixVerifier = (TestVerifier) properties.AadPrefixVerifier;
 
-                Assert.AreEqual("HelloWorld Exception!", aadPrefixVerifier.Verify("not-used"));
+                Assert.AreEqual("HelloWorld Exception!", aadPrefixVerifier.ExceptionMessage);
 
                 // But after we return, both C# and C++ will lose all references and the aad-prefix-verifier should get GCed. 
                 return new WeakReference(aadPrefixVerifier);
@@ -47,14 +47,14 @@ namespace ParquetSharp.Test
 
         private sealed class TestVerifier : AadPrefixVerifier
         {
-            public TestVerifier(string exception)
+            public TestVerifier(string exceptionMessage)
             {
-                _exception = exception;
+                ExceptionMessage = exceptionMessage;
             }
 
-            public override string Verify(string aadPrefix) => _exception;
+            public readonly string ExceptionMessage;
 
-            private readonly string _exception;
+            public override void Verify(string aadPrefix) => throw new ArgumentException(ExceptionMessage);
         }
     }
 }

--- a/csharp.test/TestAesKey.cs
+++ b/csharp.test/TestAesKey.cs
@@ -10,7 +10,7 @@ namespace ParquetSharp.Test
         public static void TestIncorrectSize()
         {
             var exception = Assert.Throws<ArgumentException>(() => new AesKey(new byte[8]));
-            Assert.AreEqual("AES key can only be 128, 192, or 256-bit in length (Parameter 'key')", exception.Message);
+            Assert.That(exception.Message, Contains.Substring("AES key can only be 128, 192, or 256-bit in length"));
         }
 
         [Test]

--- a/csharp.test/TestAesKey.cs
+++ b/csharp.test/TestAesKey.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestAesKey
+    {
+        [Test]
+        public static void TestIncorrectSize()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => new AesKey(new byte[8]));
+            Assert.AreEqual("AES key can only be 128, 192, or 256-bit in length (Parameter 'key')", exception.Message);
+        }
+
+        [Test]
+        public static void TestRoundtrip()
+        {
+            var key128 = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            var key192 = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+            var key256 = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+
+            Assert.AreEqual(key128, new AesKey(key128).ToBytes());
+            Assert.AreEqual(key192, new AesKey(key192).ToBytes());
+            Assert.AreEqual(key256, new AesKey(key256).ToBytes());
+        }
+    }
+}

--- a/csharp.test/TestDerivedKeyRetriever.cs
+++ b/csharp.test/TestDerivedKeyRetriever.cs
@@ -37,7 +37,7 @@ namespace ParquetSharp.Test
 
         private static FileDecryptionProperties CreateProperties()
         {
-            using (var builder = new FileDecryptionPropertiesBuilder(""))
+            using (var builder = new FileDecryptionPropertiesBuilder())
             {
                 builder.KeyRetriever(new TestRetriever("HelloWorld Key!"));
                 return builder.Build();

--- a/csharp.test/TestDerivedKeyRetriever.cs
+++ b/csharp.test/TestDerivedKeyRetriever.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestDerivedKeyRetriever
+    {
+        [Test]
+        public static void TestOwnership()
+        {
+            // The FileDecryptionPropertiesBuilder and FileDecryptionProperties own a std::shared_ptr on our key-retriever.
+            // Assert that the partial transfer of ownership of the key-retriever from C# to C++ is successful.
+
+            var weakRef = AssertOwnership();
+
+            GC.Collect();
+
+            Assert.IsFalse(weakRef.IsAlive, "weak reference should not be alive anymore");
+        }
+
+        private static WeakReference AssertOwnership()
+        {
+            using (var properties = CreateProperties())
+            {
+                GC.Collect();
+
+                // At this point C# has no reference to the key-receiver. And yet we can still get it back from C++.
+                var keyReceiver = properties.KeyRetriever;
+
+                Assert.AreEqual("HelloWorld Key!", keyReceiver.GetKey("not-used"));
+
+                // But after we return, both C# and C++ will lose all references and the key-receiver should get GCed. 
+                return new WeakReference(keyReceiver);
+            }
+        }
+
+        private static FileDecryptionProperties CreateProperties()
+        {
+            using (var builder = new FileDecryptionPropertiesBuilder(""))
+            {
+                builder.KeyRetriever(new TestRetriever("HelloWorld Key!"));
+                return builder.Build();
+            }
+        }
+
+        private sealed class TestRetriever : DecryptionKeyRetriever
+        {
+            public TestRetriever(string key)
+            {
+                _key = key;
+            }
+
+            public override string GetKey(string keyMetadata) => _key;
+
+            private readonly string _key;
+        }
+    }
+}

--- a/csharp.test/TestDerivedKeyRetriever.cs
+++ b/csharp.test/TestDerivedKeyRetriever.cs
@@ -28,7 +28,7 @@ namespace ParquetSharp.Test
                 // At this point C# has no reference to the key-receiver. And yet we can still get it back from C++.
                 var keyReceiver = properties.KeyRetriever;
 
-                Assert.AreEqual("HelloWorld Key!", keyReceiver.GetKey("not-used"));
+                Assert.AreEqual("HelloWorld\0 Key!", System.Text.Encoding.ASCII.GetString(keyReceiver.GetKey("not-used")));
 
                 // But after we return, both C# and C++ will lose all references and the key-receiver should get GCed. 
                 return new WeakReference(keyReceiver);
@@ -39,7 +39,7 @@ namespace ParquetSharp.Test
         {
             using (var builder = new FileDecryptionPropertiesBuilder())
             {
-                builder.KeyRetriever(new TestRetriever("HelloWorld Key!"));
+                builder.KeyRetriever(new TestRetriever("HelloWorld\0 Key!"));
                 return builder.Build();
             }
         }
@@ -51,7 +51,7 @@ namespace ParquetSharp.Test
                 _key = key;
             }
 
-            public override string GetKey(string keyMetadata) => _key;
+            public override byte[] GetKey(string keyMetadata) => System.Text.Encoding.ASCII.GetBytes(_key);
 
             private readonly string _key;
         }

--- a/csharp.test/TestEncryption.cs
+++ b/csharp.test/TestEncryption.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using ParquetSharp.IO;
 
@@ -7,11 +8,16 @@ namespace ParquetSharp.Test
     [TestFixture]
     internal static class TestEncryption
     {
+        // TODO .NET exception from C# to C++ (callbacks). String serialisation looks dodgy.
+        // TODO Above for KeyRetriever
+        // TODO Above for AadVerifier
+        // TODO ColumnCryptoMetadata (on ColumnChunkMetaData)
+
         [Test]
         public static void TestNoDecryptionKey()
         {
             // Case where the parquet file is encrypted but no decryption properties have been provided.
-            var exception = Assert.Throws<ParquetException>(() => AssertEncryptionRoundtrip(CreateEncryptAllSameKeyProperties, () => null));
+            var exception = Assert.Throws<ParquetException>(() => AssertEncryptionRoundtrip(CreateEncryptSameKeyProperties, () => null));
             Assert.That(exception.Message, Contains.Substring("Could not read encrypted metadata, no decryption found in reader's properties"));
         }
 
@@ -24,13 +30,71 @@ namespace ParquetSharp.Test
         }
 
         [Test]
+        public static void TestNoMatchingKeyMetadata()
+        {
+            // Case where the parquet file is encrypted but no key can be found matching the key metadata.
+            var exception = Assert.Throws<ParquetException>(() => AssertEncryptionRoundtrip(CreateEncryptNoMatchingKeyMetadataProperties, CreateDecryptWithKeyRetrieverProperties));
+            Assert.That(exception.Message, Contains.Substring("System.Collections.Generic.KeyNotFoundException: 'NotGoingToWork' metadata does not match any encryption key"));
+        }
+
+        [Test]
         public static void TestEncryptAllSameKey()
         {
             // Case where the footer and all columns are encrypted with the same key.
-            AssertEncryptionRoundtrip(CreateEncryptAllSameKeyProperties, CreateDecryptAllSameKeyProperties);
+            AssertEncryptionRoundtrip(CreateEncryptSameKeyProperties, CreateDecryptAllSameKeyProperties);
         }
 
-        private static FileEncryptionProperties CreateEncryptAllSameKeyProperties()
+        [Test]
+        public static void TestEncryptAllSeparateKeys()
+        {
+            // Case where the footer and all columns are encrypted all with different keys.
+            AssertEncryptionRoundtrip(CreateEncryptAllSeparateKeysProperties, CreateDecryptWithKeyRetrieverProperties);
+        }
+
+        [Test]
+        public static void TestEncryptJustColumns()
+        {
+            // Case where the footer is unencrypted and all columns are encrypted all with different keys.
+            AssertEncryptionRoundtrip(CreateEncryptJustColumnsProperties, CreateDecryptWithKeyRetrieverProperties);
+        }
+
+        [Test]
+        public static void TestEncryptJustOneColumn()
+        {
+            // Case where the footer is unencrypted and all columns are encrypted all with different keys.
+            using (var buffer = new ResizableBuffer())
+            {
+                using (var output = new BufferOutputStream(buffer))
+                using (var fileEncryptionProperties = CreateEncryptJustOneColumnProperties())
+                {
+                    WriteParquetFile(output, fileEncryptionProperties);
+                }
+
+                // Decrypt the whole parquet file with matching decrypt properties.
+                using (var input = new BufferReader(buffer))
+                using (var fileDecryptionProperties = CreateDecryptWithKeyRetrieverProperties())
+                {
+                    ReadParquetFile(fileDecryptionProperties, input);
+                }
+
+                // Decrypt only the unencrypted column without providing any decrypt properties.
+                using (var input = new BufferReader(buffer))
+                using (var fileReader = new ParquetFileReader(input))
+                using (var groupReader = fileReader.RowGroup(0))
+                {
+                    var numRows = (int) groupReader.MetaData.NumRows;
+
+                    using (var idReader = groupReader.Column(0).LogicalReader<int>())
+                    {
+                        Assert.AreEqual(Ids, idReader.ReadAll(numRows));
+                    }
+                }
+            }
+        }
+
+        // Encrypt Properties
+
+        private static FileEncryptionProperties CreateEncryptSameKeyProperties()
         {
             using (var builder = new FileEncryptionPropertiesBuilder(Key0))
             {
@@ -38,12 +102,96 @@ namespace ParquetSharp.Test
             }
         }
 
+        private static FileEncryptionProperties CreateEncryptNoMatchingKeyMetadataProperties()
+        {
+            using (var builder = new FileEncryptionPropertiesBuilder(Key0))
+            {
+                return builder
+                    .FooterKeyMetadata("NotGoingToWork")
+                    .Build();
+            }
+        }
+
+        private static FileEncryptionProperties CreateEncryptAllSeparateKeysProperties()
+        {
+            using (var builder = new FileEncryptionPropertiesBuilder(Key0))
+            using (var col0 = new ColumnEncryptionPropertiesBuilder("Id"))
+            using (var col1 = new ColumnEncryptionPropertiesBuilder("Value"))
+            {
+                return builder
+                    .FooterKeyMetadata("Key0")
+                    .EncryptedColumns(new[]
+                    {
+                        col0.Key(Key1).KeyMetadata("Key1").Build(),
+                        col1.Key(Key2).KeyMetadata("Key2").Build()
+                    })
+                    .Build();
+            }
+        }
+
+        private static FileEncryptionProperties CreateEncryptJustColumnsProperties()
+        {
+            using (var builder = new FileEncryptionPropertiesBuilder(Key0))
+            using (var col0 = new ColumnEncryptionPropertiesBuilder("Id"))
+            using (var col1 = new ColumnEncryptionPropertiesBuilder("Value"))
+            {
+                return builder
+                    .FooterKeyMetadata("Key0")
+                    .SetPlaintextFooter()
+                    .EncryptedColumns(new[]
+                    {
+                        col0.Key(Key1).KeyMetadata("Key1").Build(),
+                        col1.Key(Key2).KeyMetadata("Key2").Build()
+                    })
+                    .Build();
+            }
+        }
+
+        private static FileEncryptionProperties CreateEncryptJustOneColumnProperties()
+        {
+            using (var builder = new FileEncryptionPropertiesBuilder(Key0))
+            using (var col1 = new ColumnEncryptionPropertiesBuilder("Value"))
+            {
+                return builder
+                    .FooterKeyMetadata("Key0")
+                    .SetPlaintextFooter()
+                    .EncryptedColumns(new[]
+                    {
+                        col1.Key(Key2).KeyMetadata("Key2").Build()
+                    })
+                    .Build();
+            }
+        }
+
+        // Decrypt Properties
+
         private static FileDecryptionProperties CreateDecryptAllSameKeyProperties()
         {
             using (var builder = new FileDecryptionPropertiesBuilder())
             {
                 return builder
                     .FooterKey(Key0)
+                    .Build();
+            }
+        }
+
+        private static FileDecryptionProperties CreateDecryptWithKeyRetrieverProperties()
+        {
+            using (var builder = new FileDecryptionPropertiesBuilder())
+            {
+                return builder
+                    .KeyRetriever(new TestRetriever())
+                    .Build();
+            }
+        }
+
+        private static FileDecryptionProperties CreateDecryptWithKeyRetrieverAllowPlaintextProperties()
+        {
+            using (var builder = new FileDecryptionPropertiesBuilder())
+            {
+                return builder
+                    .PlaintextFilesAllowed()
+                    .KeyRetriever(new TestRetriever())
                     .Build();
             }
         }
@@ -128,7 +276,13 @@ namespace ParquetSharp.Test
         {
             public override byte[] GetKey(string keyMetadata)
             {
-                throw new System.NotImplementedException();
+                switch (keyMetadata)
+                {
+                    case "Key0": return Key0;
+                    case "Key1": return Key1;
+                    case "Key2": return Key2;
+                    default: throw new KeyNotFoundException($"'{keyMetadata}' metadata does not match any encryption key");
+                }
             }
         }
 
@@ -139,7 +293,7 @@ namespace ParquetSharp.Test
         public static readonly Column[] Columns =
         {
             new Column<int>("Id"), 
-            new Column<float>("Values")
+            new Column<float>("Value")
         };
 
         public static readonly int[] Ids = {1, 2, 3, 5, 7, 8, 13};

--- a/csharp.test/TestEncryption.cs
+++ b/csharp.test/TestEncryption.cs
@@ -8,7 +8,11 @@ namespace ParquetSharp.Test
     [TestFixture]
     internal static class TestEncryption
     {
-        // TODO ColumnCryptoMetadata (on ColumnChunkMetaData)
+        // TODO Unit test ColumnCryptoMetadata (on ColumnChunkMetaData)
+        // TODO Unit test builder / properties for ColumnDecryption
+        // TODO Unit test builder / properties for ColumnEncryption
+        // TODO Unit test builder / properties for FileDecryption
+        // TODO Unit test builder / properties for FileEncryption
 
         [Test]
         public static void TestNoDecryptionKey()

--- a/csharp.test/TestEncryption.cs
+++ b/csharp.test/TestEncryption.cs
@@ -1,0 +1,127 @@
+﻿using NUnit.Framework;
+using ParquetSharp.IO;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestEncryption
+    {
+        [Test]
+        public static void TestEncryptAllSameKey()
+        {
+            using (var buffer = new ResizableBuffer())
+            {
+                using (var output = new BufferOutputStream(buffer))
+                using (var fileEncryptionProperties = CreateEncryptAllSameKeyProperties())
+                {
+                    WriteParquetFile(output, fileEncryptionProperties);
+                }
+
+                using (var input = new BufferReader(buffer))
+                using (var fileDecryptionProperties = CreateDecryptAllSameKeyProperties())
+                {
+                    ReadParquetFile(fileDecryptionProperties, input);
+                }
+
+                // TODO ReaderProperties.FileDecProperties => null
+                // TODO FileDecProperties.AadPrefixVerifier => null
+                // TODO FileDecProperties.KeyRetriever => null
+            }
+        }
+
+        private static FileEncryptionProperties CreateEncryptAllSameKeyProperties()
+        {
+            using (var builder = new FileEncryptionPropertiesBuilder(Key0))
+            {
+                return builder.Build();
+            }
+        }
+
+        private static FileDecryptionProperties CreateDecryptAllSameKeyProperties()
+        {
+            using (var builder = new FileDecryptionPropertiesBuilder())
+            {
+                return builder
+                    .FooterKey(Key0)
+                    .Build();
+            }
+        }
+
+        private static void WriteParquetFile(BufferOutputStream output, FileEncryptionProperties fileEncryptionProperties)
+        {
+            using (var writerProperties = CreateWriterProperties(fileEncryptionProperties))
+            using (var fileWriter = new ParquetFileWriter(output, Columns, writerProperties))
+            using (var groupWriter = fileWriter.AppendRowGroup())
+            {
+                using (var idWriter = groupWriter.NextColumn().LogicalWriter<int>())
+                {
+                    idWriter.WriteBatch(Ids);
+                }
+
+                using (var valueWriter = groupWriter.NextColumn().LogicalWriter<float>())
+                {
+                    valueWriter.WriteBatch(Values);
+                }
+            }
+        }
+
+        private static void ReadParquetFile(FileDecryptionProperties fileDecryptionProperties, BufferReader input)
+        {
+            using (var readerProperties = CreateReaderProperties(fileDecryptionProperties))
+            using (var fileReader = new ParquetFileReader(input, readerProperties))
+            using (var groupReader = fileReader.RowGroup(0))
+            {
+                var numRows = (int) groupReader.MetaData.NumRows;
+
+                using (var idReader = groupReader.Column(0).LogicalReader<int>())
+                {
+                    Assert.AreEqual(Ids, idReader.ReadAll(numRows));
+                }
+
+                using (var valueReader = groupReader.Column(1).LogicalReader<float>())
+                {
+                    Assert.AreEqual(Values, valueReader.ReadAll(numRows));
+                }
+            }
+        }
+
+        private static WriterProperties CreateWriterProperties(FileEncryptionProperties fileEncryptionProperties)
+        {
+            using (var builder = new WriterPropertiesBuilder())
+            {
+                return builder
+                    .Compression(Compression.Lz4)
+                    .Encryption(fileEncryptionProperties)
+                    .Build();
+            }
+        }
+
+        private static ReaderProperties CreateReaderProperties(FileDecryptionProperties fileDecryptionProperties)
+        {
+            var readerProperties = ReaderProperties.GetDefaultReaderProperties();
+            readerProperties.FileDecryptionProperties = fileDecryptionProperties;
+            return readerProperties;
+        }
+
+        private sealed class TestRetriever : DecryptionKeyRetriever
+        {
+            public override byte[] GetKey(string keyMetadata)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        private static readonly byte[] Key0 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+        private static readonly byte[] Key1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+        private static readonly byte[] Key2 = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17};
+
+        public static readonly Column[] Columns =
+        {
+            new Column<int>("Id"), 
+            new Column<float>("Values")
+        };
+
+        public static readonly int[] Ids = {1, 2, 3, 5, 7, 8, 13};
+        public static readonly float[] Values = {3.14f, 1.27f, 42.0f, 10.6f, 9.81f, 2.71f, -1f};
+    }
+}

--- a/csharp.test/TestEncryption.cs
+++ b/csharp.test/TestEncryption.cs
@@ -8,9 +8,6 @@ namespace ParquetSharp.Test
     [TestFixture]
     internal static class TestEncryption
     {
-        // TODO .NET exception from C# to C++ (callbacks). String serialisation looks dodgy.
-        // TODO Above for KeyRetriever
-        // TODO Above for AadVerifier
         // TODO ColumnCryptoMetadata (on ColumnChunkMetaData)
 
         [Test]
@@ -180,17 +177,6 @@ namespace ParquetSharp.Test
             using (var builder = new FileDecryptionPropertiesBuilder())
             {
                 return builder
-                    .KeyRetriever(new TestRetriever())
-                    .Build();
-            }
-        }
-
-        private static FileDecryptionProperties CreateDecryptWithKeyRetrieverAllowPlaintextProperties()
-        {
-            using (var builder = new FileDecryptionPropertiesBuilder())
-            {
-                return builder
-                    .PlaintextFilesAllowed()
                     .KeyRetriever(new TestRetriever())
                     .Build();
             }

--- a/csharp/AadPrefixVerifier.cs
+++ b/csharp/AadPrefixVerifier.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Verifies identity(AAD Prefix) of individual file, or of file collection in a data set.
+    /// </summary>
+    public abstract class AadPrefixVerifier
+    {
+        /// <summary>
+        /// Verify the AAD file prefix.
+        /// Return null if okay, return exception message otherwise.
+        /// </summary>
+        public abstract string Verify(string aadPrefix);
+
+        /// <summary>
+        /// The native code owns a GC handle on the given instance of AadPrefixVerifier.
+        /// This is the reverse from the rest of ParquetSharp where C# owns a native handle into arrow::parquet.
+        /// </summary>
+        internal IntPtr CreateGcHandle()
+        {
+            var gcHandle = GCHandle.Alloc(this, GCHandleType.Normal);
+            return GCHandle.ToIntPtr(gcHandle);
+        }
+
+        internal static AadPrefixVerifier GetGcHandleTarget(IntPtr handle)
+        {
+            return (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target;
+        }
+
+        internal delegate void FreeGcHandleFunc(IntPtr handle);
+        internal delegate IntPtr VerifyFunc(IntPtr handle, IntPtr aadPrefix);
+        internal delegate void FreeExceptionFunc(IntPtr exception);
+
+        internal static readonly FreeGcHandleFunc FreeGcHandleCallback = FreeGcHandle;
+        internal static readonly VerifyFunc VerifyFuncCallback = Verify;
+        internal static readonly FreeExceptionFunc FreeExceptionCallback = FreeException;
+
+        private static void FreeGcHandle(IntPtr handle)
+        {
+            GCHandle.FromIntPtr(handle).Free();
+        }
+
+        private static IntPtr Verify(IntPtr handle, IntPtr aadPrefix)
+        {
+            var obj = (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target;
+            var aadPrefixStr = Marshal.PtrToStringAnsi(aadPrefix);
+            var exception = obj.Verify(aadPrefixStr);
+
+            return exception == null ? IntPtr.Zero : Marshal.StringToHGlobalAnsi(exception);
+        }
+
+        private static void FreeException(IntPtr exception)
+        {
+            Marshal.FreeHGlobal(exception);
+        }
+    }
+}

--- a/csharp/AesKey.cs
+++ b/csharp/AesKey.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace ParquetSharp
@@ -11,19 +12,24 @@ namespace ParquetSharp
     {
         public AesKey(byte[] key)
         {
-            if (key.Length != 16 && key.Length != 24 && key.Length != 32)
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            if (key.Length != 0 && key.Length != 16 && key.Length != 24 && key.Length != 32)
             {
                 throw new ArgumentException("AES key can only be 128, 192, or 256-bit in length", nameof(key));
             }
 
-            fixed (byte* srcBytes = key)
+            if (key.Length != 0)
             {
-                var src = (ulong*) srcBytes;
+                fixed (byte* srcBytes = key)
+                {
+                    var src = (ulong*) srcBytes;
 
-                _key[0] = src[0];
-                _key[1] = src[1];
-                _key[2] = key.Length > 16 ? src[2] : 0;
-                _key[3] = key.Length > 24 ? src[3] : 0;
+                    _key[0] = src[0];
+                    _key[1] = src[1];
+                    _key[2] = key.Length > 16 ? src[2] : 0;
+                    _key[3] = key.Length > 24 ? src[3] : 0;
+                }
             }
 
             _size = (uint) key.Length;
@@ -31,21 +37,24 @@ namespace ParquetSharp
 
         public byte[] ToBytes()
         {
-            if (_size != 16 && _size != 24 && _size != 32)
+            if (_size != 0 && _size != 16 && _size != 24 && _size != 32)
             {
                 throw new ArgumentException("AES key can only be 128, 192, or 256-bit in length", nameof(_size));
             }
 
             var bytes = new byte[_size];
 
-            fixed (byte* dstBytes = bytes)
+            if (_size != 0)
             {
-                var dst = (ulong*) dstBytes;
+                fixed (byte* dstBytes = bytes)
+                {
+                    var dst = (ulong*) dstBytes;
 
-                dst[0] = _key[0];
-                dst[1] = _key[1];
-                if (_size > 16) dst[2] = _key[2];
-                if (_size > 24) dst[3] = _key[3];
+                    dst[0] = _key[0];
+                    dst[1] = _key[1];
+                    if (_size > 16) dst[2] = _key[2];
+                    if (_size > 24) dst[3] = _key[3];
+                }
             }
 
             return bytes;

--- a/csharp/AesKey.cs
+++ b/csharp/AesKey.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Internal fixed size structure for easily moving AES keys to and from C++.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Size = 16)]
+    internal unsafe struct AesKey
+    {
+        public AesKey(byte[] key)
+        {
+            if (key.Length != 16 && key.Length != 24 && key.Length != 32)
+            {
+                throw new ArgumentException("AES key can only be 128, 192, or 256-bit in length", nameof(key));
+            }
+
+            fixed (byte* srcBytes = key)
+            {
+                var src = (ulong*) srcBytes;
+
+                _key[0] = src[0];
+                _key[1] = src[1];
+                _key[2] = key.Length > 16 ? src[2] : 0;
+                _key[3] = key.Length > 24 ? src[3] : 0;
+            }
+
+            _size = (uint) key.Length;
+        }
+
+        public byte[] ToBytes()
+        {
+            if (_size != 16 && _size != 24 && _size != 32)
+            {
+                throw new ArgumentException("AES key can only be 128, 192, or 256-bit in length", nameof(_size));
+            }
+
+            var bytes = new byte[_size];
+
+            fixed (byte* dstBytes = bytes)
+            {
+                var dst = (ulong*) dstBytes;
+
+                dst[0] = _key[0];
+                dst[1] = _key[1];
+                if (_size > 16) dst[2] = _key[2];
+                if (_size > 24) dst[3] = _key[3];
+            }
+
+            return bytes;
+        }
+
+        private fixed ulong _key[4];
+        private readonly uint _size;
+    }
+}

--- a/csharp/ColumnDecryptionProperties.cs
+++ b/csharp/ColumnDecryptionProperties.cs
@@ -10,18 +10,18 @@ namespace ParquetSharp
     {
         internal ColumnDecryptionProperties(IntPtr handle)
         {
-            _handle = new ParquetHandle(handle, ColumnDecryptionProperties_Free);
+            Handle = new ParquetHandle(handle, ColumnDecryptionProperties_Free);
         }
 
         public void Dispose()
         {
-            _handle.Dispose();
+            Handle.Dispose();
         }
 
-        public string ColumnPath => ExceptionInfo.ReturnString(_handle, ColumnDecryptionProperties_Column_Path, ColumnDecryptionProperties_Column_Path_Free);
-        public string Key => ExceptionInfo.ReturnString(_handle, ColumnDecryptionProperties_Key, ColumnDecryptionProperties_Key_Free);
+        public string ColumnPath => ExceptionInfo.ReturnString(Handle, ColumnDecryptionProperties_Column_Path, ColumnDecryptionProperties_Column_Path_Free);
+        public string Key => ExceptionInfo.ReturnString(Handle, ColumnDecryptionProperties_Key, ColumnDecryptionProperties_Key_Free);
 
-        public ColumnDecryptionProperties DeepClone() => new ColumnDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, ColumnDecryptionProperties_Deep_Clone));
+        public ColumnDecryptionProperties DeepClone() => new ColumnDecryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnDecryptionProperties_Deep_Clone));
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
@@ -41,6 +41,6 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern void ColumnDecryptionProperties_Key_Free(IntPtr key);
 
-        private readonly ParquetHandle _handle;
+        internal readonly ParquetHandle Handle;
     }
 }

--- a/csharp/ColumnDecryptionProperties.cs
+++ b/csharp/ColumnDecryptionProperties.cs
@@ -19,7 +19,7 @@ namespace ParquetSharp
         }
 
         public string ColumnPath => ExceptionInfo.ReturnString(Handle, ColumnDecryptionProperties_Column_Path, ColumnDecryptionProperties_Column_Path_Free);
-        public string Key => ExceptionInfo.ReturnString(Handle, ColumnDecryptionProperties_Key, ColumnDecryptionProperties_Key_Free);
+        public byte[] Key => ExceptionInfo.Return<AesKey>(Handle, ColumnDecryptionProperties_Key).ToBytes();
 
         public ColumnDecryptionProperties DeepClone() => new ColumnDecryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnDecryptionProperties_Deep_Clone));
 
@@ -36,10 +36,7 @@ namespace ParquetSharp
         private static extern void ColumnDecryptionProperties_Column_Path_Free(IntPtr columnPath);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr ColumnDecryptionProperties_Key(IntPtr properties, out IntPtr key);
-
-        [DllImport(ParquetDll.Name)]
-        private static extern void ColumnDecryptionProperties_Key_Free(IntPtr key);
+        private static extern IntPtr ColumnDecryptionProperties_Key(IntPtr properties, out AesKey key);
 
         internal readonly ParquetHandle Handle;
     }

--- a/csharp/ColumnDecryptionProperties.cs
+++ b/csharp/ColumnDecryptionProperties.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Properties related to decrypting one specific column.
+    /// </summary>
+    public sealed class ColumnDecryptionProperties : IDisposable
+    {
+        internal ColumnDecryptionProperties(IntPtr handle)
+        {
+            _handle = new ParquetHandle(handle, ColumnDecryptionProperties_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public string ColumnPath => ExceptionInfo.ReturnString(_handle, ColumnDecryptionProperties_Column_Path, ColumnDecryptionProperties_Column_Path_Free);
+        public string Key => ExceptionInfo.ReturnString(_handle, ColumnDecryptionProperties_Key, ColumnDecryptionProperties_Key_Free);
+
+        public ColumnDecryptionProperties DeepClone() => new ColumnDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, ColumnDecryptionProperties_Deep_Clone));
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnDecryptionProperties_Free(IntPtr properties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnDecryptionProperties_Column_Path(IntPtr properties, out IntPtr columnPath);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnDecryptionProperties_Column_Path_Free(IntPtr columnPath);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnDecryptionProperties_Key(IntPtr properties, out IntPtr key);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnDecryptionProperties_Key_Free(IntPtr key);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/ColumnDecryptionPropertiesBuilder.cs
+++ b/csharp/ColumnDecryptionPropertiesBuilder.cs
@@ -29,9 +29,10 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
-        public ColumnDecryptionPropertiesBuilder Key(string key)
+        public ColumnDecryptionPropertiesBuilder Key(byte[] key)
         {
-            ExceptionInfo.Check(ColumnDecryptionPropertiesBuilder_Key(_handle.IntPtr, key));
+            var aesKey = new AesKey(key);
+            ExceptionInfo.Check(ColumnDecryptionPropertiesBuilder_Key(_handle.IntPtr, in aesKey));
             GC.KeepAlive(_handle);
             return this;
         }
@@ -61,7 +62,7 @@ namespace ParquetSharp
         private static extern void ColumnDecryptionPropertiesBuilder_Free(IntPtr builder);
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Key(IntPtr builder, string key);
+        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Key(IntPtr builder, in AesKey key);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnDecryptionPropertiesBuilder_Build(IntPtr builder, out IntPtr properties);

--- a/csharp/ColumnDecryptionPropertiesBuilder.cs
+++ b/csharp/ColumnDecryptionPropertiesBuilder.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using ParquetSharp.Schema;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Builder pattern for ColumnDecryptionProperties.
+    /// </summary>
+    public sealed class ColumnDecryptionPropertiesBuilder : IDisposable
+    {
+        public ColumnDecryptionPropertiesBuilder(string columnName)
+            : this(Make(columnName))
+        {
+        }
+
+        public ColumnDecryptionPropertiesBuilder(ColumnPath columnPath)
+            : this(Make(columnPath))
+        {
+        }
+
+        internal ColumnDecryptionPropertiesBuilder(IntPtr handle)
+        {
+            _handle = new ParquetHandle(handle, ColumnDecryptionPropertiesBuilder_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public ColumnDecryptionPropertiesBuilder Key(string key)
+        {
+            ExceptionInfo.Check(ColumnDecryptionPropertiesBuilder_Key(_handle.IntPtr, key));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public ColumnDecryptionProperties Build() => new ColumnDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, ColumnDecryptionPropertiesBuilder_Build));
+
+        private static IntPtr Make(string columnName)
+        {
+            ExceptionInfo.Check(ColumnDecryptionPropertiesBuilder_Create(columnName, out var handle));
+            return handle;
+        }
+
+        private static IntPtr Make(ColumnPath columnPath)
+        {
+            ExceptionInfo.Check(ColumnDecryptionPropertiesBuilder_Create_From_Column_Path(columnPath.Handle.IntPtr, out var handle));
+            GC.KeepAlive(columnPath);
+            return handle;
+        }
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Create(string name, out IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Create_From_Column_Path(IntPtr path, out IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnDecryptionPropertiesBuilder_Free(IntPtr builder);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Key(IntPtr builder, string key);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Build(IntPtr builder, out IntPtr properties);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/ColumnEncryptionProperties.cs
+++ b/csharp/ColumnEncryptionProperties.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Properties related to encrypting one specific column.
+    /// </summary>
+    public sealed class ColumnEncryptionProperties : IDisposable
+    {
+        internal ColumnEncryptionProperties(IntPtr handle)
+        {
+            _handle = new ParquetHandle(handle, ColumnEncryptionProperties_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public string ColumnPath => ExceptionInfo.ReturnString(_handle, ColumnEncryptionProperties_Column_Path, ColumnEncryptionProperties_Column_Path_Free);
+        public bool IsEncrypted => ExceptionInfo.Return<bool>(_handle, ColumnEncryptionProperties_Is_Encrypted);
+        public bool IsEncryptedWithFooterKey => ExceptionInfo.Return<bool>(_handle, ColumnEncryptionProperties_Is_Encrypted_With_Footer_Key);
+        public string Key => ExceptionInfo.ReturnString(_handle, ColumnEncryptionProperties_Key, ColumnEncryptionProperties_Key_Free);
+        public string KeyMetadata => ExceptionInfo.ReturnString(_handle, ColumnEncryptionProperties_Key_Metadata, ColumnEncryptionProperties_Key_Metadata_Free);
+
+        public ColumnEncryptionProperties DeepClone() => new ColumnEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, ColumnEncryptionProperties_Deep_Clone));
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnEncryptionProperties_Free(IntPtr properties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionProperties_Column_Path(IntPtr properties, out IntPtr columnPath);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnEncryptionProperties_Column_Path_Free(IntPtr columnPath);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionProperties_Is_Encrypted(IntPtr properties, [MarshalAs(UnmanagedType.I1)] out bool isEncrypted);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionProperties_Is_Encrypted_With_Footer_Key(IntPtr properties, [MarshalAs(UnmanagedType.I1)] out bool isEncryptedWithFooterKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionProperties_Key(IntPtr properties, out IntPtr key);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnEncryptionProperties_Key_Free(IntPtr key);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionProperties_Key_Metadata(IntPtr properties, out IntPtr keyMetadata);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnEncryptionProperties_Key_Metadata_Free(IntPtr keyMetadata);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/ColumnEncryptionProperties.cs
+++ b/csharp/ColumnEncryptionProperties.cs
@@ -21,7 +21,7 @@ namespace ParquetSharp
         public string ColumnPath => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Column_Path, ColumnEncryptionProperties_Column_Path_Free);
         public bool IsEncrypted => ExceptionInfo.Return<bool>(Handle, ColumnEncryptionProperties_Is_Encrypted);
         public bool IsEncryptedWithFooterKey => ExceptionInfo.Return<bool>(Handle, ColumnEncryptionProperties_Is_Encrypted_With_Footer_Key);
-        public string Key => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Key, ColumnEncryptionProperties_Key_Free);
+        public byte[] Key => ExceptionInfo.Return<AesKey>(Handle, ColumnEncryptionProperties_Key).ToBytes();
         public string KeyMetadata => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Key_Metadata, ColumnEncryptionProperties_Key_Metadata_Free);
 
         public ColumnEncryptionProperties DeepClone() => new ColumnEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnEncryptionProperties_Deep_Clone));
@@ -45,10 +45,7 @@ namespace ParquetSharp
         private static extern IntPtr ColumnEncryptionProperties_Is_Encrypted_With_Footer_Key(IntPtr properties, [MarshalAs(UnmanagedType.I1)] out bool isEncryptedWithFooterKey);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr ColumnEncryptionProperties_Key(IntPtr properties, out IntPtr key);
-
-        [DllImport(ParquetDll.Name)]
-        private static extern void ColumnEncryptionProperties_Key_Free(IntPtr key);
+        private static extern IntPtr ColumnEncryptionProperties_Key(IntPtr properties, out AesKey key);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnEncryptionProperties_Key_Metadata(IntPtr properties, out IntPtr keyMetadata);

--- a/csharp/ColumnEncryptionProperties.cs
+++ b/csharp/ColumnEncryptionProperties.cs
@@ -10,21 +10,21 @@ namespace ParquetSharp
     {
         internal ColumnEncryptionProperties(IntPtr handle)
         {
-            _handle = new ParquetHandle(handle, ColumnEncryptionProperties_Free);
+            Handle = new ParquetHandle(handle, ColumnEncryptionProperties_Free);
         }
 
         public void Dispose()
         {
-            _handle.Dispose();
+            Handle.Dispose();
         }
 
-        public string ColumnPath => ExceptionInfo.ReturnString(_handle, ColumnEncryptionProperties_Column_Path, ColumnEncryptionProperties_Column_Path_Free);
-        public bool IsEncrypted => ExceptionInfo.Return<bool>(_handle, ColumnEncryptionProperties_Is_Encrypted);
-        public bool IsEncryptedWithFooterKey => ExceptionInfo.Return<bool>(_handle, ColumnEncryptionProperties_Is_Encrypted_With_Footer_Key);
-        public string Key => ExceptionInfo.ReturnString(_handle, ColumnEncryptionProperties_Key, ColumnEncryptionProperties_Key_Free);
-        public string KeyMetadata => ExceptionInfo.ReturnString(_handle, ColumnEncryptionProperties_Key_Metadata, ColumnEncryptionProperties_Key_Metadata_Free);
+        public string ColumnPath => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Column_Path, ColumnEncryptionProperties_Column_Path_Free);
+        public bool IsEncrypted => ExceptionInfo.Return<bool>(Handle, ColumnEncryptionProperties_Is_Encrypted);
+        public bool IsEncryptedWithFooterKey => ExceptionInfo.Return<bool>(Handle, ColumnEncryptionProperties_Is_Encrypted_With_Footer_Key);
+        public string Key => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Key, ColumnEncryptionProperties_Key_Free);
+        public string KeyMetadata => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Key_Metadata, ColumnEncryptionProperties_Key_Metadata_Free);
 
-        public ColumnEncryptionProperties DeepClone() => new ColumnEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, ColumnEncryptionProperties_Deep_Clone));
+        public ColumnEncryptionProperties DeepClone() => new ColumnEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnEncryptionProperties_Deep_Clone));
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
@@ -56,6 +56,6 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern void ColumnEncryptionProperties_Key_Metadata_Free(IntPtr keyMetadata);
 
-        private readonly ParquetHandle _handle;
+        internal readonly ParquetHandle Handle;
     }
 }

--- a/csharp/ColumnEncryptionPropertiesBuilder.cs
+++ b/csharp/ColumnEncryptionPropertiesBuilder.cs
@@ -29,9 +29,10 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
-        public ColumnEncryptionPropertiesBuilder Key(string key)
+        public ColumnEncryptionPropertiesBuilder Key(byte[] key)
         {
-            ExceptionInfo.Check(ColumnEncryptionPropertiesBuilder_Key(_handle.IntPtr, key));
+            var aesKey = new AesKey(key);
+            ExceptionInfo.Check(ColumnEncryptionPropertiesBuilder_Key(_handle.IntPtr, in aesKey));
             GC.KeepAlive(_handle);
             return this;
         }
@@ -75,7 +76,7 @@ namespace ParquetSharp
         private static extern void ColumnEncryptionPropertiesBuilder_Free(IntPtr builder);
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key(IntPtr builder, string key);
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key(IntPtr builder, in AesKey key);
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
         private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key_Metadata(IntPtr builder, string keyMetadata);

--- a/csharp/ColumnEncryptionPropertiesBuilder.cs
+++ b/csharp/ColumnEncryptionPropertiesBuilder.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using ParquetSharp.Schema;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Builder pattern for ColumnEncryptionProperties.
+    /// </summary>
+    public sealed class ColumnEncryptionPropertiesBuilder : IDisposable
+    {
+        public ColumnEncryptionPropertiesBuilder(string columnName)
+            : this(Make(columnName))
+        {
+        }
+
+        public ColumnEncryptionPropertiesBuilder(ColumnPath columnPath)
+            : this(Make(columnPath))
+        {
+        }
+
+        internal ColumnEncryptionPropertiesBuilder(IntPtr handle)
+        {
+            _handle = new ParquetHandle(handle, ColumnEncryptionPropertiesBuilder_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public ColumnEncryptionPropertiesBuilder Key(string key)
+        {
+            ExceptionInfo.Check(ColumnEncryptionPropertiesBuilder_Key(_handle.IntPtr, key));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public ColumnEncryptionPropertiesBuilder KeyMetadata(string keyMetadata)
+        {
+            ExceptionInfo.Check(ColumnEncryptionPropertiesBuilder_Key_Metadata(_handle.IntPtr, keyMetadata));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public ColumnEncryptionPropertiesBuilder KeyId(string keyId)
+        {
+            ExceptionInfo.Check(ColumnEncryptionPropertiesBuilder_Key_Id(_handle.IntPtr, keyId));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public ColumnEncryptionProperties Build() => new ColumnEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, ColumnEncryptionPropertiesBuilder_Build));
+
+        private static IntPtr Make(string columnName)
+        {
+            ExceptionInfo.Check(ColumnEncryptionPropertiesBuilder_Create(columnName, out var handle));
+            return handle;
+        }
+
+        private static IntPtr Make(ColumnPath columnPath)
+        {
+            ExceptionInfo.Check(ColumnEncryptionPropertiesBuilder_Create_From_Column_Path(columnPath.Handle.IntPtr, out var handle));
+            GC.KeepAlive(columnPath);
+            return handle;
+        }
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Create(string name, out IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Create_From_Column_Path(IntPtr path, out IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ColumnEncryptionPropertiesBuilder_Free(IntPtr builder);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key(IntPtr builder, string key);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key_Metadata(IntPtr builder, string keyMetadata);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key_Id(IntPtr builder, string keyId);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Build(IntPtr builder, out IntPtr properties);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/DecryptionKeyRetriever.cs
+++ b/csharp/DecryptionKeyRetriever.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Map a decryption key to a key-metadata.
+    /// Serves as a callback by FileDecryptionProperties to access decryption keys whenever they are needed.
+    /// </summary>
+    public abstract class DecryptionKeyRetriever
+    {
+        public abstract string GetKey(string keyMetadata);
+
+        /// <summary>
+        /// The native code owns a GC handle on the given instance of DecryptionKeyRetriever.
+        /// This is the reverse from the rest of ParquetSharp where C# owns a native handle into arrow::parquet.
+        /// </summary>
+        internal IntPtr CreateGcHandle()
+        {
+            var gcHandle = GCHandle.Alloc(this, GCHandleType.Normal);
+            return GCHandle.ToIntPtr(gcHandle);
+        }
+
+        internal static DecryptionKeyRetriever GetGcHandleTarget(IntPtr handle)
+        {
+            return (DecryptionKeyRetriever) GCHandle.FromIntPtr(handle).Target;
+        }
+
+        internal delegate void FreeGcHandleFunc(IntPtr handle);
+        internal delegate IntPtr GetKeyFunc(IntPtr handle, IntPtr keyMetadata);
+        internal delegate void FreeKeyFunc(IntPtr key);
+
+        internal static readonly FreeGcHandleFunc FreeGcHandleCallback = FreeGcHandle;
+        internal static readonly GetKeyFunc GetKeyFuncCallback = GetKey;
+        internal static readonly FreeKeyFunc FreeKeyCallback = FreeKey;
+
+        private static void FreeGcHandle(IntPtr handle)
+        {
+            GCHandle.FromIntPtr(handle).Free();
+        }
+
+        private static IntPtr GetKey(IntPtr handle, IntPtr keyMetadata)
+        {
+            var obj = (DecryptionKeyRetriever) GCHandle.FromIntPtr(handle).Target;
+            var keyMetadataStr = Marshal.PtrToStringAnsi(keyMetadata);
+            var key = obj.GetKey(keyMetadataStr);
+
+            return Marshal.StringToHGlobalAnsi(key);
+        }
+
+        private static void FreeKey(IntPtr key)
+        {
+            Marshal.FreeHGlobal(key);
+        }
+    }
+}

--- a/csharp/ExceptionInfo.cs
+++ b/csharp/ExceptionInfo.cs
@@ -84,6 +84,17 @@ namespace ParquetSharp
         public static string ReturnString(ParquetHandle handle, GetFunction<IntPtr> getter, Action<IntPtr> deleter = null)
         {
             Check(getter(handle.IntPtr, out var value));
+            return ConvertPtrToString(handle, deleter, value);
+        }
+        
+        public static string ReturnString<TArg0>(ParquetHandle handle, TArg0 arg0, GetFunction<TArg0, IntPtr> getter, Action<IntPtr> deleter = null)
+        {
+            Check(getter(handle.IntPtr, arg0, out var value));
+            return ConvertPtrToString(handle, deleter, value);
+        }
+
+        private static string ConvertPtrToString(ParquetHandle handle, Action<IntPtr> deleter, IntPtr value)
+        {
             var str = Marshal.PtrToStringAnsi(value);
             deleter?.Invoke(value);
             GC.KeepAlive(handle);

--- a/csharp/ExceptionInfo.cs
+++ b/csharp/ExceptionInfo.cs
@@ -86,12 +86,6 @@ namespace ParquetSharp
             Check(getter(handle.IntPtr, out var value));
             return ConvertPtrToString(handle, deleter, value);
         }
-        
-        public static string ReturnString<TArg0>(ParquetHandle handle, TArg0 arg0, GetFunction<TArg0, IntPtr> getter, Action<IntPtr> deleter = null)
-        {
-            Check(getter(handle.IntPtr, arg0, out var value));
-            return ConvertPtrToString(handle, deleter, value);
-        }
 
         private static string ConvertPtrToString(ParquetHandle handle, Action<IntPtr> deleter, IntPtr value)
         {

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Properties related to decrypting a parquet file.
+    /// </summary>
+    public sealed class FileDecryptionProperties : IDisposable
+    {
+        internal FileDecryptionProperties(IntPtr handle)
+        {
+            _handle = new ParquetHandle(handle, FileDecryptionProperties_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public string ColumnKey(string columPath) => ExceptionInfo.ReturnString(_handle, columPath, FileDecryptionProperties_Column_Key, FileDecryptionProperties_Column_Key_Free);
+        public string FooterKey => ExceptionInfo.ReturnString(_handle, FileDecryptionProperties_Footer_Key, FileDecryptionProperties_Footer_Key_Free);
+        public string AadPrefix => ExceptionInfo.ReturnString(_handle, FileDecryptionProperties_Aad_Prefix, FileDecryptionProperties_Aad_Prefix_Free);
+        //public KeyRetriever KeyRetriever => TODO
+        public bool CheckPlaintextFooterIntegrity => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Check_Plaintext_Footer_Integrity);
+        public bool PlaintextFilesAllowed => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Plaintext_Files_Allowed);
+        //public AadPrefixVerifier AadPrefixVerifier => TODO
+
+        public FileDecryptionProperties DeepClone() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Deep_Clone));
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileDecryptionProperties_Free(IntPtr properties);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileDecryptionProperties_Column_Key(IntPtr properties, string columnPath, out IntPtr columnKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileDecryptionProperties_Column_Key_Free(IntPtr columnKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Footer_Key(IntPtr properties, out IntPtr footerKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileDecryptionProperties_Footer_Key_Free(IntPtr footerKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Aad_Prefix(IntPtr properties, out IntPtr aadPrefix);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileDecryptionProperties_Aad_Prefix_Free(IntPtr aadPrefix);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Key_Retriever(IntPtr properties, out IntPtr keyRetriever);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Check_Plaintext_Footer_Integrity(IntPtr properties, [MarshalAs(UnmanagedType.I1)] out bool checkPlaintextFooterIntegrity);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Plaintext_Files_Allowed(IntPtr properties, [MarshalAs(UnmanagedType.I1)] out bool plaintextFilesAllowed);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Aad_Prefix_Verifier(IntPtr properties, out IntPtr aadPrefixVerifier);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -24,7 +24,7 @@ namespace ParquetSharp
         public DecryptionKeyRetriever KeyRetriever => DecryptionKeyRetriever.GetGcHandleTarget(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Key_Retriever));
         public bool CheckPlaintextFooterIntegrity => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Check_Plaintext_Footer_Integrity);
         public bool PlaintextFilesAllowed => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Plaintext_Files_Allowed);
-        //public AadPrefixVerifier AadPrefixVerifier => TODO
+        public AadPrefixVerifier AadPrefixVerifier => AadPrefixVerifier.GetGcHandleTarget(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Aad_Prefix_Verifier));
 
         public FileDecryptionProperties DeepClone() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Deep_Clone));
 

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -18,8 +18,8 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
-        public string ColumnKey(string columPath) => ExceptionInfo.ReturnString(_handle, columPath, FileDecryptionProperties_Column_Key, FileDecryptionProperties_Column_Key_Free);
-        public string FooterKey => ExceptionInfo.ReturnString(_handle, FileDecryptionProperties_Footer_Key, FileDecryptionProperties_Footer_Key_Free);
+        public byte[] ColumnKey(string columPath) => ExceptionInfo.Return<string, AesKey>(_handle, columPath, FileDecryptionProperties_Column_Key).ToBytes();
+        public byte[] FooterKey => ExceptionInfo.Return<AesKey>(_handle, FileDecryptionProperties_Footer_Key).ToBytes();
         public string AadPrefix => ExceptionInfo.ReturnString(_handle, FileDecryptionProperties_Aad_Prefix, FileDecryptionProperties_Aad_Prefix_Free);
         public DecryptionKeyRetriever KeyRetriever => DecryptionKeyRetriever.GetGcHandleTarget(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Key_Retriever));
         public bool CheckPlaintextFooterIntegrity => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Check_Plaintext_Footer_Integrity);
@@ -35,16 +35,10 @@ namespace ParquetSharp
         private static extern void FileDecryptionProperties_Free(IntPtr properties);
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileDecryptionProperties_Column_Key(IntPtr properties, string columnPath, out IntPtr columnKey);
+        private static extern IntPtr FileDecryptionProperties_Column_Key(IntPtr properties, string columnPath, out AesKey columnKey);
 
         [DllImport(ParquetDll.Name)]
-        private static extern void FileDecryptionProperties_Column_Key_Free(IntPtr columnKey);
-
-        [DllImport(ParquetDll.Name)]
-        private static extern IntPtr FileDecryptionProperties_Footer_Key(IntPtr properties, out IntPtr footerKey);
-
-        [DllImport(ParquetDll.Name)]
-        private static extern void FileDecryptionProperties_Footer_Key_Free(IntPtr footerKey);
+        private static extern IntPtr FileDecryptionProperties_Footer_Key(IntPtr properties, out AesKey footerKey);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionProperties_Aad_Prefix(IntPtr properties, out IntPtr aadPrefix);

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -21,7 +21,7 @@ namespace ParquetSharp
         public string ColumnKey(string columPath) => ExceptionInfo.ReturnString(_handle, columPath, FileDecryptionProperties_Column_Key, FileDecryptionProperties_Column_Key_Free);
         public string FooterKey => ExceptionInfo.ReturnString(_handle, FileDecryptionProperties_Footer_Key, FileDecryptionProperties_Footer_Key_Free);
         public string AadPrefix => ExceptionInfo.ReturnString(_handle, FileDecryptionProperties_Aad_Prefix, FileDecryptionProperties_Aad_Prefix_Free);
-        //public KeyRetriever KeyRetriever => TODO
+        public DecryptionKeyRetriever KeyRetriever => DecryptionKeyRetriever.GetGcHandleTarget(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Key_Retriever));
         public bool CheckPlaintextFooterIntegrity => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Check_Plaintext_Footer_Integrity);
         public bool PlaintextFilesAllowed => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Plaintext_Files_Allowed);
         //public AadPrefixVerifier AadPrefixVerifier => TODO

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -10,23 +10,39 @@ namespace ParquetSharp
     {
         internal FileDecryptionProperties(IntPtr handle)
         {
-            _handle = new ParquetHandle(handle, FileDecryptionProperties_Free);
+            Handle = new ParquetHandle(handle, FileDecryptionProperties_Free);
         }
 
         public void Dispose()
         {
-            _handle.Dispose();
+            Handle.Dispose();
         }
 
-        public byte[] ColumnKey(string columPath) => ExceptionInfo.Return<string, AesKey>(_handle, columPath, FileDecryptionProperties_Column_Key).ToBytes();
-        public byte[] FooterKey => ExceptionInfo.Return<AesKey>(_handle, FileDecryptionProperties_Footer_Key).ToBytes();
-        public string AadPrefix => ExceptionInfo.ReturnString(_handle, FileDecryptionProperties_Aad_Prefix, FileDecryptionProperties_Aad_Prefix_Free);
-        public DecryptionKeyRetriever KeyRetriever => DecryptionKeyRetriever.GetGcHandleTarget(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Key_Retriever));
-        public bool CheckPlaintextFooterIntegrity => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Check_Plaintext_Footer_Integrity);
-        public bool PlaintextFilesAllowed => ExceptionInfo.Return<bool>(_handle, FileDecryptionProperties_Plaintext_Files_Allowed);
-        public AadPrefixVerifier AadPrefixVerifier => AadPrefixVerifier.GetGcHandleTarget(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Aad_Prefix_Verifier));
+        public byte[] ColumnKey(string columPath) => ExceptionInfo.Return<string, AesKey>(Handle, columPath, FileDecryptionProperties_Column_Key).ToBytes();
+        public byte[] FooterKey => ExceptionInfo.Return<AesKey>(Handle, FileDecryptionProperties_Footer_Key).ToBytes();
+        public string AadPrefix => ExceptionInfo.ReturnString(Handle, FileDecryptionProperties_Aad_Prefix, FileDecryptionProperties_Aad_Prefix_Free);
+        public bool CheckPlaintextFooterIntegrity => ExceptionInfo.Return<bool>(Handle, FileDecryptionProperties_Check_Plaintext_Footer_Integrity);
+        public bool PlaintextFilesAllowed => ExceptionInfo.Return<bool>(Handle, FileDecryptionProperties_Plaintext_Files_Allowed);
 
-        public FileDecryptionProperties DeepClone() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionProperties_Deep_Clone));
+        public DecryptionKeyRetriever KeyRetriever
+        {
+            get
+            {
+                var handle = ExceptionInfo.Return<IntPtr>(Handle, FileDecryptionProperties_Key_Retriever);
+                return handle == IntPtr.Zero ? null : DecryptionKeyRetriever.GetGcHandleTarget(handle);
+            }
+        }
+
+        public AadPrefixVerifier AadPrefixVerifier
+        {
+            get
+            {
+                var handle = ExceptionInfo.Return<IntPtr>(Handle, FileDecryptionProperties_Aad_Prefix_Verifier);
+                return handle == IntPtr.Zero ? null : AadPrefixVerifier.GetGcHandleTarget(handle);
+            }
+        }
+
+        public FileDecryptionProperties DeepClone() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, FileDecryptionProperties_Deep_Clone));
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
@@ -58,6 +74,6 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionProperties_Aad_Prefix_Verifier(IntPtr properties, out IntPtr aadPrefixVerifier);
 
-        private readonly ParquetHandle _handle;
+        internal readonly ParquetHandle Handle;
     }
 }

--- a/csharp/FileDecryptionPropertiesBuilder.cs
+++ b/csharp/FileDecryptionPropertiesBuilder.cs
@@ -20,9 +20,10 @@ namespace ParquetSharp
             _handle.Dispose();
         }
         
-        public FileDecryptionPropertiesBuilder FooterKey(string footerKeyId)
+        public FileDecryptionPropertiesBuilder FooterKey(byte[] footerKey)
         {
-            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Footer_Key(_handle.IntPtr, footerKeyId));
+            var footerAesKey = new AesKey(footerKey);
+            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Footer_Key(_handle.IntPtr, in footerAesKey));
             GC.KeepAlive(_handle);
             return this;
         }
@@ -72,8 +73,7 @@ namespace ParquetSharp
                     _handle.IntPtr,
                     gcHandle,
                     DecryptionKeyRetriever.FreeGcHandleCallback,
-                    DecryptionKeyRetriever.GetKeyFuncCallback,
-                    DecryptionKeyRetriever.FreeKeyCallback));
+                    DecryptionKeyRetriever.GetKeyFuncCallback));
             }
 
             catch
@@ -118,7 +118,7 @@ namespace ParquetSharp
         private static extern void FileDecryptionPropertiesBuilder_Free(IntPtr builder);
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileDecryptionPropertiesBuilder_Footer_Key(IntPtr builder, string footerKey);
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Footer_Key(IntPtr builder, in AesKey footerKey);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionPropertiesBuilder_Column_Keys(IntPtr builder, IntPtr[] columnDecryptionProperties, int numProperties);
@@ -128,8 +128,7 @@ namespace ParquetSharp
             IntPtr builder, 
             IntPtr gcHandle,
             DecryptionKeyRetriever.FreeGcHandleFunc freeGcHandle, 
-            DecryptionKeyRetriever.GetKeyFunc getKey,
-            DecryptionKeyRetriever.FreeKeyFunc freeKey);
+            DecryptionKeyRetriever.GetKeyFunc getKey);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionPropertiesBuilder_Disable_Footer_Signature_Verification(IntPtr builder);

--- a/csharp/FileDecryptionPropertiesBuilder.cs
+++ b/csharp/FileDecryptionPropertiesBuilder.cs
@@ -39,7 +39,7 @@ namespace ParquetSharp
 
         public FileDecryptionPropertiesBuilder AadPrefixVerifier(AadPrefixVerifier aadPrefixVerifier)
         {
-            var gcHandle = aadPrefixVerifier.CreateGcHandle();
+            var gcHandle = aadPrefixVerifier?.CreateGcHandle() ?? IntPtr.Zero;
 
             try
             {
@@ -65,7 +65,7 @@ namespace ParquetSharp
 
         public FileDecryptionPropertiesBuilder KeyRetriever(DecryptionKeyRetriever keyRetriever)
         {
-            var gcHandle = keyRetriever.CreateGcHandle();
+            var gcHandle = keyRetriever?.CreateGcHandle() ?? IntPtr.Zero;
 
             try
             {

--- a/csharp/FileDecryptionPropertiesBuilder.cs
+++ b/csharp/FileDecryptionPropertiesBuilder.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Builder pattern for FileDecryptionProperties.
+    /// </summary>
+    public sealed class FileDecryptionPropertiesBuilder : IDisposable
+    {
+        public FileDecryptionPropertiesBuilder(string footerKey)
+        {
+            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Create(out var handle));
+            _handle = new ParquetHandle(handle, FileDecryptionPropertiesBuilder_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+        
+        public FileDecryptionPropertiesBuilder FooterKey(string footerKeyId)
+        {
+            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Footer_Key(_handle.IntPtr, footerKeyId));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileDecryptionPropertiesBuilder ColumnKeys(ColumnDecryptionProperties[] columnDecryptionProperties)
+        {
+            var handles = columnDecryptionProperties.Select(p => p.Handle.IntPtr).ToArray();
+            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Column_Keys(_handle.IntPtr, handles, handles.Length));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(columnDecryptionProperties);
+            return this;
+        }
+
+        // TODO
+        //public FileDecryptionPropertiesBuilder KeyRetriever(KeyRetriever keyRetriever)
+        //{
+        //    ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Key_Retriever(_handle.IntPtr, keyRetriever.Handle.IntPtr));
+        //    GC.KeepAlive(_handle);
+        //    GC.KeepAlive(keyRetriever);
+        //    return this;
+        //}
+
+        public FileDecryptionPropertiesBuilder DisableFooterSignatureVerification()
+        {
+            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Disable_Footer_Signature_Verification(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileDecryptionPropertiesBuilder AadPrefix(string aadPrefix)
+        {
+            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Aad_Prefix(_handle.IntPtr, aadPrefix));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        // TODO
+        //public FileDecryptionPropertiesBuilder AadPrefixVerifier(AadPrefixVerifier aadPrefixVerifier)
+        //{
+        //    ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Aad_Prefix_Verifier(_handle.IntPtr, aadPrefixVerifier.Handle.IntPtr));
+        //    GC.KeepAlive(_handle);
+        //    GC.KeepAlive(aadPrefixVerifier);
+        //    return this;
+        //}
+
+        public FileDecryptionPropertiesBuilder PlaintextFilesAllowed()
+        {
+            ExceptionInfo.Check(FileDecryptionPropertiesBuilder_Plaintext_Files_Allowed(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileDecryptionProperties Build() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionPropertiesBuilder_Build));
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Create(out IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileDecryptionPropertiesBuilder_Free(IntPtr builder);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Footer_Key(IntPtr builder, string footerKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Column_Keys(IntPtr builder, IntPtr[] columnDecryptionProperties, int numProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Key_Retriever(IntPtr builder, IntPtr keyRetriever);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Disable_Footer_Signature_Verification(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Aad_Prefix(IntPtr builder, string aadPrefix);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Aad_Prefix_Verifier(IntPtr builder, IntPtr aadPrefixVerifier);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Plaintext_Files_Allowed(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionPropertiesBuilder_Build(IntPtr builder, out IntPtr properties);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/FileDecryptionPropertiesBuilder.cs
+++ b/csharp/FileDecryptionPropertiesBuilder.cs
@@ -47,8 +47,7 @@ namespace ParquetSharp
                     _handle.IntPtr,
                     gcHandle,
                     ParquetSharp.AadPrefixVerifier.FreeGcHandleCallback,
-                    ParquetSharp.AadPrefixVerifier.VerifyFuncCallback,
-                    ParquetSharp.AadPrefixVerifier.FreeExceptionCallback));
+                    ParquetSharp.AadPrefixVerifier.VerifyFuncCallback));
             }
 
             catch
@@ -141,8 +140,7 @@ namespace ParquetSharp
             IntPtr builder,
             IntPtr gcHandle,
             AadPrefixVerifier.FreeGcHandleFunc freeGcHandle,
-            AadPrefixVerifier.VerifyFunc getKey,
-            AadPrefixVerifier.FreeExceptionFunc freeKey);
+            AadPrefixVerifier.VerifyFunc getKey);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionPropertiesBuilder_Plaintext_Files_Allowed(IntPtr builder);

--- a/csharp/FileEncryptionProperties.cs
+++ b/csharp/FileEncryptionProperties.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Properties related to encrypting a parquet file.
+    /// </summary>
+    public sealed class FileEncryptionProperties : IDisposable
+    {
+        internal FileEncryptionProperties(IntPtr handle)
+        {
+            _handle = new ParquetHandle(handle, FileEncryptionProperties_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public bool EncryptedFooter => ExceptionInfo.Return<bool>(_handle, FileEncryptionProperties_Encrypted_Footer);
+        //public EncryptionAlgorithm Algorithm => TODO
+        public string FooterKey => ExceptionInfo.ReturnString(_handle, FileEncryptionProperties_Footer_Key, FileEncryptionProperties_Footer_Key_Free);
+        public string FooterKeyMetadata => ExceptionInfo.ReturnString(_handle, FileEncryptionProperties_Footer_Key_Metadata, FileEncryptionProperties_Footer_Key_Metadata_Free);
+        public string FileAad => ExceptionInfo.ReturnString(_handle, FileEncryptionProperties_File_Aad, FileEncryptionProperties_File_Aad_Free);
+
+        public ColumnEncryptionProperties ColumnEncryptionProperties(string columnPath) => new ColumnEncryptionProperties(ExceptionInfo.Return<string, IntPtr>(_handle, columnPath, FileEncryptionProperties_Column_Encryption_Properties));
+        public FileEncryptionProperties DeepClone() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileEncryptionProperties_Deep_Clone));
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileEncryptionProperties_Free(IntPtr properties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionProperties_Encrypted_Footer(IntPtr properties, [MarshalAs(UnmanagedType.I1)] out bool encryptedFooter);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionProperties_Algorithm(IntPtr properties, IntPtr algorithm);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionProperties_Footer_Key(IntPtr properties, out IntPtr footerKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileEncryptionProperties_Footer_Key_Free(IntPtr footerKey);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionProperties_Footer_Key_Metadata(IntPtr properties, out IntPtr footerKeyMetadata);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileEncryptionProperties_Footer_Key_Metadata_Free(IntPtr footerKeyMetadata);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionProperties_File_Aad(IntPtr properties, out IntPtr fileAad);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileEncryptionProperties_File_Aad_Free(IntPtr fileAad);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileEncryptionProperties_Column_Encryption_Properties(IntPtr properties,  string columnPath, out IntPtr columnEncryptionProperties);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/FileEncryptionProperties.cs
+++ b/csharp/FileEncryptionProperties.cs
@@ -10,22 +10,22 @@ namespace ParquetSharp
     {
         internal FileEncryptionProperties(IntPtr handle)
         {
-            _handle = new ParquetHandle(handle, FileEncryptionProperties_Free);
+            Handle = new ParquetHandle(handle, FileEncryptionProperties_Free);
         }
 
         public void Dispose()
         {
-            _handle.Dispose();
+            Handle.Dispose();
         }
 
-        public bool EncryptedFooter => ExceptionInfo.Return<bool>(_handle, FileEncryptionProperties_Encrypted_Footer);
+        public bool EncryptedFooter => ExceptionInfo.Return<bool>(Handle, FileEncryptionProperties_Encrypted_Footer);
         //public EncryptionAlgorithm Algorithm => TODO
-        public string FooterKey => ExceptionInfo.ReturnString(_handle, FileEncryptionProperties_Footer_Key, FileEncryptionProperties_Footer_Key_Free);
-        public string FooterKeyMetadata => ExceptionInfo.ReturnString(_handle, FileEncryptionProperties_Footer_Key_Metadata, FileEncryptionProperties_Footer_Key_Metadata_Free);
-        public string FileAad => ExceptionInfo.ReturnString(_handle, FileEncryptionProperties_File_Aad, FileEncryptionProperties_File_Aad_Free);
+        public byte[] FooterKey => ExceptionInfo.Return<AesKey>(Handle, FileEncryptionProperties_Footer_Key).ToBytes();
+        public string FooterKeyMetadata => ExceptionInfo.ReturnString(Handle, FileEncryptionProperties_Footer_Key_Metadata, FileEncryptionProperties_Footer_Key_Metadata_Free);
+        public string FileAad => ExceptionInfo.ReturnString(Handle, FileEncryptionProperties_File_Aad, FileEncryptionProperties_File_Aad_Free);
 
-        public ColumnEncryptionProperties ColumnEncryptionProperties(string columnPath) => new ColumnEncryptionProperties(ExceptionInfo.Return<string, IntPtr>(_handle, columnPath, FileEncryptionProperties_Column_Encryption_Properties));
-        public FileEncryptionProperties DeepClone() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileEncryptionProperties_Deep_Clone));
+        public ColumnEncryptionProperties ColumnEncryptionProperties(string columnPath) => new ColumnEncryptionProperties(ExceptionInfo.Return<string, IntPtr>(Handle, columnPath, FileEncryptionProperties_Column_Encryption_Properties));
+        public FileEncryptionProperties DeepClone() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, FileEncryptionProperties_Deep_Clone));
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
@@ -40,10 +40,7 @@ namespace ParquetSharp
         private static extern IntPtr FileEncryptionProperties_Algorithm(IntPtr properties, IntPtr algorithm);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr FileEncryptionProperties_Footer_Key(IntPtr properties, out IntPtr footerKey);
-
-        [DllImport(ParquetDll.Name)]
-        private static extern void FileEncryptionProperties_Footer_Key_Free(IntPtr footerKey);
+        private static extern IntPtr FileEncryptionProperties_Footer_Key(IntPtr properties, out AesKey footerKey);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileEncryptionProperties_Footer_Key_Metadata(IntPtr properties, out IntPtr footerKeyMetadata);
@@ -60,6 +57,6 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
         private static extern IntPtr FileEncryptionProperties_Column_Encryption_Properties(IntPtr properties,  string columnPath, out IntPtr columnEncryptionProperties);
 
-        private readonly ParquetHandle _handle;
+        internal readonly ParquetHandle Handle;
     }
 }

--- a/csharp/FileEncryptionPropertiesBuilder.cs
+++ b/csharp/FileEncryptionPropertiesBuilder.cs
@@ -9,9 +9,10 @@ namespace ParquetSharp
     /// </summary>
     public sealed class FileEncryptionPropertiesBuilder : IDisposable
     {
-        public FileEncryptionPropertiesBuilder(string footerKey)
+        public FileEncryptionPropertiesBuilder(byte[] footerKey)
         {
-            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Create(footerKey, out var handle));
+            var footerAesKey = new AesKey(footerKey);
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Create(in footerAesKey, out var handle));
             _handle = new ParquetHandle(handle, FileEncryptionPropertiesBuilder_Free);
         }
 
@@ -74,7 +75,7 @@ namespace ParquetSharp
         public FileEncryptionProperties Build() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileEncryptionPropertiesBuilder_Build));
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileEncryptionPropertiesBuilder_Create(string footerKey, out IntPtr builder);
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Create(in AesKey footerKey, out IntPtr builder);
 
         [DllImport(ParquetDll.Name)]
         private static extern void FileEncryptionPropertiesBuilder_Free(IntPtr builder);

--- a/csharp/FileEncryptionPropertiesBuilder.cs
+++ b/csharp/FileEncryptionPropertiesBuilder.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Builder pattern for FileEncryptionProperties.
+    /// </summary>
+    public sealed class FileEncryptionPropertiesBuilder : IDisposable
+    {
+        public FileEncryptionPropertiesBuilder(string footerKey)
+        {
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Create(footerKey, out var handle));
+            _handle = new ParquetHandle(handle, FileEncryptionPropertiesBuilder_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public FileEncryptionPropertiesBuilder SetPlaintextFooter()
+        {
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Set_Plaintext_Footer(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileEncryptionPropertiesBuilder Algorithm(ParquetCipher parquetCipher)
+        {
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Algorithm(_handle.IntPtr, parquetCipher));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileEncryptionPropertiesBuilder FooterKeyId(string footerKeyId)
+        {
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Footer_Key_Id(_handle.IntPtr, footerKeyId));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileEncryptionPropertiesBuilder FooterKeyMetadata(string footerKeyMetadata)
+        {
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Footer_Key_Metadata(_handle.IntPtr, footerKeyMetadata));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileEncryptionPropertiesBuilder AadPrefix(string aadPrefix)
+        {
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Aad_Prefix(_handle.IntPtr, aadPrefix));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileEncryptionPropertiesBuilder DisableAadPrefixStorage()
+        {
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Disable_Aad_Prefix_Storage(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        public FileEncryptionPropertiesBuilder EncryptedColumns(ColumnEncryptionProperties[] columnEncryptionProperties)
+        {
+            var handles = columnEncryptionProperties.Select(p => p.Handle.IntPtr).ToArray();
+            ExceptionInfo.Check(FileEncryptionPropertiesBuilder_Encrypted_Columns(_handle.IntPtr, handles, handles.Length));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(columnEncryptionProperties);
+            return this;
+        }
+
+        public FileEncryptionProperties Build() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileEncryptionPropertiesBuilder_Build));
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Create(string footerKey, out IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void FileEncryptionPropertiesBuilder_Free(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Set_Plaintext_Footer(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Algorithm(IntPtr builder, ParquetCipher parquetCipher);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Footer_Key_Id(IntPtr builder, string footerKeyId);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Footer_Key_Metadata(IntPtr builder, string footerKeyMetadata);
+
+        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Aad_Prefix(IntPtr builder, string aadPrefix);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Disable_Aad_Prefix_Storage(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Encrypted_Columns(IntPtr builder, IntPtr[] columnEncryptionProperties, int numProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Build(IntPtr builder, out IntPtr properties);
+
+        private readonly ParquetHandle _handle;
+    }
+}

--- a/csharp/ParquetCipher.cs
+++ b/csharp/ParquetCipher.cs
@@ -1,0 +1,9 @@
+﻿
+namespace ParquetSharp
+{
+    public enum ParquetCipher
+    {
+        AesGcmV1 = 0, 
+        AesGcmCtrV1 = 1
+    }
+}

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -7,18 +7,34 @@ namespace ParquetSharp
     public sealed class ParquetFileReader : IDisposable
     {
         public ParquetFileReader(string path)
+            : this(path, ReaderProperties.GetDefaultReaderProperties())
         {
-            if (path == null) throw new ArgumentNullException(nameof(path));
-
-            ExceptionInfo.Check(ParquetFileReader_OpenFile(path, out var reader));
-            _handle = new ParquetHandle(reader, ParquetFileReader_Free);
         }
 
         public ParquetFileReader(RandomAccessFile randomAccessFile)
+            : this(randomAccessFile, ReaderProperties.GetDefaultReaderProperties())
+        {
+        }
+
+        public ParquetFileReader(string path, ReaderProperties readerProperties)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (readerProperties == null) throw new ArgumentNullException(nameof(readerProperties));
+
+            ExceptionInfo.Check(ParquetFileReader_OpenFile(path, readerProperties.Handle.IntPtr, out var reader));
+            _handle = new ParquetHandle(reader, ParquetFileReader_Free);
+
+            GC.KeepAlive(readerProperties);
+        }
+
+        public ParquetFileReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties)
         {
             if (randomAccessFile == null) throw new ArgumentNullException(nameof(randomAccessFile));
+            if (readerProperties == null) throw new ArgumentNullException(nameof(readerProperties));
 
-            _handle = new ParquetHandle(ExceptionInfo.Return<IntPtr>(randomAccessFile.Handle, ParquetFileReader_Open), ParquetFileReader_Free);
+            _handle = new ParquetHandle(ExceptionInfo.Return<IntPtr, IntPtr>(randomAccessFile.Handle, readerProperties.Handle.IntPtr, ParquetFileReader_Open), ParquetFileReader_Free);
+
+            GC.KeepAlive(readerProperties);
         }
 
         public void Dispose()
@@ -37,10 +53,10 @@ namespace ParquetSharp
         }
 
         [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ParquetFileReader_OpenFile(string path, out IntPtr reader);
+        private static extern IntPtr ParquetFileReader_OpenFile(string path, IntPtr readerProperties, out IntPtr reader);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr ParquetFileReader_Open(IntPtr readableFileInterface, out IntPtr reader);
+        private static extern IntPtr ParquetFileReader_Open(IntPtr readableFileInterface, IntPtr readerProperties, out IntPtr reader);
 
         [DllImport(ParquetDll.Name)]
         private static extern void ParquetFileReader_Free(IntPtr reader);

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -9,7 +9,8 @@ namespace ParquetSharp
     public sealed class ParquetFileWriter : IDisposable
     {
         public ParquetFileWriter(
-            string path, Column[] columns, 
+            string path, 
+            Column[] columns, 
             Compression compression = Compression.Lz4, 
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
@@ -21,7 +22,8 @@ namespace ParquetSharp
         }
 
         public ParquetFileWriter(
-            OutputStream outputStream, Column[] columns, 
+            OutputStream outputStream, 
+            Column[] columns, 
             Compression compression = Compression.Lz4, 
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
@@ -33,14 +35,42 @@ namespace ParquetSharp
         }
 
         public ParquetFileWriter(
-            string path, GroupNode schema, WriterProperties writerProperties, 
+            string path, 
+            Column[] columns,
+            WriterProperties writerProperties,
+            IReadOnlyDictionary<string, string> keyValueMetadata = null)
+        {
+            using (var schema = Column.CreateSchemaNode(columns))
+            {
+                _handle = CreateParquetFileWriter(path, schema, writerProperties, keyValueMetadata);
+            }
+        }
+
+        public ParquetFileWriter(
+            OutputStream outputStream, 
+            Column[] columns,
+            WriterProperties writerProperties,
+            IReadOnlyDictionary<string, string> keyValueMetadata = null)
+        {
+            using (var schema = Column.CreateSchemaNode(columns))
+            {
+                _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, keyValueMetadata);
+            }
+        }
+
+        public ParquetFileWriter(
+            string path, 
+            GroupNode schema, 
+            WriterProperties writerProperties, 
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             _handle = CreateParquetFileWriter(path, schema, writerProperties, keyValueMetadata);
         }
 
         public ParquetFileWriter(
-            OutputStream outputStream, GroupNode schema, WriterProperties writerProperties,
+            OutputStream outputStream, 
+            GroupNode schema, 
+            WriterProperties writerProperties,
             IReadOnlyDictionary<string, string> keyValueMetadata = null)
         {
             _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, keyValueMetadata);

--- a/csharp/ReaderProperties.cs
+++ b/csharp/ReaderProperties.cs
@@ -41,7 +41,7 @@ namespace ParquetSharp
             }
             set
             {
-                ExceptionInfo.Check(ReaderProperties_Set_File_Decryption_Properties(Handle.IntPtr, value.Handle.IntPtr));
+                ExceptionInfo.Check(ReaderProperties_Set_File_Decryption_Properties(Handle.IntPtr, value?.Handle.IntPtr ?? IntPtr.Zero));
                 GC.KeepAlive(Handle);
                 GC.KeepAlive(value);
             }

--- a/csharp/ReaderProperties.cs
+++ b/csharp/ReaderProperties.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    public sealed class ReaderProperties : IDisposable
+    {
+        public static ReaderProperties GetDefaultReaderProperties()
+        {
+            return new ReaderProperties(ExceptionInfo.Return<IntPtr>(ReaderProperties_Get_Default_Reader_Properties));
+        }
+
+        internal ReaderProperties(IntPtr handle)
+        {
+            Handle = new ParquetHandle(handle, ReaderProperties_Free);
+        }
+
+        public void Dispose()
+        {
+            Handle.Dispose();
+        }
+
+        public bool IsBufferedStreamEnabled => ExceptionInfo.Return<bool>(Handle, ReaderProperties_Is_Buffered_Stream_Enabled);
+
+        public long BufferSize
+        {
+            get => ExceptionInfo.Return<long>(Handle, ReaderProperties_Get_Buffer_Size);
+            set
+            {
+                ExceptionInfo.Check(ReaderProperties_Set_Buffer_Size(Handle.IntPtr, value));
+                GC.KeepAlive(Handle);
+            }
+        }
+
+        public FileDecryptionProperties FileDecryptionProperties
+        {
+            get
+            {
+                var handle = ExceptionInfo.Return<IntPtr>(Handle, ReaderProperties_Get_File_Decryption_Properties);
+                return handle == IntPtr.Zero ? null : new FileDecryptionProperties(handle);
+            }
+            set
+            {
+                ExceptionInfo.Check(ReaderProperties_Set_File_Decryption_Properties(Handle.IntPtr, value.Handle.IntPtr));
+                GC.KeepAlive(Handle);
+                GC.KeepAlive(value);
+            }
+        }
+
+        public void EnableBufferedStream()
+        {
+            ExceptionInfo.Check(ReaderProperties_Enable_Buffered_Stream(Handle.IntPtr));
+            GC.KeepAlive(Handle);
+        }
+
+        public void DisableBufferedStream()
+        {
+            ExceptionInfo.Check(ReaderProperties_Disable_Buffered_Stream(Handle.IntPtr));
+            GC.KeepAlive(Handle);
+        }
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Get_Default_Reader_Properties(out IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern void ReaderProperties_Free(IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)] 
+        private static extern IntPtr ReaderProperties_Is_Buffered_Stream_Enabled(IntPtr readerProperties, [MarshalAs(UnmanagedType.I1)] out bool isBufferedStreamEnabled);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Enable_Buffered_Stream(IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Disable_Buffered_Stream(IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Set_Buffer_Size(IntPtr readerProperties, long bufferSize);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Get_Buffer_Size(IntPtr readerProperties, out long bufferSize);
+
+        [DllImport(ParquetDll.Name)] 
+        private static extern IntPtr ReaderProperties_Set_File_Decryption_Properties(IntPtr readerProperties, IntPtr fileDecryptionProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Get_File_Decryption_Properties(IntPtr readerProperties, out IntPtr fileDecryptionProperties);
+
+        internal readonly ParquetHandle Handle;
+    }
+}

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -26,6 +26,7 @@ namespace ParquetSharp
         public Encoding DictionaryIndexEncoding => ExceptionInfo.Return<Encoding>(Handle, WriterProperties_Dictionary_Index_Encoding);
         public Encoding DictionaryPageEncoding => ExceptionInfo.Return<Encoding>(Handle, WriterProperties_Dictionary_Page_Encoding);
         public long DictionaryPagesizeLimit => ExceptionInfo.Return<long>(Handle, WriterProperties_Dictionary_Pagesize_Limit);
+        public FileEncryptionProperties FileEncryptionProperties => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, WriterProperties_File_Encryption_Properties));
         public long MaxRowGroupLength => ExceptionInfo.Return<long>(Handle, WriterProperties_Max_Row_Group_Length);
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(Handle, WriterProperties_Version);
         public long WriteBatchSize => ExceptionInfo.Return<long>(Handle, WriterProperties_Write_Batch_Size);
@@ -109,6 +110,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterProperties_Encoding(IntPtr writerProperties, IntPtr path, out Encoding encoding);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterProperties_File_Encryption_Properties(IntPtr writerProperties, out IntPtr fileEncryptionProperties);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterProperties_Statistics_Enabled(IntPtr writerProperties, IntPtr path, [MarshalAs(UnmanagedType.I1)] out bool enabled);

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -205,6 +205,14 @@ namespace ParquetSharp
             return this;
         }
 
+        public WriterPropertiesBuilder Encryption(FileEncryptionProperties fileEncryptionProperties)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Encryption(_handle.IntPtr, fileEncryptionProperties.Handle.IntPtr));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(fileEncryptionProperties);
+            return this;
+        }
+
         public WriterPropertiesBuilder MaxRowGroupLength(long maxRowGroupLength)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Max_Row_Group_Length(_handle.IntPtr, maxRowGroupLength));
@@ -311,6 +319,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Encoding_By_ColumnPath(IntPtr builder, IntPtr path, Encoding encodingType);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Encryption(IntPtr builder, IntPtr fileEncryptionProperties);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Max_Row_Group_Length(IntPtr builder, long maxRowGroupLength);

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -207,7 +207,7 @@ namespace ParquetSharp
 
         public WriterPropertiesBuilder Encryption(FileEncryptionProperties fileEncryptionProperties)
         {
-            ExceptionInfo.Check(WriterPropertiesBuilder_Encryption(_handle.IntPtr, fileEncryptionProperties.Handle.IntPtr));
+            ExceptionInfo.Check(WriterPropertiesBuilder_Encryption(_handle.IntPtr, fileEncryptionProperties?.Handle.IntPtr ?? IntPtr.Zero));
             GC.KeepAlive(_handle);
             GC.KeepAlive(fileEncryptionProperties);
             return this;

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -4,6 +4,9 @@ using ParquetSharp.Schema;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Builder pattern for WriterProperties.
+    /// </summary>
     public sealed class WriterPropertiesBuilder : IDisposable
     {
         public WriterPropertiesBuilder()

--- a/vcpkg_linux.sh
+++ b/vcpkg_linux.sh
@@ -3,9 +3,9 @@ set -e
 
 mkdir -p build
 cd build
-git clone https://github.com/philjdf/vcpkg.git vcpkg.linux
+git clone https://github.com/Microsoft/vcpkg.git vcpkg.linux
 cd vcpkg.linux
-git checkout Arrow016
+git checkout master
 ./bootstrap-vcpkg.sh
 
 ./vcpkg install arrow:x64-linux

--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -1,8 +1,8 @@
 mkdir build
 cd build || goto :error
-git clone https://github.com/philjdf/vcpkg.git vcpkg.windows || goto :error
+git clone https://github.com/Microsoft/vcpkg.git vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error
-git checkout Arrow016 || goto :error
+git checkout master || goto :error
 call bootstrap-vcpkg.bat || goto :error
 
 vcpkg.exe install arrow:x64-windows-static || goto :error


### PR DESCRIPTION
Adding new Encryption support from IBM in Arrow 0.16.

See:
- https://github.com/apache/parquet-format/blob/master/Encryption.md
- https://cdn.oreillystatic.com/en/assets/1/event/300/Parquet%20modular%20encryption_%20Confidentiality%20and%20integrity%20of%20sensitive%20column%20data%20Presentation.pdf