### PR TITLE
Pin .NET Core SDK version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       if: runner.os == 'Linux' || runner.os == 'macOS'
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 3.1.407
     - name: Setup MSBuild
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  dotnet_version: '3.1.407'
+
 jobs:
 
   # Note that vcpkg dependencies takes the majority of the build time.
@@ -81,12 +84,13 @@ jobs:
       run: build/vcpkg.$(echo ${{ runner.os }})/vcpkg export --x-all-installed --raw --output=../../cache/vcpkg
       shell: bash
       
-    # .NET Core Setup.
+    # .NET Core Setup (and also MSBuild for Windows).
     - name: Setup .NET Core
-      if: runner.os == 'Linux' || runner.os == 'macOS'
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.407
+        dotnet-version: ${{ env.dotnet_version }}
+    - name: Pin .NET Core SDK
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_version }}
     - name: Setup MSBuild
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v1
@@ -131,6 +135,12 @@ jobs:
       with:
         name: macOS-native-library
         path: bin
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.dotnet_version }}
+    - name: Pin .NET Core SDK
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_version }}
     - name: Build NuGet package
       run: dotnet build csharp --configuration=Release
     - name: Upload NuGet artifact 
@@ -169,6 +179,12 @@ jobs:
       run: |
         choco install nuget.commandline
         nuget add -source local nuget/ParquetSharp.${{ steps.get-version.outputs.version }}.nupkg
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.dotnet_version }}
+    - name: Pin .NET Core SDK
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_version }}
     - name: Add local NuGet feed
       run: |
         dotnet nuget add source -n local $PWD/local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
 
 env:
+  DOTNET_NOLOGO: true
   dotnet_version: '3.1.407'
 
 jobs:


### PR DESCRIPTION
This PR pins the version of the .NET Core SDK used in the CI to avoid building/testing with a random version decided by GitHub. It does so by generating a `global.json` file during the workflow run. This prevents `dotnet` from using the latest available SDK installed on the GitHub Actions runner.

This PR also upgrades the CI workflow to use the latest version of .NET Core 3.1 (3.1.407) and disables displaying the "welcome screen" (aka the logo).