### PR TITLE
Fix windows vcpkg cache creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         vcpkg_windows.bat
         move build/vcpkg.windows build/vcpkg.windows.full
-        build/vcpkg.windows.full/vcpkg export --7zip --output=../vcpkg.windows arrow:x64-windows-static
+        build\vcpkg.windows.full\vcpkg export --raw --output=../vcpkg.windows arrow:x64-windows-static
       shell: cmd
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
       run: |
         vcpkg_windows.bat
-        move build/vcpkg.windows build/vcpkg.windows.full
+        move build\vcpkg.windows build\vcpkg.windows.full
         build\vcpkg.windows.full\vcpkg export --raw --output=../vcpkg.windows arrow:x64-windows-static
       shell: cmd
     - name: Setup MSBuild


### PR DESCRIPTION
For some reason, GitHub was saying everything was fine.