### PR TITLE
Update to Arrow-0.17

### DIFF
--- a/cpp/ManagedRandomAccessFile.cpp
+++ b/cpp/ManagedRandomAccessFile.cpp
@@ -63,10 +63,10 @@ public:
 
 	Result<std::shared_ptr<arrow::Buffer>> Read(const int64_t nbytes) override
 	{
-		std::shared_ptr<arrow::ResizableBuffer> buffer;
-		RETURN_NOT_OK(arrow::AllocateResizableBuffer(nbytes, &buffer));
+		ARROW_ASSIGN_OR_RAISE(auto pBuffer, arrow::AllocateResizableBuffer(nbytes));	
+		std::shared_ptr<arrow::ResizableBuffer> buffer(pBuffer.release());
 
-		ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, Read(nbytes, buffer->mutable_data()));
+		ARROW_ASSIGN_OR_RAISE(const int64_t bytes_read, Read(nbytes, buffer->mutable_data()));
 		if (bytes_read < nbytes)
 		{
 			RETURN_NOT_OK(buffer->Resize(bytes_read));

--- a/cpp/Node.cpp
+++ b/cpp/Node.cpp
@@ -13,9 +13,9 @@ extern "C"
 		delete node;
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* Node_Id(const std::shared_ptr<const schema::Node>* node, int* id)
+	PARQUETSHARP_EXPORT ExceptionInfo* Node_Field_Id(const std::shared_ptr<const schema::Node>* node, int* id)
 	{
-		TRYCATCH(*id = (*node)->id();)
+		TRYCATCH(*id = (*node)->field_id();)
 	}
 
 	PARQUETSHARP_EXPORT ExceptionInfo* Node_Logical_Type(const std::shared_ptr<const schema::Node>* node, const std::shared_ptr<const LogicalType>** logical_type)

--- a/cpp/ReaderProperties.cpp
+++ b/cpp/ReaderProperties.cpp
@@ -54,7 +54,7 @@ extern "C"
 		TRYCATCH
 		(
 			const auto p = reader_properties->file_decryption_properties();
-			*file_decryption_properties = p ? new std::shared_ptr<FileDecryptionProperties>(p, [](const FileDecryptionProperties* ptr) {}) : nullptr;
+			*file_decryption_properties = p ? new std::shared_ptr<FileDecryptionProperties>(p) : nullptr;
 		)
 	}
 }

--- a/cpp/ResizableBuffer.cpp
+++ b/cpp/ResizableBuffer.cpp
@@ -3,14 +3,15 @@
 #include "ExceptionInfo.h"
 
 #include <arrow/buffer.h>
+#include <arrow/result.h>
 
 extern "C"
 {
 	PARQUETSHARP_EXPORT ExceptionInfo* ResizableBuffer_Create(const int64_t initialSize, std::shared_ptr<arrow::ResizableBuffer>** buffer)
 	{
 		TRYCATCH(
-			*buffer = new std::shared_ptr<arrow::ResizableBuffer>();
-			arrow::AllocateResizableBuffer(initialSize, *buffer);
+			auto pBuffer = arrow::AllocateResizableBuffer(initialSize);
+			*buffer = new std::shared_ptr<arrow::ResizableBuffer>(pBuffer.ValueOrDie().release());
 		)
 	}
 }

--- a/csharp.test/TestColumn.cs
+++ b/csharp.test/TestColumn.cs
@@ -24,7 +24,7 @@ namespace ParquetSharp.Test
                 using var node = column.CreateSchemaNode();
 
                 Assert.AreEqual(expected.LogicalType, node.LogicalType);
-                Assert.AreEqual(-1, node.Id);
+                Assert.AreEqual(-1, node.FieldId);
                 Assert.AreEqual(expected.Name, node.Name);
                 Assert.AreEqual(NodeType.Primitive, node.NodeType);
                 Assert.AreEqual(null, node.Parent);

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -1,4 +1,7 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using ParquetSharp.IO;
 using ParquetSharp.Schema;
 
 namespace ParquetSharp.Test
