### PR TITLE
Fix broken vcpkg build

### DIFF
--- a/vcpkg_linux.sh
+++ b/vcpkg_linux.sh
@@ -7,7 +7,6 @@ mkdir -p build
 cd build
 git clone $vcpkg_url -b $vcpkg_ref vcpkg.linux
 cd vcpkg.linux
-[ "$GITHUB_ACTIONS" == "true" ] && echo "set(VCPKG_BUILD_TYPE release)" >> triplets/x64-linux.cmake
 ./bootstrap-vcpkg.sh
 
 ./vcpkg install arrow:x64-linux

--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -7,7 +7,7 @@ mkdir build
 cd build || goto :error
 git clone %vcpkg_url% -b %vcpkg_ref% vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error
-if %GITHUB_ACTIONS%==true echo "set(VCPKG_BUILD_TYPE release)" >> triplets\x64-windows-static.cmake || goto :error
+if %GITHUB_ACTIONS%==true echo set(VCPKG_BUILD_TYPE release) >> triplets\x64-windows-static.cmake || goto :error
 call bootstrap-vcpkg.bat || goto :error
 
 vcpkg.exe install arrow:x64-windows-static || goto :error


### PR DESCRIPTION
#129 introduced a typo in the Windows CI vcpkg build, which would make it fail once changing the version of vcpkg. This PR fixes it.

This PR also re-enables debug build of vcpkg in the Linux CI, as trying to build release-only currently fails on Linux.