### PR TITLE
Test dotnet 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
 
 env:
   DOTNET_NOLOGO: true
-  dotnet_version: '3.1.407'
+  dotnet_3_version: '3.1.407'
+  dotnet_5_version: '5.0.201'
 
 jobs:
 
@@ -25,6 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-latest]
       fail-fast: false
+    name: Build native library (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -89,9 +91,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ env.dotnet_version }}
+        dotnet-version: ${{ env.dotnet_3_version }}
     - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ env.dotnet_version }}
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_3_version }}
     - name: Setup MSBuild
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v1
@@ -116,6 +118,7 @@ jobs:
   # Download all native shared libraries and create the nuget package.
   # Upload nuget package as an artifact.
   build-nuget:
+    name: Build NuGet package
     runs-on: windows-latest    
     needs: build-native
     steps:
@@ -139,9 +142,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ env.dotnet_version }}
+        dotnet-version: ${{ env.dotnet_3_version }}
     - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ env.dotnet_version }}
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_3_version }}
     - name: Build NuGet package
       run: dotnet build csharp --configuration=Release
     - name: Upload NuGet artifact 
@@ -155,7 +158,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        dotnet: [3, 5]
       fail-fast: false
+    name: Test NuGet package (.NET ${{ matrix.dotnet }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: build-nuget
     steps:
@@ -180,12 +185,20 @@ jobs:
       run: |
         choco install nuget.commandline
         nuget add -source local nuget/ParquetSharp.${{ steps.get-version.outputs.version }}.nupkg
+    - name: Setup .NET variables
+      id: dotnet
+      shell: bash
+      run: |
+        case ${{ matrix.dotnet }} in 3) framework=netcoreapp3.1;; 5) framework=net5.0;; esac
+        version=${dotnet_${{ matrix.dotnet }}_version}
+        echo "::set-output name=version::$version"
+        echo "::set-output name=framework::$framework"
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ env.dotnet_version }}
+        dotnet-version: ${{ steps.dotnet.outputs.version }}
     - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ env.dotnet_version }}
+      run: dotnet new globaljson --sdk-version ${{ steps.dotnet.outputs.version }}
     - name: Add local NuGet feed
       run: dotnet nuget add source -n local $PWD/local
     - name: Change test project references to use local NuGet package
@@ -193,4 +206,4 @@ jobs:
         dotnet remove csharp.test reference csharp/ParquetSharp.csproj
         dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
     - name: Build & Run .NET unit tests
-      run: dotnet test csharp.test --configuration=Release
+      run: dotnet test csharp.test --configuration=Release --framework ${{ steps.dotnet.outputs.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,12 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.dotnet_3_version }}
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.dotnet_5_version }}
     - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ env.dotnet_3_version }}
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_5_version }}
     - name: Setup MSBuild
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v1
@@ -142,9 +146,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ env.dotnet_3_version }}
+        dotnet-version: ${{ env.dotnet_5_version }}
     - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ env.dotnet_3_version }}
+      run: dotnet new globaljson --sdk-version ${{ env.dotnet_5_version }}
     - name: Build NuGet package
       run: dotnet build csharp --configuration=Release
     - name: Upload NuGet artifact 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,12 +153,15 @@ jobs:
         name: nuget-package
         path: nuget
 
-  # Run .NET unit tests with the nuget package on all platforms (thus testing the user workflow).
+  # Run .NET unit tests with the nuget package on all platforms and all supported .NET runtimes (thus testing the user workflow).
   test-nuget:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         dotnet: [3, 5]
+        include:
+        - os: windows-latest
+          dotnet: 4
       fail-fast: false
     name: Test NuGet package (.NET ${{ matrix.dotnet }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -189,9 +192,22 @@ jobs:
       id: dotnet
       shell: bash
       run: |
-        case ${{ matrix.dotnet }} in 3) framework=netcoreapp3.1;; 5) framework=net5.0;; esac
-        version=${dotnet_${{ matrix.dotnet }}_version}
-        echo "::set-output name=version::$version"
+        major=${{ matrix.dotnet }}
+        case $major in
+          3)
+            framework=netcoreapp3.1
+            ;;
+          4)
+            framework=net461
+            # We build for .NET framework with .NET Core 3.1 SDK
+            major=3
+            ;;
+          5)
+            framework=net5.0
+            ;;
+        esac
+        version=dotnet_${major}_version
+        echo "::set-output name=version::${!version}"
         echo "::set-output name=framework::$framework"
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">netcoreapp3.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)'=='Unix'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <AssemblyName>ParquetSharp.Test</AssemblyName>
     <RootNamespace>ParquetSharp.Test</RootNamespace>

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">netstandard2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)'=='Unix'">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>ParquetSharp</AssemblyName>
     <RootNamespace>ParquetSharp</RootNamespace>


### PR DESCRIPTION
This PR modifies the test project to allow running on the .NET 5.0 runtime ~~when `-p:Channel=experimental` is specified~~. This requires building with the .NET 5.0 SDK, which might have an impact on the code we generate, though that should not be the case. It also requires contributors to have it installed to be able to build the tests.

This PR also modifies the CI workflow to run the tests on .NET 5.0 in parallel to .NET Core 3.1 and .NET Framework 4.6.1.