### PR TITLE
 Fix vcpkg_windows.bat for case when GITHUB_ACTIONS is unset (Take 2)

### DIFF
--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -7,7 +7,7 @@ mkdir build
 cd build || goto :error
 git clone %vcpkg_url% -b %vcpkg_ref% vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error
-if %GITHUB_ACTIONS%==true echo set(VCPKG_BUILD_TYPE release) >> triplets\x64-windows-static.cmake || goto :error
+if "%GITHUB_ACTIONS%"=="true" echo set(VCPKG_BUILD_TYPE release) >> triplets\x64-windows-static.cmake || goto :error
 call bootstrap-vcpkg.bat || goto :error
 
 vcpkg.exe install arrow:x64-windows-static || goto :error


### PR DESCRIPTION
Revised version of https://github.com/G-Research/ParquetSharp/pull/138 after comments
I think without the quotes it's not valid bat file syntax
`if %NOT_EXISTING_VAR%==true echo Hello`
works for me on the commandline but not in a batch file
http://steve-jansen.github.io/guides/windows-batch-scripting/part-5-if-then-conditionals.html