### PR TITLE
Fix yet another ABI compression enum break from Arrow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_DEBUG_POSTFIX d)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 
 foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
@@ -31,7 +31,6 @@ if (MSVC)
 		endif()
 	endforeach()
 
-	add_compile_options("/std:c++17")
 	add_compile_options("/MP") # Compile files in parallel.
 	add_compile_options("/WX") # Threat warnings as errors.
 
@@ -41,7 +40,6 @@ if (UNIX)
 	
 	set(CMAKE_SHARED_LIBRARY_PREFIX )
 
-	add_compile_options("-std=c++17")
 	add_compile_options("-Wall")
 	add_compile_options("-Werror")
 	add_compile_options("-fvisibility-inlines-hidden")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if (MSVC)
 		endif()
 	endforeach()
 
+	add_compile_options("/std:c++17")
 	add_compile_options("/MP") # Compile files in parallel.
 	add_compile_options("/WX") # Threat warnings as errors.
 
@@ -40,6 +41,7 @@ if (UNIX)
 	
 	set(CMAKE_SHARED_LIBRARY_PREFIX )
 
+	add_compile_options("-std=c++17")
 	add_compile_options("-Wall")
 	add_compile_options("-Werror")
 	add_compile_options("-fvisibility-inlines-hidden")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(ParquetSharpNative SHARED
 	ColumnReader.cpp
 	ColumnWriter.cpp
 	CString.h
+	Enums.cpp
 	ExceptionInfo.h
 	ExceptionInfo.cpp
 	FileDecryptionProperties.cpp

--- a/cpp/Enums.cpp
+++ b/cpp/Enums.cpp
@@ -1,0 +1,85 @@
+
+#include <parquet/properties.h>
+
+using namespace parquet;
+
+namespace
+{
+
+	// Arrow does not offer guarantees around C++ ABI compatibility.
+	// Since for the moment the C# API uses the same enum values as the C++ API, verify that they match.
+	// This should stop us from releasing new versions of ParquetSharp with silent breaks in enum values.
+	[[maybe_unused]] void CheckEnumsAbiCompatibility()
+	{
+		static_assert(ColumnOrder::UNDEFINED == 0);
+		static_assert(ColumnOrder::TYPE_DEFINED_ORDER == 1);
+
+		static_assert(Compression::UNCOMPRESSED == 0);
+		static_assert(Compression::SNAPPY == 1);
+		static_assert(Compression::GZIP == 2);
+		static_assert(Compression::BROTLI == 3);
+		static_assert(Compression::ZSTD == 4);
+		static_assert(Compression::LZ4 == 5);
+		static_assert(Compression::LZ4_FRAME == 6);
+		static_assert(Compression::LZO == 7);
+		static_assert(Compression::BZ2 == 8);
+
+		static_assert(Encoding::PLAIN == 0);
+		static_assert(Encoding::PLAIN_DICTIONARY == 2);
+		static_assert(Encoding::RLE == 3);
+		static_assert(Encoding::BIT_PACKED == 4);
+		static_assert(Encoding::DELTA_BINARY_PACKED == 5);
+		static_assert(Encoding::DELTA_LENGTH_BYTE_ARRAY == 6);
+		static_assert(Encoding::DELTA_BYTE_ARRAY == 7);
+		static_assert(Encoding::RLE_DICTIONARY == 8);
+		static_assert(Encoding::BYTE_STREAM_SPLIT == 9);
+		static_assert(Encoding::UNDEFINED == 10);
+
+		static_assert(LogicalType::Type::UNKNOWN == 0);
+		static_assert(LogicalType::Type::STRING == 1);
+		static_assert(LogicalType::Type::MAP == 2);
+		static_assert(LogicalType::Type::LIST == 3);
+		static_assert(LogicalType::Type::ENUM == 4);
+		static_assert(LogicalType::Type::DECIMAL == 5);
+		static_assert(LogicalType::Type::DATE == 6);
+		static_assert(LogicalType::Type::TIME == 7);
+		static_assert(LogicalType::Type::TIMESTAMP == 8);
+		static_assert(LogicalType::Type::INTERVAL == 9);
+		static_assert(LogicalType::Type::INT == 10);
+		static_assert(LogicalType::Type::NIL == 11);
+		static_assert(LogicalType::Type::JSON == 12);
+		static_assert(LogicalType::Type::BSON == 13);
+		static_assert(LogicalType::Type::UUID == 14);
+		static_assert(LogicalType::Type::NONE == 15);
+
+		static_assert(ParquetCipher::AES_GCM_V1 == 0);
+		static_assert(ParquetCipher::AES_GCM_CTR_V1 == 1);
+
+		static_assert(ParquetVersion::PARQUET_1_0 == 0);
+		static_assert(ParquetVersion::PARQUET_2_0 == 1);
+
+		static_assert(Type::BOOLEAN == 0);
+		static_assert(Type::INT32 == 1);
+		static_assert(Type::INT64 == 2);
+		static_assert(Type::INT96 == 3);
+		static_assert(Type::FLOAT == 4);
+		static_assert(Type::DOUBLE == 5);
+		static_assert(Type::BYTE_ARRAY == 6);
+		static_assert(Type::FIXED_LEN_BYTE_ARRAY == 7);
+		static_assert(Type::UNDEFINED == 8);
+
+		static_assert(Repetition::REQUIRED == 0);
+		static_assert(Repetition::OPTIONAL == 1);
+		static_assert(Repetition::REPEATED == 2);
+
+		static_assert(SortOrder::SIGNED == 0);
+		static_assert(SortOrder::UNSIGNED == 1);
+		static_assert(SortOrder::UNKNOWN == 2);
+
+		static_assert(LogicalType::TimeUnit::UNKNOWN == 0);
+		static_assert(LogicalType::TimeUnit::MILLIS == 1);
+		static_assert(LogicalType::TimeUnit::MICROS == 2);
+		static_assert(LogicalType::TimeUnit::NANOS == 3);
+	}
+
+}

--- a/csharp/ApplicationVersion.cs
+++ b/csharp/ApplicationVersion.cs
@@ -36,7 +36,7 @@ namespace ParquetSharp
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct CStruct
+        internal readonly struct CStruct
         {
             public readonly IntPtr Application;
             public readonly IntPtr Build;

--- a/csharp/ByteArray.cs
+++ b/csharp/ByteArray.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     /// Represents a Parquet array of contiguous bytes.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct ByteArray : IEquatable<ByteArray>
+    public readonly struct ByteArray : IEquatable<ByteArray>
     {
         public ByteArray(IntPtr pointer, int length)
         {

--- a/csharp/ColumnOrder.cs
+++ b/csharp/ColumnOrder.cs
@@ -5,5 +5,5 @@ namespace ParquetSharp
     {
         Undefined = 0,
         TypeDefinedOrder = 1
-    };
+    }
 }

--- a/csharp/Compression.cs
+++ b/csharp/Compression.cs
@@ -12,5 +12,5 @@ namespace ParquetSharp
         Lz4Frame = 6,
         Lzo = 7,
         Bz2 = 8
-    };
+    }
 }

