### PR TITLE
Sort fields and properties by MetadataToken.

### DIFF
--- a/vcpkg_version.txt
+++ b/vcpkg_version.txt
@@ -1,1 +1,1 @@
-https://github.com/Microsoft/vcpkg.git aea911913663ee417391e64c74814b34c7da0345
+https://github.com/Microsoft/vcpkg.git 2020.11


### PR DESCRIPTION
I found an issue that when writing parquet files using a writer like:

```c#
var writer =
    ParquetFie.CreateRowWriter<(long, int, double, int, long, short)>(
        "path/to/my.parquet",
        new [] {"C1", "C2", "C3", "C4", "C5", "C6"}
    );
```

the resulting parquet file would have column C1 typed as `int` and C2 as `long` - i.e. the first two column types were swapped.

Upon debugging it transpired that this was when `Type.GetFields()` was being used to build the write delegate. `Type.GetFields()` was not returning fields in declaration order so the mapping of column name to type failed. The .NET docs for this method (and `Type.GetProperties()`) explicitly state that order is not guaranteed. So, I have changed the code to sort by `MemberInfo.MetadataToken` as advised in [this SO article](https://stackoverflow.com/questions/8067493/if-getfields-doesnt-guarantee-order-how-does-layoutkind-sequential-work).

Note that no unit tests have been added to cover this as it proved impossible to find a circumstance which reliably failed with the old code. It seems the order `GetFields` uses is usually declaration order but might change under certain runtime conditions. I have verified though that my change here fixed the issue I was seeing in my code.