### PR TITLE
Add ParquetSharp.targets to the buildTransitive folder too

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -29,7 +29,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="ParquetSharp.targets" Pack="true" PackagePath="build" />
+    <None Include="ParquetSharp.targets">
+      <Pack>True</Pack>
+      <PackagePath>build;buildTransitive</PackagePath>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This ensures ParquetSharpNative.dll is copied to all transitive consumers of this package.