### PR TITLE
Fix vcpkg cache in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,12 @@ jobs:
       uses: actions/checkout@v2
     - name: Resolve vcpkg version
       id: resolve-vcpkg-version
-      run: echo "::set-output name=commit-id::$(git ls-remote $(cat vcpkg_version.txt) | cut -f1)"
+      run: |
+        read -r vcpkg_url vcpkg_ref << EOF
+        $(cat vcpkg_version.txt)
+        EOF
+        if [ ${#vcpkg_ref} -eq 40 ]; then commit_id=$vcpkg_ref; else commit_id=$(git ls-remote $vcpkg_url $vcpkg_ref | cut -f1); fi
+        echo "::set-output name=commit-id::$commit_id"
       shell: bash
     - name: Get cached vcpkg dependencies
       id: get-cached-vcpkg


### PR DESCRIPTION
Trying to resolve the vcpkg version of a commit SHA was giving an empty string, which was then causing the caching key to be wrong:

|      | Example |
| ---- | --- |
| Bad  | ![image](https://user-images.githubusercontent.com/3692455/95481412-448c0d80-098d-11eb-8c11-ed633601faa5.png) |
| Good | ![image](https://user-images.githubusercontent.com/3692455/95481570-6dac9e00-098d-11eb-9d76-103be935817a.png) |

This PR fixes that by first checking whether we already have a commit SHA in `vcpkg_version.txt`, and only resolving if it's a tag/branch name instead.