### PR TITLE
Add support for commit SHA as ref in vcpkg_version.txt

### DIFF
--- a/vcpkg_unix.sh
+++ b/vcpkg_unix.sh
@@ -32,8 +32,10 @@ EOF
 
 mkdir -p build
 cd build
-git clone $vcpkg_url -b $vcpkg_ref vcpkg.$os
+# Clone without checking out a branch, as vcpkg_ref could be a commit SHA
+git clone $vcpkg_url vcpkg.$os
 cd vcpkg.$os
+git checkout $vcpkg_ref
 ./bootstrap-vcpkg.sh
 
 ./vcpkg install arrow:$triplet

--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -5,8 +5,10 @@ for /f "tokens=1,2" %%a in (vcpkg_version.txt) do (
 
 mkdir build
 cd build || goto :error
-git clone %vcpkg_url% -b %vcpkg_ref% vcpkg.windows || goto :error
+rem Clone without checking out a branch, as vcpkg_ref could be a commit SHA
+git clone %vcpkg_url% vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error
+git checkout %vcpkg_ref% || goto :error
 if "%GITHUB_ACTIONS%"=="true" echo set(VCPKG_BUILD_TYPE release) >> triplets\x64-windows-static.cmake || goto :error
 call bootstrap-vcpkg.bat || goto :error
 


### PR DESCRIPTION
This PR adds the ability to directly target a commit SHA in `vcpkg_version.txt`.

It can be useful when support for a new version of Arrow gets added to vcpkg, and we neither want to wait for a release of vcpkg, nor do we want to use `master`, as it could change at any time.