### PR TITLE
Fixed row-oriented ParquetRowWriter not correctly writing empty row group (Issue #110).

### DIFF
--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -89,6 +89,29 @@ namespace ParquetSharp.Test
         }
 
         [Test]
+        public static void TestEmptyRowGroup([Values(false, true)] bool closeBeforeDispose)
+        {
+            // Writing and reading an empty row group file.
+            // https://github.com/G-Research/ParquetSharp/issues/110
+
+            using var buffer = new ResizableBuffer();
+
+            using (var outputStream = new BufferOutputStream(buffer))
+            {
+                using var writer = ParquetFile.CreateRowWriter<(int, double, DateTime)>(outputStream);
+                if (closeBeforeDispose)
+                {
+                    writer.Close();
+                }
+            }
+
+            using var inputStream = new BufferReader(buffer);
+            using var reader = ParquetFile.CreateRowReader<(int, double, DateTime)>(inputStream);
+
+            Assert.AreEqual(new (int, double, DateTime)[0], reader.ReadRows(0));
+        }
+
+        [Test]
         public static void TestWriterDoubleDispose()
         {
             // ParquetRowWriter is not double-Dispose safe (Issue 64)

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1591;</NoWarn>
-    <Version>2.1.0-beta1</Version>
+    <Version>2.1.0-beta2</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -43,27 +43,13 @@ namespace ParquetSharp.RowOriented
 
         public void Dispose()
         {
-            if (_pos != 0)
-            {
-                _writeAction(this, _rows, _pos);
-                _pos = 0;
-            }
-
-            _rowGroupWriter?.Dispose();
-            _rowGroupWriter = null;
+            FlushAndDisposeRowGroup();
             _parquetFileWriter.Dispose();
         }
 
         public void Close()
         {
-            if (_pos != 0)
-            {
-                _writeAction(this, _rows, _pos);
-                _pos = 0;
-            }
-
-            _rowGroupWriter?.Dispose();
-            _rowGroupWriter = null;
+            FlushAndDisposeRowGroup();
             _parquetFileWriter.Close();
         }
 
@@ -103,6 +89,18 @@ namespace ParquetSharp.RowOriented
             {
                 columnWriter.WriteBatch(values, 0, length);
             }
+        }
+
+        private void FlushAndDisposeRowGroup()
+        {
+            if (_rowGroupWriter != null)
+            {
+                _writeAction(this, _rows, _pos);
+                _pos = 0;
+            }
+
+            _rowGroupWriter?.Dispose();
+            _rowGroupWriter = null;
         }
 
         private readonly ParquetFileWriter _parquetFileWriter;


### PR DESCRIPTION
Bumped release version to 2.1.0-beta2.