@@ -27,9 +30,7 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestPropertiesBuilder()
         {
-            var builder = new WriterPropertiesBuilder();
-
-            builder
+            var p = new WriterPropertiesBuilder()
                 .Compression(Compression.Snappy)
                 .CompressionLevel(3)
                 .CreatedBy("Meeeee!!!")
@@ -39,9 +40,7 @@ namespace ParquetSharp.Test
                 .MaxRowGroupLength(789)
                 .Version(ParquetVersion.PARQUET_1_0)
                 .WriteBatchSize(666)
-                ;
-
-            var p = builder.Build();
+                .Build();
 
             Assert.AreEqual("Meeeee!!!", p.CreatedBy);
             Assert.AreEqual(Compression.Snappy, p.Compression(new ColumnPath("anypath")));
@@ -53,6 +52,59 @@ namespace ParquetSharp.Test
             Assert.AreEqual(789, p.MaxRowGroupLength);
             Assert.AreEqual(ParquetVersion.PARQUET_1_0, p.Version);
             Assert.AreEqual(666, p.WriteBatchSize);
+        }
+
+        [Test]
+        public static void TestByteStreamSplitEncoding()
+        {
+            const int numRows = 10230;
+
+            var ids = Enumerable.Range(0, numRows).ToArray();
+            var values = ids.Select(i => i / 3.14f).ToArray();
+
+            using var buffer = new ResizableBuffer();
+
+            using (var output = new BufferOutputStream(buffer))
+            {
+                var columns = new Column[]
+                {
+                    new Column<int>("id"),
+                    new Column<float>("value")
+                };
+
+                var p = new WriterPropertiesBuilder()
+                    .Compression(Compression.Lz4)
+                    .DisableDictionary("value")
+                    .Encoding("value", Encoding.ByteStreamSplit)
+                    .Build();
+
+                using var fileWriter = new ParquetFileWriter(output, columns, p);
+                using var groupWriter = fileWriter.AppendRowGroup();
+
+                using var idWriter = groupWriter.NextColumn().LogicalWriter<int>();
+                idWriter.WriteBatch(ids);
+
+                using var valueWriter = groupWriter.NextColumn().LogicalWriter<float>();
+                valueWriter.WriteBatch(values);
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            using var groupReader = fileReader.RowGroup(0);
+
+            using var metadataId = groupReader.MetaData.GetColumnChunkMetaData(0);
+            using var metadataValue = groupReader.MetaData.GetColumnChunkMetaData(1);
+
+            Assert.AreEqual(new[] {Encoding.PlainDictionary, Encoding.Plain, Encoding.Rle}, metadataId.Encodings);
+            Assert.AreEqual(new[] {Encoding.ByteStreamSplit, Encoding.Rle}, metadataValue.Encodings);
+
+            using var idReader = groupReader.Column(0).LogicalReader<int>();
+            using var valueReader = groupReader.Column(1).LogicalReader<float>();
+
+            Assert.AreEqual(ids, idReader.ReadAll(numRows));
+            Assert.AreEqual(values, valueReader.ReadAll(numRows));
         }
     }
 }

--- a/csharp/Encoding.cs
+++ b/csharp/Encoding.cs
@@ -10,6 +10,8 @@ namespace ParquetSharp
         DeltaBinaryPacked = 5,
         DeltaLengthByteArray = 6,
         DeltaByteArray = 7,
-        RleDictionary = 8
+        RleDictionary = 8,
+        ByteStreamSplit = 9,
+        Undefined = 10
     };
 }

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>1591;</NoWarn>
-    <Version>2.1.0-beta2</Version>
+    <Version>2.2.0-beta1</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/Schema/Node.cs
+++ b/csharp/Schema/Node.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp.Schema
     /// <summary>
     /// Base class for logical schema types. A type has a name, repetition level, and optionally a logical type.
     /// </summary>
-    [DebuggerDisplay("{NodeType}Node: ({Id}), {Name}, LogicalType: {LogicalType}")]
+    [DebuggerDisplay("{NodeType}Node: ({FieldId}), {Name}, LogicalType: {LogicalType}")]
     public abstract class Node : IDisposable, IEquatable<Node>
     {
         protected Node(IntPtr handle)
@@ -20,7 +20,10 @@ namespace ParquetSharp.Schema
             Handle.Dispose();
         }
 
-        public int Id => ExceptionInfo.Return<int>(Handle, Node_Id);
+        [Obsolete("Use FieldId instead")]
+        public int Id => FieldId;
+
+        public int FieldId => ExceptionInfo.Return<int>(Handle, Node_Field_Id);
         public LogicalType LogicalType => LogicalType.Create(ExceptionInfo.Return<IntPtr>(Handle, Node_Logical_Type));
         public string Name => ExceptionInfo.ReturnString(Handle, Node_Name);
         public NodeType NodeType => ExceptionInfo.Return<NodeType>(Handle, Node_Node_Type);
@@ -58,7 +61,7 @@ namespace ParquetSharp.Schema
         private static extern void Node_Free(IntPtr node);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr Node_Id(IntPtr node, out int id);
+        private static extern IntPtr Node_Field_Id(IntPtr node, out int id);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr Node_Logical_Type(IntPtr node, out IntPtr logicalType);

--- a/vcpkg_linux.sh
+++ b/vcpkg_linux.sh
@@ -3,9 +3,9 @@ set -e
 
 mkdir -p build
 cd build
-git clone https://github.com/Microsoft/vcpkg.git vcpkg.linux
+git clone https://github.com/GPSnoopy/vcpkg.git vcpkg.linux
 cd vcpkg.linux
-git checkout master
+git checkout Arrow-0.17
 ./bootstrap-vcpkg.sh
 
 ./vcpkg install arrow:x64-linux

--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -1,8 +1,8 @@
 mkdir build
 cd build || goto :error
-git clone https://github.com/Microsoft/vcpkg.git vcpkg.windows || goto :error
+git clone https://github.com/GPSnoopy/vcpkg.git vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error
-git checkout master || goto :error
+git checkout Arrow-0.17 || goto :error
 call bootstrap-vcpkg.bat || goto :error
 
 vcpkg.exe install arrow:x64-windows-static || goto :error


### PR DESCRIPTION
Fix API breakage and deprecated API calls.
Add support for new ByteStreamSplit encoding (Issue #112).
Should fix data corruption in Issue #116 (will merge the existing unit tests as part of another PR).