--- a/csharp/Compression.cs
+++ b/csharp/Compression.cs
@@ -9,7 +9,8 @@ namespace ParquetSharp
         Brotli = 3,
         Zstd = 4,
         Lz4 = 5,
-        Lzo = 6,
-        Bz2 = 7
+        Lz4Frame = 6,
+        Lzo = 7,
+        Bz2 = 8
     };
 }

--- a/csharp/Date.cs
+++ b/csharp/Date.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     /// Represent a Parquet 32-bit date, based around 1970-01-01.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Date : IEquatable<Date>
+    public readonly struct Date : IEquatable<Date>
     {
         public Date(int year, int month, int day)
             : this(new DateTime(year, month, day))

--- a/csharp/DateTimeNanos.cs
+++ b/csharp/DateTimeNanos.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     /// Represents a Parquet Timestamp with Nanoseconds time unit.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct DateTimeNanos : IEquatable<DateTimeNanos>
+    public readonly struct DateTimeNanos : IEquatable<DateTimeNanos>
     {
         public DateTimeNanos(long ticks)
         {

--- a/csharp/Encoding.cs
+++ b/csharp/Encoding.cs
@@ -13,5 +13,5 @@ namespace ParquetSharp
         RleDictionary = 8,
         ByteStreamSplit = 9,
         Undefined = 10
-    };
+    }
 }

--- a/csharp/Int96.cs
+++ b/csharp/Int96.cs
@@ -8,7 +8,7 @@ namespace ParquetSharp
     /// This is obsolete (see https://issues.apache.org/jira/browse/PARQUET-323).
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Int96 : IEquatable<Int96>
+    public readonly struct Int96 : IEquatable<Int96>
     {
         public Int96(int a, int b, int c)
         {

--- a/csharp/PhysicalType.cs
+++ b/csharp/PhysicalType.cs
@@ -10,6 +10,7 @@ namespace ParquetSharp
         Float = 4,
         Double = 5,
         ByteArray = 6,
-        FixedLenByteArray = 7
-    };
+        FixedLenByteArray = 7,
+        Undefined = 8
+    }
 }

--- a/csharp/SortOrder.cs
+++ b/csharp/SortOrder.cs
@@ -6,5 +6,5 @@ namespace ParquetSharp
         Signed = 0,
         Unsigned = 1,
         Unknown = 2
-    };
+    }
 }

--- a/csharp/TimeSpanNanos.cs
+++ b/csharp/TimeSpanNanos.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     /// Represents a Parquet Time with Nanoseconds time unit.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct TimeSpanNanos : IEquatable<TimeSpanNanos>
+    public readonly struct TimeSpanNanos : IEquatable<TimeSpanNanos>
     {
         public TimeSpanNanos(long ticks)
         {


### PR DESCRIPTION
Be more defensive about enum ABI compatibility breaks. See discussion at the bottom of https://github.com/apache/arrow/pull/7789