### PR TITLE
Fix add-path warning in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         dotnet-version: 3.1.100
     - name: Setup MSBuild
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
     - name: Compile native ParquetSharp library (Unix)
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: ./build_unix.sh


### PR DESCRIPTION
A newer version of the microsoft/setup-msbuild action has been released that is not vulnerable to [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w): https://github.com/microsoft/setup-msbuild/issues/26

This PR changes the version pinning to v1 instead of v1.0.0, so that the latest v1 will be used.

Fixes #154.