### PR TITLE
Get rid of net461, rely purely on netstandard2.0

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>ParquetSharp</AssemblyName>
     <RootNamespace>ParquetSharp</RootNamespace>
@@ -64,10 +63,6 @@
     <Content Include="..\bin\ParquetSharpNative.dylib" Link="ParquetSharpNative.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNative.dylib'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET Framework 4.6.1 is obsolete. AFAIK .NET Framework 4.7.1 and higher should work fine with .netstandard2.0 integration.