### PR TITLE
Make Date : IComparable<Date>, DateTimeNanos : IComparable<DateTimeNanos>

### DIFF
--- a/csharp/Date.cs
+++ b/csharp/Date.cs
@@ -48,9 +48,9 @@ namespace ParquetSharp
             return Days;
         }
 
-        public int CompareTo(Date? other)
+        public int CompareTo(Date other)
         {
-            return Days.CompareTo(other?.Days);
+            return Days.CompareTo(other.Days);
         }
 
         public override string ToString()

--- a/csharp/Date.cs
+++ b/csharp/Date.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     /// Represent a Parquet 32-bit date, based around 1970-01-01.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public readonly struct Date : IEquatable<Date>
+    public readonly struct Date : IEquatable<Date>, IComparable<Date>
     {
         public Date(int year, int month, int day)
             : this(new DateTime(year, month, day))
@@ -46,6 +46,11 @@ namespace ParquetSharp
         public override int GetHashCode()
         {
             return Days;
+        }
+
+        public int CompareTo(Date? other)
+        {
+            return Days.CompareTo(other?.Days);
         }
 
         public override string ToString()

--- a/csharp/DateTimeNanos.cs
+++ b/csharp/DateTimeNanos.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     /// Represents a Parquet Timestamp with Nanoseconds time unit.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public readonly struct DateTimeNanos : IEquatable<DateTimeNanos>
+    public readonly struct DateTimeNanos : IEquatable<DateTimeNanos>, IComparable<DateTimeNanos>
     {
         public DateTimeNanos(long ticks)
         {
@@ -32,6 +32,11 @@ namespace ParquetSharp
         public bool Equals(DateTimeNanos other)
         {
             return Ticks == other.Ticks;
+        }
+
+        public int CompareTo(DateTimeNanos? other)
+        {
+            return Ticks.CompareTo(other?.Ticks);
         }
 
         public override string ToString()

--- a/csharp/DateTimeNanos.cs
+++ b/csharp/DateTimeNanos.cs
@@ -34,9 +34,9 @@ namespace ParquetSharp
             return Ticks == other.Ticks;
         }
 
-        public int CompareTo(DateTimeNanos? other)
+        public int CompareTo(DateTimeNanos other)
         {
-            return Ticks.CompareTo(other?.Ticks);
+            return Ticks.CompareTo(other.Ticks);
         }
 
         public override string ToString()


### PR DESCRIPTION
Was trying to sort some rows generically, it failed because Date is not IComparable.