### PR TITLE
Fix CI with .NET >= 5.0.200

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,14 @@ jobs:
         choco install nuget.commandline
         nuget add -source local nuget/ParquetSharp.${{ steps.get-version.outputs.version }}.nupkg
     - name: Add local NuGet feed
-      run: dotnet nuget add source -n local $PWD/local
+      run: |
+        dotnet nuget add source -n local $PWD/local
+        # Removing and adding back nuget.org ensures that our local source will be used first
+        dotnet nuget remove source nuget.org
+        dotnet nuget add source -n nuget.org https://api.nuget.org/v3/index.json
     - name: Change test project references to use local NuGet package
       run: |
         dotnet remove csharp.test reference csharp/ParquetSharp.csproj
-        dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }} -s local
+        dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
     - name: Build & Run .NET unit tests
       run: dotnet test csharp.test --configuration=Release


### PR DESCRIPTION
This PR fixes recent CI woes since GitHub started deploying .NET 5.0.200 as the default SDK on their GitHub Actions runners (see failure examples [here](https://github.com/G-Research/ParquetSharp/pull/168/checks?check_run_id=2098347678) and [here](https://github.com/G-Research/ParquetSharp/pull/167/checks?check_run_id=2098093685)).

The behaviour of the `test-nuget` job is changed as follows: NuGet sources are specified in the right order in the top-level config and the implicit restore done during the package add will then use it instead of a unique source specified on the command line.

Before .NET 5.0.200, the implicit restore was also considering the nuget.org source, so this problem never occured.