### PR TITLE
Promoting 2.4.0-beta2 to release version.

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -13,7 +13,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>2.4.0-beta2</Version>
+    <Version>2.4.0</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>


### PR DESCRIPTION
Arrow 4.0.0 has been released, so time to start a new beta branch.

Clarification: 2.4.0 uses Arrow 3.0.0. Let's release that as non-beta, as it's been stable for a while. Then we start 2.5.0-beta ultimately targeting Arrow 4.0.0 when available on vcpkg.