### PR TITLE
Remove NuGet source reordering as it is actually a no-op

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,11 +170,7 @@ jobs:
         choco install nuget.commandline
         nuget add -source local nuget/ParquetSharp.${{ steps.get-version.outputs.version }}.nupkg
     - name: Add local NuGet feed
-      run: |
-        dotnet nuget add source -n local $PWD/local
-        # Removing and adding back nuget.org ensures that our local source will be used first
-        dotnet nuget remove source nuget.org
-        dotnet nuget add source -n nuget.org https://api.nuget.org/v3/index.json
+      run: dotnet nuget add source -n local $PWD/local
     - name: Change test project references to use local NuGet package
       run: |
         dotnet remove csharp.test reference csharp/ParquetSharp.csproj


### PR DESCRIPTION
According to the NuGet documentation and my own empirical testing, NuGet will always check our local source first, so the reordering attempted in #170 is a no-op.

The [documentation](https://docs.microsoft.com/en-us/nuget/concepts/package-installation-process) states:
> When acquiring the package, the order of sources in the NuGet configuration may apply:
> * NuGet checks sources local folder and network shares before checking HTTP sources.