### PR TITLE
Improve vcpkg cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get --yes install flex bison
+    - name: Resolve vcpkg version
+      id: resolve-vcpkg-version
+      run: echo "::set-output name=commit-id::$(git ls-remote https://github.com/microsoft/vcpkg.git $(< vcpkg_version.txt) | cut -f1)"
     - name: Get cached vcpkg dependencies
       id: get-cached-vcpkg
       uses: actions/cache@v1
       with:
         path: cache/vcpkg
-        key: vcpkg-linux-2-${{ hashFiles('vcpkg_version.txt') }}
+        key: vcpkg-linux-${{ steps.resolve-vcpkg-version.outputs.commit-id }}
     - name: Use cached vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit == 'true'
       run: |
@@ -61,12 +64,15 @@ jobs:
     runs-on: windows-latest    
     steps:
     - uses: actions/checkout@v2
+    - name: Resolve vcpkg version
+      id: resolve-vcpkg-version
+      run: echo "::set-output name=commit-id::$(git ls-remote https://github.com/microsoft/vcpkg.git $(Get-Content vcpkg_version.txt) | %{ $_.Split()[0]; })"
     - name: Get cached vcpkg dependencies
       id: get-cached-vcpkg
       uses: actions/cache@v1
       with:
         path: cache/vcpkg
-        key: vcpkg-windows-2-${{ hashFiles('vcpkg_version.txt') }}
+        key: vcpkg-windows-${{ steps.resolve-vcpkg-version.outputs.commit-id }}
     - name: Use cached vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit == 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,19 @@ jobs:
       id: get-cached-vcpkg
       uses: actions/cache@v1
       with:
-        path: build/vcpkg.linux
+        path: cache/vcpkg
         key: vcpkg-linux-2-${{ hashFiles('vcpkg_version.txt') }}
+    - name: Use cached vcpkg dependencies
+      if: steps.get-cached-vcpkg.outputs.cache-hit == 'true'
+      run: |
+        mkdir build
+        mv cache/vcpkg build/vcpkg.linux
     - name: Compile vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
-      run: |
-        ./vcpkg_linux.sh
-        mv ./build/vcpkg.linux ./build/vcpkg.linux.full
-        ./build/vcpkg.linux.full/vcpkg export --raw --output=../vcpkg.linux arrow:x64-linux
+      run: ./vcpkg_linux.sh
+    - name: Export vcpkg dependencies
+      if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
+      run: build/vcpkg.linux/vcpkg export --x-all-installed --raw --output=../../cache/vcpkg
     - name: Compile native ParquetSharp library
       run: ./build_linux.sh
     - name: Build & Run .NET unit tests
@@ -57,15 +62,20 @@ jobs:
       id: get-cached-vcpkg
       uses: actions/cache@v1
       with:
-        path: build/vcpkg.windows
+        path: cache/vcpkg
         key: vcpkg-windows-2-${{ hashFiles('vcpkg_version.txt') }}
+    - name: Use cached vcpkg dependencies
+      if: steps.get-cached-vcpkg.outputs.cache-hit == 'true'
+      run: |
+        mkdir build
+        mv cache\vcpkg build\vcpkg.windows
     - name: Compile vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
-      run: |
-        vcpkg_windows.bat
-        move build/vcpkg.windows build/vcpkg.windows.full
-        build/vcpkg.windows.full/vcpkg export --7zip --output=../vcpkg.windows arrow:x64-windows-static
+      run: vcpkg_windows.bat
       shell: cmd
+    - name: Export vcpkg dependencies
+      if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
+      run: build\vcpkg.windows\vcpkg export --x-all-installed --raw --output=..\..\cache\vcpkg
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.0
     - name: Compile native ParquetSharp library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,7 @@ jobs:
         mv cache\vcpkg build\vcpkg.windows
     - name: Compile vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
-      run: vcpkg_windows.bat
-      shell: cmd
+      run: .\vcpkg_windows.bat
     - name: Cleanup vcpkg build
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
       run: '"buildtrees","downloads" | % { rm -r build\vcpkg.windows\$_ }'
@@ -85,11 +84,9 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.0
     - name: Compile native ParquetSharp library
-      run: build_windows.bat
-      shell: cmd
+      run: .\build_windows.bat
     - name: Build & Run .NET unit tests
       run: dotnet test csharp.test --configuration=Release
-      shell: cmd
     - name: Upload native ParquetSharp library
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Compile vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
       run: ./vcpkg_linux.sh
+    - name: Cleanup vcpkg build
+      if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
+      run: rm -rf build/vcpkg.linux/{buildtrees,downloads}
     - name: Export vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
       run: build/vcpkg.linux/vcpkg export --x-all-installed --raw --output=../../cache/vcpkg
@@ -73,6 +76,9 @@ jobs:
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
       run: vcpkg_windows.bat
       shell: cmd
+    - name: Cleanup vcpkg build
+      if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
+      run: '"buildtrees","downloads" | % { rm -r build\vcpkg.windows\$_ }'
     - name: Export vcpkg dependencies
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true'
       run: build\vcpkg.windows\vcpkg export --x-all-installed --raw --output=..\..\cache\vcpkg


### PR DESCRIPTION
Fix vcpkg caching on Windows, and use the vcpkg commit ID in the cache key, so that a branch name (i.e. `master`) can be used safely.