### PR TITLE
Fix reading vcpkg_version.txt on Unix when it doesn't end with a newline

### DIFF
--- a/vcpkg_unix.sh
+++ b/vcpkg_unix.sh
@@ -25,7 +25,10 @@ case $(uname) in
     ;;
 esac
 
-read -r vcpkg_url vcpkg_ref < vcpkg_version.txt
+# Make sure reading vcpkg_version.txt works even when it doesn't end with a newline
+read -r vcpkg_url vcpkg_ref << EOF
+$(cat vcpkg_version.txt)
+EOF
 
 mkdir -p build
 cd build


### PR DESCRIPTION
This fix is best tested locally, as the CI will not execute `vcpkg_unix.sh` because of caching.