### PR TITLE
Do not run CI for PRs where both branches are from the same repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:
@@ -14,6 +12,11 @@ jobs:
   # Build everything on all platorms (thus testing the developer workflow).
   # Upload the native shared libraries as artifacts.
   build-native:
+    # Do not run this job for pull requests where both branches are from the same repo.
+    # Other jobs will be skipped too, as they depend on this one.
+    # This prevents duplicate CI runs for our own pull requests, whilst preserving the ability to
+    # run the CI for each branch push to a fork, and for each pull request originating from a fork.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-latest]


### PR DESCRIPTION
When a pull request is created by comparing branches that are on the same repo, duplicate CI runs could be created: one for the branch push, and one for the pull request. PR #100 avoided that by running the CI for all PRs, and for pushes to the master branch only.

This PR instead lets the CI run for any branch push, and only for PRs originating from a fork. This will reinstate the ability to run the CI for each branch push to a fork, whilst preserving it for each PR originating from a fork.