### PR TITLE
Writing decimals fails when column names provided

### DIFF
--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -148,7 +148,7 @@ namespace ParquetSharp.Test
 
         private static void TestRoundtrip<TTuple>(TTuple[] rows)
         {
-            RoundTripAndCompare(rows, rows);
+            RoundTripAndCompare(rows, rows, columnNames: null);
 
             var columnNames =
                 Enumerable.Range(1, typeof(TTuple).GetFields().Length + typeof(TTuple).GetProperties().Length)
@@ -163,10 +163,10 @@ namespace ParquetSharp.Test
             var expectedRows = rows.Select(
                 i => (TTupleRead) Activator.CreateInstance(typeof(TTupleRead), i)
             );
-            RoundTripAndCompare(rows, expectedRows);
+            RoundTripAndCompare(rows, expectedRows, columnNames: null);
         }
 
-        private static void RoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[] columnNames = default)
+        private static void RoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[] columnNames)
         {
             using var buffer = new ResizableBuffer();
 

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -149,6 +149,13 @@ namespace ParquetSharp.Test
         private static void TestRoundtrip<TTuple>(TTuple[] rows)
         {
             RoundTripAndCompare(rows, rows);
+
+            var columnNames =
+                Enumerable.Range(1, typeof(TTuple).GetFields().Length + typeof(TTuple).GetProperties().Length)
+                          .Select(x => $"Col{x}")
+                          .ToArray();
+            
+            RoundTripAndCompare(rows, rows, columnNames);
         }
 
         private static void TestRoundtripMapped<TTupleWrite, TTupleRead>(TTupleWrite[] rows)
@@ -159,13 +166,13 @@ namespace ParquetSharp.Test
             RoundTripAndCompare(rows, expectedRows);
         }
 
-        private static void RoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows)
+        private static void RoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[] columnNames = default)
         {
             using var buffer = new ResizableBuffer();
 
             using (var outputStream = new BufferOutputStream(buffer))
             {
-                using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream);
+                using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream, columnNames);
 
                 writer.WriteRows(rows);
                 writer.Close();

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -78,7 +78,7 @@ namespace ParquetSharp.RowOriented
                     throw new ArgumentException("the length of column names does not mach the number of public fields and properties", nameof(columnNames));
                 }
 
-                columns = columns.Select((c, i) => new Column(c.LogicalSystemType, columnNames[i])).ToArray();
+                columns = columns.Select((c, i) => new Column(c.LogicalSystemType, columnNames[i], c.LogicalTypeOverride, c.Length)).ToArray();
             }
 
             return (columns, (ParquetRowWriter<TTuple>.WriteAction) writeDelegate);


### PR DESCRIPTION
Writing a decimal column was fine unless you provide custom column names. When custom column names were provided, writing failed when copying the `Column` object to set the name because the copy failed to provide the `LogicalTypeOverride` and the `Length`. This fixes that and adds test coverage. 