### PR TITLE
Use C# 8.0 and enable nullables.

### DIFF
--- a/csharp.benchmark/ParquetSharp.Benchmark.csproj
+++ b/csharp.benchmark/ParquetSharp.Benchmark.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-		<LangVersion>8.0</LangVersion>
-		<Nullable>enable</Nullable>
-		<AssemblyName>ParquetSharp.Benchmark</AssemblyName>
-		<RootNamespace>ParquetSharp.Benchmark</RootNamespace>
-		<Platforms>x64</Platforms>
-		<PlatformTarget>x64</PlatformTarget>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>ParquetSharp.Benchmark</AssemblyName>
+    <RootNamespace>ParquetSharp.Benchmark</RootNamespace>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-		<PackageReference Include="Parquet.Net" Version="3.8.6" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Parquet.Net" Version="3.8.6" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\csharp\ParquetSharp.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\csharp\ParquetSharp.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/csharp.benchmark/ParquetSharp.Benchmark.csproj
+++ b/csharp.benchmark/ParquetSharp.Benchmark.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
-    <AssemblyName>ParquetSharp.Benchmark</AssemblyName>
-    <RootNamespace>ParquetSharp.Benchmark</RootNamespace>
-    <Platforms>x64</Platforms>
-    <PlatformTarget>x64</PlatformTarget>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+		<LangVersion>8.0</LangVersion>
+		<Nullable>enable</Nullable>
+		<AssemblyName>ParquetSharp.Benchmark</AssemblyName>
+		<RootNamespace>ParquetSharp.Benchmark</RootNamespace>
+		<Platforms>x64</Platforms>
+		<PlatformTarget>x64</PlatformTarget>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Parquet.Net" Version="3.8.6" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+		<PackageReference Include="Parquet.Net" Version="3.8.6" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\csharp\ParquetSharp.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\csharp\ParquetSharp.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/csharp.benchmark/SizeInBytesColumn.cs
+++ b/csharp.benchmark/SizeInBytesColumn.cs
@@ -20,8 +20,7 @@ namespace ParquetSharp.Benchmark
             var instance = Activator.CreateInstance(type);
             var result = method.Invoke(instance, new object[0]);
 
-            // ReSharper disable once PossibleNullReferenceException
-            return ((long) result).ToString("N0");
+            return ((long) result!).ToString("N0");
         }
 
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,27 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
-    <AssemblyName>ParquetSharp.Test</AssemblyName>
-    <RootNamespace>ParquetSharp.Test</RootNamespace>
-    <Platforms>x64</Platforms>
-    <PlatformTarget>x64</PlatformTarget>
-    <GenerateProgramFile>false</GenerateProgramFile>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+		<LangVersion>8.0</LangVersion>
+		<Nullable>enable</Nullable>
+		<AssemblyName>ParquetSharp.Test</AssemblyName>
+		<RootNamespace>ParquetSharp.Test</RootNamespace>
+		<Platforms>x64</Platforms>
+		<PlatformTarget>x64</PlatformTarget>
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Parquet.Net" Version="3.8.6" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+		<PackageReference Include="Parquet.Net" Version="3.8.6" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\csharp\ParquetSharp.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\csharp\ParquetSharp.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,28 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-		<TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
-		<LangVersion>8.0</LangVersion>
-		<Nullable>enable</Nullable>
-		<AssemblyName>ParquetSharp.Test</AssemblyName>
-		<RootNamespace>ParquetSharp.Test</RootNamespace>
-		<Platforms>x64</Platforms>
-		<PlatformTarget>x64</PlatformTarget>
-		<GenerateProgramFile>false</GenerateProgramFile>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>ParquetSharp.Test</AssemblyName>
+    <RootNamespace>ParquetSharp.Test</RootNamespace>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-		<PackageReference Include="NUnit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-		<PackageReference Include="Parquet.Net" Version="3.8.6" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Parquet.Net" Version="3.8.6" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\csharp\ParquetSharp.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\csharp\ParquetSharp.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/csharp.test/TestAadPrefixVerifier.cs
+++ b/csharp.test/TestAadPrefixVerifier.cs
@@ -26,9 +26,9 @@ namespace ParquetSharp.Test
             GC.Collect();
 
             // At this point C# has no reference to the key-receiver. And yet we can still get it back from C++.
-            var aadPrefixVerifier = (TestVerifier) properties.AadPrefixVerifier;
+            var aadPrefixVerifier = (TestVerifier?) properties.AadPrefixVerifier;
 
-            Assert.AreEqual("HelloWorld Exception!", aadPrefixVerifier.ExceptionMessage);
+            Assert.AreEqual("HelloWorld Exception!", aadPrefixVerifier?.ExceptionMessage);
 
             // But after we return, both C# and C++ will lose all references and the aad-prefix-verifier should get GCed. 
             return new WeakReference(aadPrefixVerifier);

--- a/csharp.test/TestAesKey.cs
+++ b/csharp.test/TestAesKey.cs
@@ -10,7 +10,7 @@ namespace ParquetSharp.Test
         public static void TestIncorrectSize()
         {
             var exception = Assert.Throws<ArgumentException>(() => new AesKey(new byte[8]));
-            Assert.That(exception.Message, Contains.Substring("AES key can only be 128, 192, or 256-bit in length"));
+            Assert.That(exception?.Message, Contains.Substring("AES key can only be 128, 192, or 256-bit in length"));
         }
 
         [Test]

--- a/csharp.test/TestByteArrayReaderCache.cs
+++ b/csharp.test/TestByteArrayReaderCache.cs
@@ -67,7 +67,7 @@ namespace ParquetSharp.Test
 
         private sealed class StringReferenceComparer : EqualityComparer<string>
         {
-            public override bool Equals(string x, string y) => ReferenceEquals(x, y);
+            public override bool Equals(string? x, string? y) => ReferenceEquals(x, y);
             public override int GetHashCode(string obj) => RuntimeHelpers.GetHashCode(obj);
         }
     }

--- a/csharp.test/TestColumn.cs
+++ b/csharp.test/TestColumn.cs
@@ -45,7 +45,7 @@ namespace ParquetSharp.Test
             Assert.False(Column.IsSupported(typeof(TestColumn)));
 
             var exception = Assert.Throws<ArgumentException>(() => new Column<object>("unsupported").CreateSchemaNode());
-            Assert.AreEqual("unsupported logical type System.Object", exception.Message);
+            Assert.AreEqual("unsupported logical type System.Object", exception?.Message);
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace ParquetSharp.Test
                 new Column<DateTime>("DateTime", LogicalType.Json()).CreateSchemaNode());
 
             Assert.That(
-                exception.Message,
+                exception?.Message,
                 Contains.Substring("JSON can not be applied to primitive type INT64"));
         }
 
@@ -63,280 +63,238 @@ namespace ParquetSharp.Test
         {
             return new[]
             {
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(bool))
                 {
-                    Type = typeof(bool),
                     PhysicalType = PhysicalType.Boolean
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(sbyte))
                 {
-                    Type = typeof(sbyte),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(8, isSigned: true)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(byte))
                 {
-                    Type = typeof(byte),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(8, isSigned: false)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(short))
                 {
-                    Type = typeof(short),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(16, isSigned: true)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(ushort))
                 {
-                    Type = typeof(ushort),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(16, isSigned: false)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(int))
                 {
-                    Type = typeof(int),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(32, isSigned: true)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(uint))
                 {
-                    Type = typeof(uint),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(32, isSigned: false)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(long))
                 {
-                    Type = typeof(long),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Int(64, isSigned: true)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(ulong))
                 {
-                    Type = typeof(ulong),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Int(64, isSigned: false)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(float))
                 {
-                    Type = typeof(float),
                     PhysicalType = PhysicalType.Float
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(double))
                 {
-                    Type = typeof(double),
                     PhysicalType = PhysicalType.Double
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(decimal))
                 {
-                    Type = typeof(decimal),
                     PhysicalType = PhysicalType.FixedLenByteArray,
                     LogicalType = LogicalType.Decimal(29, 3),
                     LogicalTypeOverride = LogicalType.Decimal(29, 3),
                     Length = 16
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(Date))
                 {
-                    Type = typeof(Date),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Date()
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(DateTime))
                 {
-                    Type = typeof(DateTime),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Timestamp(true, TimeUnit.Micros)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(DateTime))
                 {
-                    Type = typeof(DateTime),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Timestamp(true, TimeUnit.Millis),
                     LogicalTypeOverride = LogicalType.Timestamp(true, TimeUnit.Millis)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(DateTimeNanos))
                 {
-                    Type = typeof(DateTimeNanos),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Timestamp(true, TimeUnit.Nanos)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(TimeSpan))
                 {
-                    Type = typeof(TimeSpan),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Time(true, TimeUnit.Micros)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(TimeSpan))
                 {
-                    Type = typeof(TimeSpan),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Time(true, TimeUnit.Millis),
                     LogicalTypeOverride = LogicalType.Time(true, TimeUnit.Millis)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(TimeSpanNanos))
                 {
-                    Type = typeof(TimeSpanNanos),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Time(true, TimeUnit.Nanos)
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(string))
                 {
-                    Type = typeof(string),
                     PhysicalType = PhysicalType.ByteArray,
                     LogicalType = LogicalType.String(),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(string))
                 {
-                    Type = typeof(string),
                     PhysicalType = PhysicalType.ByteArray,
                     LogicalType = LogicalType.Json(),
                     LogicalTypeOverride = LogicalType.Json(),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(byte[]))
                 {
-                    Type = typeof(byte[]),
                     PhysicalType = PhysicalType.ByteArray,
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(byte[]))
                 {
-                    Type = typeof(byte[]),
                     PhysicalType = PhysicalType.ByteArray,
                     LogicalType = LogicalType.Bson(),
                     LogicalTypeOverride = LogicalType.Bson(),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(bool?))
                 {
-                    Type = typeof(bool?),
                     PhysicalType = PhysicalType.Boolean,
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(sbyte?))
                 {
-                    Type = typeof(sbyte?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(8, isSigned: true),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(byte?))
                 {
-                    Type = typeof(byte?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(8, isSigned: false),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(short?))
                 {
-                    Type = typeof(short?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(16, isSigned: true),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(ushort?))
                 {
-                    Type = typeof(ushort?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(16, isSigned: false),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(int?))
                 {
-                    Type = typeof(int?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(32, isSigned: true),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(uint?))
                 {
-                    Type = typeof(uint?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Int(32, isSigned: false),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(long?))
                 {
-                    Type = typeof(long?),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Int(64, isSigned: true),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(ulong?))
                 {
-                    Type = typeof(ulong?),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Int(64, isSigned: false),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(float?))
                 {
-                    Type = typeof(float?),
                     PhysicalType = PhysicalType.Float,
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(double?))
                 {
-                    Type = typeof(double?),
                     PhysicalType = PhysicalType.Double,
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(decimal?))
                 {
-                    Type = typeof(decimal?),
                     PhysicalType = PhysicalType.FixedLenByteArray,
                     LogicalType = LogicalType.Decimal(29, 2),
                     LogicalTypeOverride = LogicalType.Decimal(29, 2),
                     Repetition = Repetition.Optional,
                     Length = 16
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(Date?))
                 {
-                    Type = typeof(Date?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Date(),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(DateTime?))
                 {
-                    Type = typeof(DateTime?),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Timestamp(true, TimeUnit.Micros),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(DateTime?))
                 {
-                    Type = typeof(DateTime?),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Timestamp(true, TimeUnit.Millis),
                     LogicalTypeOverride = LogicalType.Timestamp(true, TimeUnit.Millis),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(DateTimeNanos?))
                 {
-                    Type = typeof(DateTimeNanos?),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Timestamp(true, TimeUnit.Nanos),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(TimeSpan?))
                 {
-                    Type = typeof(TimeSpan?),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Time(true, TimeUnit.Micros),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(TimeSpan?))
                 {
-                    Type = typeof(TimeSpan?),
                     PhysicalType = PhysicalType.Int32,
                     LogicalType = LogicalType.Time(true, TimeUnit.Millis),
                     LogicalTypeOverride = LogicalType.Time(true, TimeUnit.Millis),
                     Repetition = Repetition.Optional
                 },
-                new ExpectedPrimitive
+                new ExpectedPrimitive(typeof(TimeSpanNanos?))
                 {
-                    Type = typeof(TimeSpanNanos?),
                     PhysicalType = PhysicalType.Int64,
                     LogicalType = LogicalType.Time(true, TimeUnit.Nanos),
                     Repetition = Repetition.Optional
@@ -346,7 +304,12 @@ namespace ParquetSharp.Test
 
         private sealed class ExpectedPrimitive
         {
-            public Type Type;
+            public ExpectedPrimitive(Type type)
+            {
+                Type = type;
+            }
+
+            public Type Type { get; }
             public LogicalType LogicalType = LogicalType.None();
             public LogicalType LogicalTypeOverride = LogicalType.None();
             public string Name = "MyName";

--- a/csharp.test/TestColumnWriter.cs
+++ b/csharp.test/TestColumnWriter.cs
@@ -46,7 +46,7 @@ namespace ParquetSharp.Test
             var exception = Assert.Throws<ArgumentException>(() => 
                 new ParquetFileWriter(outStream, new Column[] {new Column<object>("unsupported")}));
 
-            Assert.AreEqual("unsupported logical type System.Object", exception.Message);
+            Assert.AreEqual("unsupported logical type System.Object", exception?.Message);
         }
     }
 }

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -56,7 +56,7 @@ namespace ParquetSharp.Test
                 new Decimal128(1e+027M, multiplier: 100);
             });
 
-            Assert.AreEqual("value 1.000000E+027 is too large for decimal scale 2", exception.Message);
+            Assert.AreEqual("value 1.000000E+027 is too large for decimal scale 2", exception?.Message);
         }
 
         [Test]

--- a/csharp.test/TestDerivedKeyRetriever.cs
+++ b/csharp.test/TestDerivedKeyRetriever.cs
@@ -28,7 +28,8 @@ namespace ParquetSharp.Test
             // At this point C# has no reference to the key-receiver. And yet we can still get it back from C++.
             var keyReceiver = properties.KeyRetriever;
 
-            Assert.AreEqual("HelloWorld\0 Key!", System.Text.Encoding.ASCII.GetString(keyReceiver.GetKey("not-used")));
+            Assert.IsNotNull(keyReceiver);
+            Assert.AreEqual("HelloWorld\0 Key!", System.Text.Encoding.ASCII.GetString(keyReceiver!.GetKey("not-used")));
 
             // But after we return, both C# and C++ will lose all references and the key-receiver should get GCed. 
             return new WeakReference(keyReceiver);

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -296,7 +296,7 @@ namespace ParquetSharp.Test
              * None
              * [[]]
              */
-            double?[]?[]?[] expected = new double?[]?[]?[]
+            var expected = new double?[]?[]?[]
             {
                 new double?[]?[] {null, new double?[] { }, new double?[] {1.0, null, 2.0}},
                 new double?[]?[] { },

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -18,7 +18,9 @@ namespace ParquetSharp.Test
         )
         {
             var expectedColumns = CreateExpectedColumns();
-            var schemaColumns = expectedColumns.Select(c => new Column(c.Values.GetType().GetElementType(), c.Name, c.LogicalTypeOverride)).ToArray();
+            var schemaColumns = expectedColumns         
+                .Select(c => new Column(c.Values.GetType().GetElementType() ?? throw new InvalidOperationException(), c.Name, c.LogicalTypeOverride))
+                .ToArray();
 
             using var buffer = new ResizableBuffer();
 
@@ -56,7 +58,9 @@ namespace ParquetSharp.Test
         )
         {
             var expectedColumns = CreateExpectedColumns();
-            var schemaColumns = expectedColumns.Select(c => new Column(c.Values.GetType().GetElementType(), c.Name, c.LogicalTypeOverride)).ToArray();
+            var schemaColumns = expectedColumns
+                .Select(c => new Column(c.Values.GetType().GetElementType() ?? throw new InvalidOperationException(), c.Name, c.LogicalTypeOverride))
+                .ToArray();
 
             using var buffer = new ResizableBuffer();
 
@@ -147,18 +151,18 @@ namespace ParquetSharp.Test
 
                     if (expected.HasStatistics)
                     {
-                        Assert.AreEqual(expected.HasMinMax, statistics.HasMinMax);
-                        //Assert.AreEqual(expected.NullCount, statistics.NullCount);
-                        //Assert.AreEqual(expected.NumValues, statistics.NumValues);
-                        Assert.AreEqual(expected.PhysicalType, statistics.PhysicalType);
+                        Assert.AreEqual(expected.HasMinMax, statistics?.HasMinMax);
+                        //Assert.AreEqual(expected.NullCount, statistics?.NullCount);
+                        //Assert.AreEqual(expected.NumValues, statistics?.NumValues);
+                        Assert.AreEqual(expected.PhysicalType, statistics?.PhysicalType);
 
                         // BUG Don't check for decimal until https://issues.apache.org/jira/browse/ARROW-6149 is fixed.
                         var buggy = expected.LogicalType is DecimalLogicalType;
 
                         if (expected.HasMinMax && !buggy)
                         {
-                            Assert.AreEqual(expected.Min, expected.Converter(statistics.MinUntyped));
-                            Assert.AreEqual(expected.Max, expected.Converter(statistics.MaxUntyped));
+                            Assert.AreEqual(expected.Min, expected.Converter(statistics!.MinUntyped));
+                            Assert.AreEqual(expected.Max, expected.Converter(statistics!.MaxUntyped));
                         }
                     }
                     else
@@ -292,12 +296,12 @@ namespace ParquetSharp.Test
              * None
              * [[]]
              */
-            var expected = new double?[][][]
+            double?[]?[]?[] expected = new double?[]?[]?[]
             {
-                new double?[][] {null, new double?[] { }, new double?[] {1.0, null, 2.0}},
-                new double?[][] { },
+                new double?[]?[] {null, new double?[] { }, new double?[] {1.0, null, 2.0}},
+                new double?[]?[] { },
                 null,
-                new double?[][] {new double?[] { }}
+                new double?[]?[] {new double?[] { }}
             };
 
             using var buffer = new ResizableBuffer();
@@ -306,7 +310,7 @@ namespace ParquetSharp.Test
             {
                 using var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<double?[][]>("a")});
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
-                using var colWriter = rowGroupWriter.NextColumn().LogicalWriter<double?[][]>();
+                using var colWriter = rowGroupWriter.NextColumn().LogicalWriter<double?[]?[]?>();
 
                 colWriter.WriteBatch(expected);
 
@@ -876,7 +880,7 @@ namespace ParquetSharp.Test
                             };
                         }
 
-                        return new long[][]
+                        return new long[]?[]
                         {
                             null
                         };
@@ -914,7 +918,7 @@ namespace ParquetSharp.Test
                             };
                         }
 
-                        return new long?[][]
+                        return new long?[]?[]
                         {
                             null
                         };
@@ -950,7 +954,7 @@ namespace ParquetSharp.Test
                             };
                         }
 
-                        return new byte[][]
+                        return new byte[]?[]
                         {
                             null
                         };
@@ -966,8 +970,8 @@ namespace ParquetSharp.Test
 
         private sealed class ExpectedColumn
         {
-            public string Name;
-            public Array Values;
+            public string Name = ""; // TODO replace with init;
+            public Array Values = new object[0]; // TODO replace with init;
             public PhysicalType PhysicalType;
             public LogicalType LogicalType = LogicalType.None();
             public LogicalType LogicalTypeOverride = LogicalType.None();
@@ -975,8 +979,8 @@ namespace ParquetSharp.Test
 
             public bool HasStatistics = true;
             public bool HasMinMax = true;
-            public object Min;
-            public object Max;
+            public object? Min;
+            public object? Max;
             public long NullCount;
             public long NumValues = NumRows;
 

--- a/csharp.test/TestManagedRandomAccessFile.cs
+++ b/csharp.test/TestManagedRandomAccessFile.cs
@@ -80,7 +80,7 @@ namespace ParquetSharp.Test
             });
 
             Assert.That(
-                exception.Message,
+                exception?.Message,
                 Contains.Substring("this is an erroneous writer"));
         }
 
@@ -114,7 +114,7 @@ namespace ParquetSharp.Test
             });
 
             Assert.That(
-                exception.Message,
+                exception?.Message,
                 Contains.Substring("this is an erroneous reader"));
         }
 

--- a/csharp.test/TestNode.cs
+++ b/csharp.test/TestNode.cs
@@ -198,7 +198,7 @@ namespace ParquetSharp.Test
         private string _groupName = "root";
         private PhysicalType _physicalType = PhysicalType.Int32;
         private LogicalType _primitiveLogicalType = LogicalType.Int(32, true);
-        private LogicalType _groupLogicalType = null;
+        private LogicalType? _groupLogicalType = null;
         private Repetition _primitiveRepetition = Repetition.Required;
         private Repetition _groupRepetition = Repetition.Required;
         private int _length = 16;

--- a/csharp.test/TestParquetFileReader.cs
+++ b/csharp.test/TestParquetFileReader.cs
@@ -21,7 +21,7 @@ namespace ParquetSharp.Test
                 " (message: 'IOError: Failed to open local file 'non_existent.parquet'. Detail: " +
                 (isUnix ? "[errno 2] No such file or directory" : "[Windows error 2] The system cannot find the file specified." + Environment.NewLine) +
                 "')",
-                exception.Message);
+                exception?.Message);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace ParquetSharp.Test
                 "Unable to cast object of type " +
                 "'ParquetSharp.LogicalColumnReader`3[System.Int32,System.Int32,System.Int32]'" +
                 " to type 'ParquetSharp.LogicalColumnReader`1[System.Single]'.",
-                exception.Message);
+                exception?.Message);
         }
 
         [Test]
@@ -143,7 +143,7 @@ namespace ParquetSharp.Test
             Console.WriteLine("FINISHED");
         }
 
-        private static string ToString(object value)
+        private static string? ToString(object? value)
         {
             if (value is null)
             {

--- a/csharp.test/TestParquetFileWriter.cs
+++ b/csharp.test/TestParquetFileWriter.cs
@@ -88,10 +88,10 @@ namespace ParquetSharp.Test
             //Assert.AreEqual(0, fileWriter.NumRows); // 2021-04-08: calling this results in a segfault when the writer has been closed
             //Assert.AreEqual(1, fileWriter.NumRowGroups); // 2021-04-08: calling this results in a segfault when the writer has been closed
             Assert.IsNotNull(fileWriter.FileMetaData);
-            Assert.AreEqual(2, fileWriter.FileMetaData.NumColumns);
-            Assert.AreEqual(6, fileWriter.FileMetaData.NumRows);
-            Assert.AreEqual(1, fileWriter.FileMetaData.NumRowGroups);
-            Assert.AreEqual(kvm, fileWriter.FileMetaData.KeyValueMetadata);
+            Assert.AreEqual(2, fileWriter.FileMetaData?.NumColumns);
+            Assert.AreEqual(6, fileWriter.FileMetaData?.NumRows);
+            Assert.AreEqual(1, fileWriter.FileMetaData?.NumRowGroups);
+            Assert.AreEqual(kvm, fileWriter.FileMetaData?.KeyValueMetadata);
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace ParquetSharp.Test
             fileWriter.Dispose();
 
             var exception = Assert.Throws<NullReferenceException>(() => fileWriter.AppendRowGroup());
-            Assert.AreEqual("null native handle", exception.Message);
+            Assert.AreEqual("null native handle", exception?.Message);
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace ParquetSharp.Test
                 throw new Exception("this is the expected message");
             });
 
-            Assert.That(exception.Message, Contains.Substring("this is the expected message"));
+            Assert.That(exception?.Message, Contains.Substring("this is the expected message"));
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace ParquetSharp.Test
                 throw new Exception("this is the expected message");
             });
 
-            Assert.That(exception.Message, Contains.Substring("this is the expected message"));
+            Assert.That(exception?.Message, Contains.Substring("this is the expected message"));
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace ParquetSharp.Test
                 }
             });
 
-            Assert.That(exception.Message, Contains.Substring("this is the expected message"));
+            Assert.That(exception?.Message, Contains.Substring("this is the expected message"));
         }
 
         [Test]

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -234,8 +234,8 @@ namespace ParquetSharp.Test
 
         private sealed class ExpectedColumn
         {
-            public string Name;
-            public Array Values;
+            public string Name = ""; // TODO replace with init;
+            public Array Values = new object[0]; // TODO replace with init;
 
             public int MaxDefinitionlevel = 0;
             public int MaxRepetitionLevel = 0;

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -178,7 +178,7 @@ namespace ParquetSharp.Test
             RoundTripAndCompare(rows, expectedRows, columnNames: null);
         }
 
-        private static void RoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[] columnNames)
+        private static void RoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[]? columnNames)
         {
             using var buffer = new ResizableBuffer();
 
@@ -206,7 +206,7 @@ namespace ParquetSharp.Test
             [ParquetDecimalScale(3)]
             public decimal D;
 
-            public bool Equals(Row1 other)
+            public bool Equals(Row1? other)
             {
                 if (ReferenceEquals(null, other)) return false;
                 if (ReferenceEquals(this, other)) return true;

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -173,7 +173,7 @@ namespace ParquetSharp.Test
         private static void TestRoundtripMapped<TTupleWrite, TTupleRead>(TTupleWrite[] rows)
         {
             var expectedRows = rows.Select(
-                i => (TTupleRead) Activator.CreateInstance(typeof(TTupleRead), i)
+                r => (TTupleRead) (Activator.CreateInstance(typeof(TTupleRead), r) ?? throw new Exception("create instance failed"))
             );
             RoundTripAndCompare(rows, expectedRows, columnNames: null);
         }

--- a/csharp/AadPrefixVerifier.cs
+++ b/csharp/AadPrefixVerifier.cs
@@ -30,7 +30,7 @@ namespace ParquetSharp
         }
 
         internal delegate void FreeGcHandleFunc(IntPtr handle);
-        internal delegate void VerifyFunc(IntPtr handle, IntPtr aadPrefix, out string exception);
+        internal delegate void VerifyFunc(IntPtr handle, IntPtr aadPrefix, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
 
         internal static readonly FreeGcHandleFunc FreeGcHandleCallback = FreeGcHandle;
         internal static readonly VerifyFunc VerifyFuncCallback = Verify;
@@ -40,13 +40,13 @@ namespace ParquetSharp
             GCHandle.FromIntPtr(handle).Free();
         }
 
-        private static void Verify(IntPtr handle, IntPtr aadPrefix, out string exception)
+        private static void Verify(IntPtr handle, IntPtr aadPrefix, out string? exception)
         {
             exception = null;
 
             try
             {
-                var obj = (AadPrefixVerifier)GCHandle.FromIntPtr(handle).Target;
+                var obj = (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target;
                 var aadPrefixStr = Marshal.PtrToStringAnsi(aadPrefix);
                 obj.Verify(aadPrefixStr);
             }

--- a/csharp/BufferedReader.cs
+++ b/csharp/BufferedReader.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     /// </summary>
     internal sealed class BufferedReader<TPhysicalvalue> where TPhysicalvalue : unmanaged
     {
-        public BufferedReader(ColumnReader reader, TPhysicalvalue[] values, short[] defLevels, short[] repLevels)
+        public BufferedReader(ColumnReader reader, TPhysicalvalue[] values, short[]? defLevels, short[]? repLevels)
         {
             _columnReader = reader;
             _values = values;
@@ -30,6 +30,9 @@ namespace ParquetSharp
 
         public (short DefLevel, short RepLevel) GetCurrentDefinition()
         {
+            if (_defLevels == null) throw new InvalidOperationException("definition levels not defined");
+            if (_repLevels == null) throw new InvalidOperationException("repetition levels not defined");
+
             if (_levelIndex >= _numLevels)
             {
                 if (!FillBuffer())
@@ -69,8 +72,8 @@ namespace ParquetSharp
 
         private readonly ColumnReader _columnReader;
         private readonly TPhysicalvalue[] _values;
-        private readonly short[] _defLevels;
-        private readonly short[] _repLevels;
+        private readonly short[]? _defLevels;
+        private readonly short[]? _repLevels;
 
         private long _numValues;
         private int _valueIndex;

--- a/csharp/ByteArrayReaderCache.cs
+++ b/csharp/ByteArrayReaderCache.cs
@@ -27,12 +27,14 @@ namespace ParquetSharp
 
         public void Clear()
         {
+            if (_map == null) throw new InvalidOperationException("cache is not in a usable state");
             _map.Clear();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TLogical Add(TPhysical physical, TLogical logical)
         {
+            if (_map == null) throw new InvalidOperationException("cache is not in a usable state");
             _map.Add(physical, logical);
             return logical;
         }
@@ -40,6 +42,7 @@ namespace ParquetSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(TPhysical physical, out TLogical logical)
         {
+            if (_map == null) throw new InvalidOperationException("cache is not in a usable state");
             return _map.TryGetValue(physical, out logical);
         }
 
@@ -49,7 +52,7 @@ namespace ParquetSharp
             return _scratch.Length >= minLength ? _scratch : _scratch = new byte[Math.Max(_scratch.Length * 2, minLength)];
         }
 
-        private readonly Dictionary<TPhysical, TLogical> _map;
+        private readonly Dictionary<TPhysical, TLogical>? _map;
         private byte[] _scratch;
     }
 }

--- a/csharp/ColumnChunkMetaData.cs
+++ b/csharp/ColumnChunkMetaData.cs
@@ -17,7 +17,7 @@ namespace ParquetSharp
 
         public Compression Compression => ExceptionInfo.Return<Compression>(_handle, ColumnChunkMetaData_Compression);
 
-        public ColumnCryptoMetaData CryptoMetadata
+        public ColumnCryptoMetaData? CryptoMetadata
         {
             get
             {
@@ -48,7 +48,7 @@ namespace ParquetSharp
         public long NumValues => ExceptionInfo.Return<long>(_handle, ColumnChunkMetaData_Num_Values);
         public long TotalCompressedSize => ExceptionInfo.Return<long>(_handle, ColumnChunkMetaData_Total_Compressed_Size);
         public long TotalUncompressedSize => ExceptionInfo.Return<long>(_handle, ColumnChunkMetaData_Total_Uncompressed_Size);
-        public Statistics Statistics => Statistics.Create(ExceptionInfo.Return<IntPtr>(_handle, ColumnChunkMetaData_Statistics));
+        public Statistics? Statistics => Statistics.Create(ExceptionInfo.Return<IntPtr>(_handle, ColumnChunkMetaData_Statistics));
         public PhysicalType Type => ExceptionInfo.Return<PhysicalType>(_handle, ColumnChunkMetaData_Type);
         
         [DllImport(ParquetDll.Name)]

--- a/csharp/ColumnDescriptor.cs
+++ b/csharp/ColumnDescriptor.cs
@@ -23,7 +23,7 @@ namespace ParquetSharp
         public short MaxRepetitionLevel => ExceptionInfo.Return<short>(_handle, ColumnDescriptor_Max_Repetition_Level);
         public string Name => Marshal.PtrToStringAnsi(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Name));
         public Schema.ColumnPath Path => new Schema.ColumnPath(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Path));
-        public Schema.Node SchemaNode => Schema.Node.Create(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Schema_Node));
+        public Schema.Node SchemaNode => Schema.Node.Create(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Schema_Node)) ?? throw new InvalidOperationException();
         public PhysicalType PhysicalType => ExceptionInfo.Return<PhysicalType>(_handle, ColumnDescriptor_Physical_Type);
         public SortOrder SortOrder => ExceptionInfo.Return<SortOrder>(_handle, ColumnDescriptor_SortOrder);
         public int TypeLength => ExceptionInfo.Return<int>(_handle, ColumnDescriptor_Type_Length);

--- a/csharp/DecryptionKeyRetriever.cs
+++ b/csharp/DecryptionKeyRetriever.cs
@@ -29,7 +29,7 @@ namespace ParquetSharp
         }
 
         internal delegate void FreeGcHandleFunc(IntPtr handle);
-        internal delegate void GetKeyFunc(IntPtr handle, IntPtr keyMetadata, out AesKey key, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        internal delegate void GetKeyFunc(IntPtr handle, IntPtr keyMetadata, out AesKey key, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
 
         internal static readonly FreeGcHandleFunc FreeGcHandleCallback = FreeGcHandle;
         internal static readonly GetKeyFunc GetKeyFuncCallback = GetKey;
@@ -39,7 +39,7 @@ namespace ParquetSharp
             GCHandle.FromIntPtr(handle).Free();
         }
 
-        private static void GetKey(IntPtr handle, IntPtr keyMetadata, out AesKey key, out string exception)
+        private static void GetKey(IntPtr handle, IntPtr keyMetadata, out AesKey key, out string? exception)
         {
             exception = null;
 

--- a/csharp/ExceptionInfo.cs
+++ b/csharp/ExceptionInfo.cs
@@ -81,26 +81,26 @@ namespace ParquetSharp
             return value;
         }
 
-        public static string ReturnString(IntPtr handle, GetFunction<IntPtr> getter, Action<IntPtr> deleter = null)
+        public static string ReturnString(IntPtr handle, GetFunction<IntPtr> getter, Action<IntPtr>? deleter = null)
         {
             Check(getter(handle, out var value));
             return ConvertPtrToString(handle, deleter, value);
         }
 
-        public static string ReturnString(ParquetHandle handle, GetFunction<IntPtr> getter, Action<IntPtr> deleter = null)
+        public static string ReturnString(ParquetHandle handle, GetFunction<IntPtr> getter, Action<IntPtr>? deleter = null)
         {
             Check(getter(handle.IntPtr, out var value));
             return ConvertPtrToString(handle, deleter, value);
         }
 
-        private static string ConvertPtrToString(IntPtr handle, Action<IntPtr> deleter, IntPtr value)
+        private static string ConvertPtrToString(IntPtr handle, Action<IntPtr>? deleter, IntPtr value)
         {
             var str = Marshal.PtrToStringAnsi(value);
             deleter?.Invoke(value);
             return str;
         }
 
-        private static string ConvertPtrToString(ParquetHandle handle, Action<IntPtr> deleter, IntPtr value)
+        private static string ConvertPtrToString(ParquetHandle handle, Action<IntPtr>? deleter, IntPtr value)
         {
             var str = Marshal.PtrToStringAnsi(value);
             deleter?.Invoke(value);

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -24,7 +24,7 @@ namespace ParquetSharp
         public bool CheckPlaintextFooterIntegrity => ExceptionInfo.Return<bool>(Handle, FileDecryptionProperties_Check_Plaintext_Footer_Integrity);
         public bool PlaintextFilesAllowed => ExceptionInfo.Return<bool>(Handle, FileDecryptionProperties_Plaintext_Files_Allowed);
 
-        public DecryptionKeyRetriever KeyRetriever
+        public DecryptionKeyRetriever? KeyRetriever
         {
             get
             {
@@ -33,7 +33,7 @@ namespace ParquetSharp
             }
         }
 
-        public AadPrefixVerifier AadPrefixVerifier
+        public AadPrefixVerifier? AadPrefixVerifier
         {
             get
             {

--- a/csharp/FileMetaData.cs
+++ b/csharp/FileMetaData.cs
@@ -29,10 +29,8 @@ namespace ParquetSharp
                     return new Dictionary<string, string>();
                 }
 
-                using (var keyValueMetadata = new KeyValueMetadata(kvmHandle))
-                {
-                    return keyValueMetadata.ToDictionary();
-                }
+                using var keyValueMetadata = new KeyValueMetadata(kvmHandle);
+                return keyValueMetadata.ToDictionary();
             }
         }
 
@@ -40,12 +38,12 @@ namespace ParquetSharp
         public long NumRows => ExceptionInfo.Return<long>(_handle, FileMetaData_Num_Rows);
         public int NumRowGroups => ExceptionInfo.Return<int>(_handle, FileMetaData_Num_Row_Groups);
         public int NumSchemaElements => ExceptionInfo.Return<int>(_handle, FileMetaData_Num_Schema_Elements);
-        public SchemaDescriptor Schema => _schema ?? (_schema = new SchemaDescriptor(ExceptionInfo.Return<IntPtr>(_handle, FileMetaData_Schema)));
+        public SchemaDescriptor Schema => _schema ??= new SchemaDescriptor(ExceptionInfo.Return<IntPtr>(_handle, FileMetaData_Schema));
         public int Size => ExceptionInfo.Return<int>(_handle, FileMetaData_Size);
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(_handle, FileMetaData_Version);
         public ApplicationVersion WriterVersion => new ApplicationVersion(ExceptionInfo.Return<AppVer>(_handle, FileMetaData_Writer_Version));
 
-        public bool Equals(FileMetaData other)
+        public bool Equals(FileMetaData? other)
         {
             return other != null && ExceptionInfo.Return<bool>(_handle, other._handle, FileMetaData_Equals);
         }
@@ -87,6 +85,6 @@ namespace ParquetSharp
         private static extern IntPtr FileMetaData_Writer_Version(IntPtr fileMetaData, out AppVer applicationVersion);
 
         private readonly ParquetHandle _handle;
-        private SchemaDescriptor _schema;
+        private SchemaDescriptor? _schema;
     }
 }

--- a/csharp/IO/BufferOutputStream.cs
+++ b/csharp/IO/BufferOutputStream.cs
@@ -20,7 +20,7 @@ namespace ParquetSharp.IO
 
         public Buffer Finish()
         {
-            return new Buffer(ExceptionInfo.Return<IntPtr>(Handle, BufferOutputStream_Finish));
+            return new Buffer(ExceptionInfo.Return<IntPtr>(Handle!, BufferOutputStream_Finish));
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/IO/ManagedOutputStream.cs
+++ b/csharp/IO/ManagedOutputStream.cs
@@ -38,7 +38,7 @@ namespace ParquetSharp.IO
             return new ParquetHandle(handle, OutputStream_Free);
         }
 
-        private byte Write(IntPtr src, long nbytes, out string exception)
+        private byte Write(IntPtr src, long nbytes, out string? exception)
         {
             try
             {
@@ -73,7 +73,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte Tell(IntPtr position, out string exception)
+        private byte Tell(IntPtr position, out string? exception)
         {
             try
             {
@@ -87,7 +87,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte Flush(out string exception)
+        private byte Flush(out string? exception)
         {
             try
             {
@@ -101,7 +101,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte Close(out string exception)
+        private byte Close(out string? exception)
         {
             try
             {
@@ -131,7 +131,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte HandleException(Exception error, out string exception)
+        private byte HandleException(Exception error, out string? exception)
         {
             if (error is OutOfMemoryException)
             {
@@ -158,10 +158,10 @@ namespace ParquetSharp.IO
             out IntPtr outputStream);
 
 
-        private delegate byte WriteDelegate(IntPtr buffer, long nbyte, [MarshalAs(UnmanagedType.LPStr)] out string exception);
-        private delegate byte TellDelegate(IntPtr position, [MarshalAs(UnmanagedType.LPStr)] out string exception);
-        private delegate byte FlushDelegate([MarshalAs(UnmanagedType.LPStr)] out string exception);
-        private delegate byte CloseDelegate([MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private delegate byte WriteDelegate(IntPtr buffer, long nbyte, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
+        private delegate byte TellDelegate(IntPtr position, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
+        private delegate byte FlushDelegate([MarshalAs(UnmanagedType.LPStr)] out string? exception);
+        private delegate byte CloseDelegate([MarshalAs(UnmanagedType.LPStr)] out string? exception);
         private delegate bool ClosedDelegate();
 
         private readonly Stream _stream;
@@ -178,7 +178,7 @@ namespace ParquetSharp.IO
 
         // The lifetime of the exception message must match the lifetime of this class.
         // ReSharper disable NotAccessedField.Local
-        private string _exceptionMessage;
+        private string? _exceptionMessage;
         // ReSharper restore NotAccessedField.Local
     }
 }

--- a/csharp/IO/ManagedRandomAccessFile.cs
+++ b/csharp/IO/ManagedRandomAccessFile.cs
@@ -40,7 +40,7 @@ namespace ParquetSharp.IO
             return new ParquetHandle(handle, RandomAccessFile_Free);
         }
 
-        private byte Read(long nbytes, IntPtr bytesRead, IntPtr dest, out string exception)
+        private byte Read(long nbytes, IntPtr bytesRead, IntPtr dest, out string? exception)
         {
             try
             {
@@ -65,7 +65,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte Close(out string exception)
+        private byte Close(out string? exception)
         {
             try
             {
@@ -83,7 +83,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte GetSize(IntPtr size, out string exception)
+        private byte GetSize(IntPtr size, out string? exception)
         {
             try
             {
@@ -97,7 +97,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte Tell(IntPtr position, out string exception)
+        private byte Tell(IntPtr position, out string? exception)
         {
             try
             {
@@ -111,7 +111,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte Seek(long position, out string exception)
+        private byte Seek(long position, out string? exception)
         {
             try
             {
@@ -137,7 +137,7 @@ namespace ParquetSharp.IO
             }
         }
 
-        private byte HandleException(Exception error, out string exception)
+        private byte HandleException(Exception error, out string? exception)
         {
             if (error is OutOfMemoryException)
             {
@@ -164,11 +164,11 @@ namespace ParquetSharp.IO
             ClosedDelegate closed,
             out IntPtr randomAccessFile);
 
-        private delegate byte ReadDelegate(long nbyte, IntPtr bytesRead, IntPtr dest, [MarshalAs(UnmanagedType.LPStr)] out string exception);
-        private delegate byte CloseDelegate([MarshalAs(UnmanagedType.LPStr)] out string exception);
-        private delegate byte GetSizeDelegate(IntPtr size, [MarshalAs(UnmanagedType.LPStr)] out string exception);
-        private delegate byte TellDelegate(IntPtr position, [MarshalAs(UnmanagedType.LPStr)] out string exception);
-        private delegate byte SeekDelegate(long position, [MarshalAs(UnmanagedType.LPStr)] out string exception);
+        private delegate byte ReadDelegate(long nbyte, IntPtr bytesRead, IntPtr dest, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
+        private delegate byte CloseDelegate([MarshalAs(UnmanagedType.LPStr)] out string? exception);
+        private delegate byte GetSizeDelegate(IntPtr size, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
+        private delegate byte TellDelegate(IntPtr position, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
+        private delegate byte SeekDelegate(long position, [MarshalAs(UnmanagedType.LPStr)] out string? exception);
         private delegate bool ClosedDelegate();
 
         private readonly Stream _stream;
@@ -186,7 +186,7 @@ namespace ParquetSharp.IO
 
         // The lifetime of the exception message must match the lifetime of this class.
         // ReSharper disable NotAccessedField.Local
-        private string _exceptionMessage;
+        private string? _exceptionMessage;
         // ReSharper restore NotAccessedField.Local
     }
 }

--- a/csharp/IO/OutputStream.cs
+++ b/csharp/IO/OutputStream.cs
@@ -27,6 +27,6 @@ namespace ParquetSharp.IO
         [DllImport(ParquetDll.Name)]
         internal static extern void OutputStream_Free(IntPtr outputStream);
 
-        internal ParquetHandle Handle;
+        internal ParquetHandle? Handle;
     }
 }

--- a/csharp/IO/RandomAccessFile.cs
+++ b/csharp/IO/RandomAccessFile.cs
@@ -27,6 +27,6 @@ namespace ParquetSharp.IO
         [DllImport(ParquetDll.Name)]
         internal static extern void RandomAccessFile_Free(IntPtr randomAccessFile);
 
-        internal ParquetHandle Handle;
+        internal ParquetHandle? Handle;
     }
 }

--- a/csharp/LogicalColumnReader.cs
+++ b/csharp/LogicalColumnReader.cs
@@ -119,7 +119,8 @@ namespace ParquetSharp
         internal LogicalColumnReader(ColumnReader columnReader, int bufferLength)
             : base(columnReader, bufferLength)
         {
-            ByteArrayReaderCache<TPhysical, TLogical> byteArrayCache = new ByteArrayReaderCache<TPhysical, TLogical>(columnReader.ColumnChunkMetaData);
+            var byteArrayCache = new ByteArrayReaderCache<TPhysical, TLogical>(columnReader.ColumnChunkMetaData);
+
             _bufferedReader = new BufferedReader<TPhysical>(Source, (TPhysical[]) Buffer, DefLevels, RepLevels);
             _directReader = LogicalRead<TLogical, TPhysical>.GetDirectReader();
             _converter = LogicalRead<TLogical, TPhysical>.GetConverter(LogicalType, ColumnDescriptor.TypeScale, byteArrayCache);

--- a/csharp/LogicalColumnStream.cs
+++ b/csharp/LogicalColumnStream.cs
@@ -31,9 +31,9 @@ namespace ParquetSharp
         private static List<Schema.Node> GetSchemaNode(Schema.Node node)
         {
             var schemaNodes = new List<Schema.Node>();
-            for (; node != null; node = node.Parent)
+            for (var n = node; n != null; n = n.Parent)
             {
-                schemaNodes.Add(node);
+                schemaNodes.Add(n);
             }
             schemaNodes.RemoveAt(schemaNodes.Count - 1); // we don't need the schema root
             schemaNodes.Reverse(); // root to leaf
@@ -46,9 +46,9 @@ namespace ParquetSharp
         public LogicalType LogicalType { get; }
 
         protected readonly Array Buffer;
-        protected readonly short[] DefLevels;
-        protected readonly short[] RepLevels;
+        protected readonly short[]? DefLevels;
+        protected readonly short[]? RepLevels;
 
-        protected readonly Schema.Node[] ArraySchemaNodes;
+        protected readonly Schema.Node[]? ArraySchemaNodes;
     }
 }

--- a/csharp/LogicalColumnWriter.cs
+++ b/csharp/LogicalColumnWriter.cs
@@ -111,7 +111,7 @@ namespace ParquetSharp
             }
             else
             {
-                WriteBatchSimple(values, converter as LogicalWrite<TElement, TPhysical>.Converter);
+                WriteBatchSimple(values, (converter as LogicalWrite<TElement, TPhysical>.Converter)!);
             }
         }
 
@@ -119,9 +119,9 @@ namespace ParquetSharp
         {
             if (elementType.IsArray && elementType != typeof(byte[]))
             {
-                if (schemaNodes.Length >= 2
-                    && (schemaNodes[0] is GroupNode g1) && g1.LogicalType is ListLogicalType && g1.Repetition == Repetition.Optional
-                    && (schemaNodes[1] is GroupNode g2) && g2.LogicalType is NoneLogicalType && g2.Repetition == Repetition.Repeated)
+                if (schemaNodes.Length >= 2 && 
+                    schemaNodes[0] is GroupNode {LogicalType: ListLogicalType _, Repetition: Repetition.Optional} &&
+                    schemaNodes[1] is GroupNode {LogicalType: NoneLogicalType _, Repetition: Repetition.Repeated})
                 {
                     var containedType = elementType.GetElementType();
 
@@ -204,7 +204,8 @@ namespace ParquetSharp
             ReadOnlySpan<TLogical> valuesSpan = (TLogical[])values;
 
             if (converter == null) throw new ArgumentNullException(nameof(converter));
-            if (DefLevels == null) throw new ArgumentException("internal error: DefLevels should not be null.");
+            if (DefLevels == null) throw new InvalidOperationException("DefLevels should not be null.");
+            if (RepLevels == null) throw new InvalidOperationException("RepLevels should not be null.");
 
             var rowsWritten = 0;
             var columnWriter = (ColumnWriter<TPhysical>) Source;
@@ -266,6 +267,6 @@ namespace ParquetSharp
             }
         }
 
-        private readonly ByteBuffer _byteBuffer;
+        private readonly ByteBuffer? _byteBuffer;
     }
 }

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -13,7 +13,7 @@ namespace ParquetSharp
         public delegate long DirectReader(ColumnReader<TPhysical> columnReader, Span<TLogical> destination);
         public delegate void Converter(ReadOnlySpan<TPhysical> source, ReadOnlySpan<short> defLevels, Span<TLogical> destination, short nullLevel);
 
-        public static DirectReader GetDirectReader()
+        public static DirectReader? GetDirectReader()
         {
             long Read<TPhys>(ColumnReader<TPhys> r, Span<TPhys> d) where TPhys : unmanaged
             {
@@ -235,8 +235,8 @@ namespace ParquetSharp
             if (typeof(TLogical) == typeof(string))
             {
                 return byteArrayCache.IsUsable
-                    ? (Converter) (Delegate) (LogicalRead<string, ByteArray>.Converter) ((s, dl, d, nl) => ConvertString(s, dl, d, nl, (ByteArrayReaderCache<ByteArray, string>) (object) byteArrayCache)) 
-                    : (Converter) (Delegate) (LogicalRead<string, ByteArray>.Converter) ConvertString;
+                    ? (Converter) (Delegate) (LogicalRead<string?, ByteArray>.Converter) ((s, dl, d, nl) => ConvertString(s, dl, d, nl, (ByteArrayReaderCache<ByteArray, string>) (object) byteArrayCache)) 
+                    : (Converter) (Delegate) (LogicalRead<string?, ByteArray>.Converter) ConvertString;
             }
 
             if (typeof(TLogical) == typeof(byte[]))
@@ -248,7 +248,7 @@ namespace ParquetSharp
                 //    ? (Converter) (Delegate) (LogicalRead<byte[], ByteArray>.Converter) ((s, dl, d, nl) => ConvertByteArray(s, dl, d, nl, (ByteArrayReaderCache<ByteArray, byte[]>) (object) byteArrayCache))
                 //    : (Converter) (Delegate) (LogicalRead<byte[], ByteArray>.Converter) ConvertByteArray;
                 
-                return (Converter) (Delegate) (LogicalRead<byte[], ByteArray>.Converter) ConvertByteArray;
+                return (Converter) (Delegate) (LogicalRead<byte[]?, ByteArray>.Converter) ConvertByteArray;
             }
 
             throw new NotSupportedException($"unsupported logical system type {typeof(TLogical)} with logical type {logicalType}");
@@ -431,7 +431,7 @@ namespace ParquetSharp
             }
         }
 
-        private static void ConvertString(ReadOnlySpan<ByteArray> source, ReadOnlySpan<short> defLevels, Span<string> destination, short nullLevel, ByteArrayReaderCache<ByteArray, string> byteArrayCache)
+        private static void ConvertString(ReadOnlySpan<ByteArray> source, ReadOnlySpan<short> defLevels, Span<string?> destination, short nullLevel, ByteArrayReaderCache<ByteArray, string> byteArrayCache)
         {
             for (int i = 0, src = 0; i < destination.Length; ++i)
             {
@@ -439,7 +439,7 @@ namespace ParquetSharp
             }
         }
 
-        private static void ConvertString(ReadOnlySpan<ByteArray> source, ReadOnlySpan<short> defLevels, Span<string> destination, short nullLevel)
+        private static void ConvertString(ReadOnlySpan<ByteArray> source, ReadOnlySpan<short> defLevels, Span<string?> destination, short nullLevel)
         {
             for (int i = 0, src = 0; i < destination.Length; ++i)
             {
@@ -447,7 +447,7 @@ namespace ParquetSharp
             }
         }
 
-        private static void ConvertByteArray(ReadOnlySpan<ByteArray> source, ReadOnlySpan<short> defLevels, Span<byte[]> destination, short nullLevel)
+        private static void ConvertByteArray(ReadOnlySpan<ByteArray> source, ReadOnlySpan<short> defLevels, Span<byte[]?> destination, short nullLevel)
         {
             for (int i = 0, src = 0; i < destination.Length; ++i)
             {

--- a/csharp/LogicalType.cs
+++ b/csharp/LogicalType.cs
@@ -38,7 +38,7 @@ namespace ParquetSharp
 
         public LogicalTypeEnum Type => ExceptionInfo.Return<LogicalTypeEnum>(Handle, LogicalType_Type);
 
-        public bool Equals(LogicalType other)
+        public bool Equals(LogicalType? other)
         {
             if (other == null) return false;
             if (Handle.IntPtr == IntPtr.Zero || other.Handle.IntPtr == IntPtr.Zero) return false;
@@ -74,48 +74,31 @@ namespace ParquetSharp
         {
             if (handle == IntPtr.Zero)
             {
-                return null;
+                throw new ArgumentNullException(nameof(handle));
             }
 
             var type = ExceptionInfo.Return<LogicalTypeEnum>(handle, LogicalType_Type);
 
-            switch (type)
+            return type switch
             {
-                case LogicalTypeEnum.String:
-                    return new StringLogicalType(handle);
-                case LogicalTypeEnum.Map:
-                    return new MapLogicalType(handle);
-                case LogicalTypeEnum.List:
-                    return new ListLogicalType(handle);
-                case LogicalTypeEnum.Enum:
-                    return new EnumLogicalType(handle);
-                case LogicalTypeEnum.Decimal:
-                    return new DecimalLogicalType(handle);
-                case LogicalTypeEnum.Date:
-                    return new DateLogicalType(handle);
-                case LogicalTypeEnum.Time:
-                    return new TimeLogicalType(handle);
-                case LogicalTypeEnum.Timestamp:
-                    return new TimestampLogicalType(handle);
-                case LogicalTypeEnum.Interval:
-                    return new IntervalLogicalType(handle);
-                case LogicalTypeEnum.Int:
-                    return new IntLogicalType(handle);
-                case LogicalTypeEnum.Nil:
-                    return new NullLogicalType(handle);
-                case LogicalTypeEnum.Json:
-                    return new JsonLogicalType(handle);
-                case LogicalTypeEnum.Bson:
-                    return new BsonLogicalType(handle);
-                case LogicalTypeEnum.Uuid:
-                    return new UuidLogicalType(handle);
-                case LogicalTypeEnum.None:
-                    return new NoneLogicalType(handle);
-                case LogicalTypeEnum.Unknown:
-                    return new UnknownLogicalType(handle);
-                default:
-                    throw new ArgumentOutOfRangeException($"unknown logical type {type}");
-            }
+                LogicalTypeEnum.String => new StringLogicalType(handle),
+                LogicalTypeEnum.Map => new MapLogicalType(handle),
+                LogicalTypeEnum.List => new ListLogicalType(handle),
+                LogicalTypeEnum.Enum => new EnumLogicalType(handle),
+                LogicalTypeEnum.Decimal => new DecimalLogicalType(handle),
+                LogicalTypeEnum.Date => new DateLogicalType(handle),
+                LogicalTypeEnum.Time => new TimeLogicalType(handle),
+                LogicalTypeEnum.Timestamp => new TimestampLogicalType(handle),
+                LogicalTypeEnum.Interval => new IntervalLogicalType(handle),
+                LogicalTypeEnum.Int => new IntLogicalType(handle),
+                LogicalTypeEnum.Nil => new NullLogicalType(handle),
+                LogicalTypeEnum.Json => new JsonLogicalType(handle),
+                LogicalTypeEnum.Bson => new BsonLogicalType(handle),
+                LogicalTypeEnum.Uuid => new UuidLogicalType(handle),
+                LogicalTypeEnum.None => new NoneLogicalType(handle),
+                LogicalTypeEnum.Unknown => new UnknownLogicalType(handle),
+                _ => throw new ArgumentOutOfRangeException($"unknown logical type {type}")
+            };
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/LogicalWrite.cs
+++ b/csharp/LogicalWrite.cs
@@ -13,7 +13,7 @@ namespace ParquetSharp
     {
         public delegate void Converter(ReadOnlySpan<TLogical> source, Span<short> defLevels, Span<TPhysical> destination, short nullLevel);
 
-        public static Converter GetConverter(LogicalType logicalType, int scale, ByteBuffer byteBuffer)
+        public static Converter GetConverter(LogicalType logicalType, int scale, ByteBuffer? byteBuffer)
         {
             if (typeof(TLogical) == typeof(bool) ||
                 typeof(TLogical) == typeof(int) ||
@@ -97,23 +97,27 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(decimal))
             {
+                if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 var multiplier = Decimal128.GetScaleMultiplier(scale);
                 return (Converter) (Delegate) (LogicalWrite<decimal, FixedLenByteArray>.Converter) ((s, dl, d, nl) => ConvertDecimal128(s, d, multiplier, byteBuffer));
             }
 
             if (typeof(TLogical) == typeof(decimal?))
             {
+                if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 var multiplier = Decimal128.GetScaleMultiplier(scale);
                 return (Converter) (Delegate) (LogicalWrite<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, nl) => ConvertDecimal128(s, dl, d, multiplier, nl, byteBuffer));
             }
 
             if (typeof(TLogical) == typeof(Guid))
             {
+                if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 return (Converter) (Delegate) (LogicalWrite<Guid, FixedLenByteArray>.Converter) ((s, dl, d, nl) => ConvertUuid(s, d, byteBuffer));
             }
 
             if (typeof(TLogical) == typeof(Guid?))
             {
+                if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 return (Converter) (Delegate) (LogicalWrite<Guid?, FixedLenByteArray>.Converter) ((s, dl, d, nl) => ConvertUuid(s, dl, d, nl, byteBuffer));
             }
 
@@ -193,11 +197,13 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(string))
             {
+                if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 return (Converter) (Delegate) (LogicalWrite<string, ByteArray>.Converter) ((s, dl, d, nl) => ConvertString(s, dl, d, nl, byteBuffer));
             }
 
             if (typeof(TLogical) == typeof(byte[]))
             {
+                if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 return (Converter) (Delegate) (LogicalWrite<byte[], ByteArray>.Converter) ((s, dl, d, nl) => ConvertByteArray(s, dl, d, nl, byteBuffer));
             }
 

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -30,6 +30,7 @@ namespace ParquetSharp
         public ParquetFileReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties)
         {
             if (randomAccessFile == null) throw new ArgumentNullException(nameof(randomAccessFile));
+            if (randomAccessFile.Handle == null) throw new ArgumentNullException(nameof(randomAccessFile.Handle));
             if (readerProperties == null) throw new ArgumentNullException(nameof(readerProperties));
 
             _handle = new ParquetHandle(ExceptionInfo.Return<IntPtr, IntPtr>(randomAccessFile.Handle, readerProperties.Handle.IntPtr, ParquetFileReader_Open), ParquetFileReader_Free);
@@ -49,9 +50,7 @@ namespace ParquetSharp
             GC.KeepAlive(_handle);
         }
 
-        public FileMetaData FileMetaData =>
-            _fileMetaData 
-            ?? (_fileMetaData = new FileMetaData(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileReader_MetaData)));
+        public FileMetaData FileMetaData => _fileMetaData ??= new FileMetaData(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileReader_MetaData));
 
         public RowGroupReader RowGroup(int i)
         {
@@ -77,6 +76,6 @@ namespace ParquetSharp
         private static extern IntPtr ParquetFileReader_RowGroup(IntPtr reader, int i, out IntPtr rowGroupReader);
 
         private readonly ParquetHandle _handle;
-        private FileMetaData _fileMetaData;
+        private FileMetaData? _fileMetaData;
     }
 }

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -1,73 +1,73 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-		<LangVersion>8.0</LangVersion>
-		<Nullable>enable</Nullable>
-		<AssemblyName>ParquetSharp</AssemblyName>
-		<RootNamespace>ParquetSharp</RootNamespace>
-		<Platforms>x64</Platforms>
-		<PlatformTarget>x64</PlatformTarget>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<NoWarn>1591;</NoWarn>
-		<Version>2.5.0-beta1</Version>
-		<Company>G-Research</Company>
-		<Authors>G-Research</Authors>
-		<Product>ParquetSharp</Product>
-		<Description>ParquetSharp is a .NET library for reading and writing Parquet files. It's implemented in C# as a PInvoke wrapper around apache-parquet-cpp to provide high performance and compatibility.</Description>
-		<Copyright>Copyright G-Research 2021</Copyright>
-		<PackageProjectUrl>https://github.com/G-Research/ParquetSharp</PackageProjectUrl>
-		<PackageTags>apache parquet gresearch g-research .net c#</PackageTags>
-		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-		<PackageOutputPath>..\nuget</PackageOutputPath>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>ParquetSharp</AssemblyName>
+    <RootNamespace>ParquetSharp</RootNamespace>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1591;</NoWarn>
+    <Version>2.5.0-beta1</Version>
+    <Company>G-Research</Company>
+    <Authors>G-Research</Authors>
+    <Product>ParquetSharp</Product>
+    <Description>ParquetSharp is a .NET library for reading and writing Parquet files. It's implemented in C# as a PInvoke wrapper around apache-parquet-cpp to provide high performance and compatibility.</Description>
+    <Copyright>Copyright G-Research 2021</Copyright>
+    <PackageProjectUrl>https://github.com/G-Research/ParquetSharp</PackageProjectUrl>
+    <PackageTags>apache parquet gresearch g-research .net c#</PackageTags>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageOutputPath>..\nuget</PackageOutputPath>
+  </PropertyGroup>
 
-	<ItemGroup Label="Additional nuget files">
-		<None Include="..\LICENSE.txt">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="ParquetSharp.targets">
-			<Pack>True</Pack>
-			<PackagePath>build;buildTransitive</PackagePath>
-		</None>
-	</ItemGroup>
+  <ItemGroup Label="Additional nuget files">
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="ParquetSharp.targets">
+      <Pack>True</Pack>
+      <PackagePath>build;buildTransitive</PackagePath>
+    </None>
+  </ItemGroup>
 
-	<PropertyGroup>
-		<IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
-		<IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-		<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-	</PropertyGroup>
+  <PropertyGroup>
+    <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+  </PropertyGroup>
 
-	<ItemGroup Label="Native Library">
-		<Content Include="..\bin\ParquetSharpNatived.dll" Link="ParquetSharpNatived.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\bin\ParquetSharpNatived.pdb" Link="ParquetSharpNatived.pdb" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\bin\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Release' AND '$(IsWindows)'=='true'">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\bin\ParquetSharpNatived.so" Link="ParquetSharpNatived.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNatived.so'))">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\bin\ParquetSharpNative.so" Link="ParquetSharpNative.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNative.so'))">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\bin\ParquetSharpNatived.dylib" Link="ParquetSharpNatived.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNatived.dylib'))">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\bin\ParquetSharpNative.dylib" Link="ParquetSharpNative.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNative.dylib'))">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
+  <ItemGroup Label="Native Library">
+    <Content Include="..\bin\ParquetSharpNatived.dll" Link="ParquetSharpNatived.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\ParquetSharpNatived.pdb" Link="ParquetSharpNatived.pdb" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Release' AND '$(IsWindows)'=='true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\ParquetSharpNatived.so" Link="ParquetSharpNatived.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNatived.so'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\ParquetSharpNative.so" Link="ParquetSharpNative.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNative.so'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\ParquetSharpNatived.dylib" Link="ParquetSharpNatived.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNatived.dylib'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\ParquetSharpNative.dylib" Link="ParquetSharpNative.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNative.dylib'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="System.Memory" Version="4.5.4" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
 
 </Project>

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -1,72 +1,73 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
-    <AssemblyName>ParquetSharp</AssemblyName>
-    <RootNamespace>ParquetSharp</RootNamespace>
-    <Platforms>x64</Platforms>
-    <PlatformTarget>x64</PlatformTarget>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591;</NoWarn>
-    <Version>2.4.0</Version>
-    <Company>G-Research</Company>
-    <Authors>G-Research</Authors>
-    <Product>ParquetSharp</Product>
-    <Description>ParquetSharp is a .NET library for reading and writing Parquet files. It's implemented in C# as a PInvoke wrapper around apache-parquet-cpp to provide high performance and compatibility.</Description>
-    <Copyright>Copyright G-Research 2020</Copyright>
-    <PackageProjectUrl>https://github.com/G-Research/ParquetSharp</PackageProjectUrl>
-    <PackageTags>apache parquet gresearch g-research .net c#</PackageTags>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <PackageOutputPath>..\nuget</PackageOutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+		<LangVersion>8.0</LangVersion>
+		<Nullable>enable</Nullable>
+		<AssemblyName>ParquetSharp</AssemblyName>
+		<RootNamespace>ParquetSharp</RootNamespace>
+		<Platforms>x64</Platforms>
+		<PlatformTarget>x64</PlatformTarget>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>1591;</NoWarn>
+		<Version>2.5.0-beta1</Version>
+		<Company>G-Research</Company>
+		<Authors>G-Research</Authors>
+		<Product>ParquetSharp</Product>
+		<Description>ParquetSharp is a .NET library for reading and writing Parquet files. It's implemented in C# as a PInvoke wrapper around apache-parquet-cpp to provide high performance and compatibility.</Description>
+		<Copyright>Copyright G-Research 2020</Copyright>
+		<PackageProjectUrl>https://github.com/G-Research/ParquetSharp</PackageProjectUrl>
+		<PackageTags>apache parquet gresearch g-research .net c#</PackageTags>
+		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+		<PackageOutputPath>..\nuget</PackageOutputPath>
+	</PropertyGroup>
 
-  <ItemGroup Label="Additional nuget files">
-    <None Include="..\LICENSE.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="ParquetSharp.targets">
-      <Pack>True</Pack>
-      <PackagePath>build;buildTransitive</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup Label="Additional nuget files">
+		<None Include="..\LICENSE.txt">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+		<None Include="ParquetSharp.targets">
+			<Pack>True</Pack>
+			<PackagePath>build;buildTransitive</PackagePath>
+		</None>
+	</ItemGroup>
 
-  <PropertyGroup>
-    <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-  </PropertyGroup>
+	<PropertyGroup>
+		<IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
+		<IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+		<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+	</PropertyGroup>
 
-  <ItemGroup Label="Native Library">
-    <Content Include="..\bin\ParquetSharpNatived.dll" Link="ParquetSharpNatived.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\ParquetSharpNatived.pdb" Link="ParquetSharpNatived.pdb" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Release' AND '$(IsWindows)'=='true'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\ParquetSharpNatived.so" Link="ParquetSharpNatived.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNatived.so'))">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\ParquetSharpNative.so" Link="ParquetSharpNative.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNative.so'))">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\ParquetSharpNatived.dylib" Link="ParquetSharpNatived.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNatived.dylib'))">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\bin\ParquetSharpNative.dylib" Link="ParquetSharpNative.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNative.dylib'))">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup Label="Native Library">
+		<Content Include="..\bin\ParquetSharpNatived.dll" Link="ParquetSharpNatived.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\bin\ParquetSharpNatived.pdb" Link="ParquetSharpNatived.pdb" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND '$(IsWindows)'=='true'">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\bin\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Release' AND '$(IsWindows)'=='true'">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\bin\ParquetSharpNatived.so" Link="ParquetSharpNatived.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNatived.so'))">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\bin\ParquetSharpNative.so" Link="ParquetSharpNative.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsLinux)'=='true' OR Exists('..\bin\ParquetSharpNative.so'))">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\bin\ParquetSharpNatived.dylib" Link="ParquetSharpNatived.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNatived.dylib'))">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\bin\ParquetSharpNative.dylib" Link="ParquetSharpNative.dylib" PackagePath="runtimes/osx-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsOSX)'=='true' OR Exists('..\bin\ParquetSharpNative.dylib'))">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Memory" Version="4.5.4" />
+	</ItemGroup>
 
 </Project>

--- a/csharp/ReaderProperties.cs
+++ b/csharp/ReaderProperties.cs
@@ -32,7 +32,7 @@ namespace ParquetSharp
             }
         }
 
-        public FileDecryptionProperties FileDecryptionProperties
+        public FileDecryptionProperties? FileDecryptionProperties
         {
             get
             {

--- a/csharp/RowGroupMetaData.cs
+++ b/csharp/RowGroupMetaData.cs
@@ -12,7 +12,7 @@ namespace ParquetSharp
 
         public int NumColumns => ExceptionInfo.Return<int>(_handle, RowGroupMetaData_Num_Columns);
         public long NumRows => ExceptionInfo.Return<long>(_handle, RowGroupMetaData_Num_Rows);
-        public SchemaDescriptor Schema => _schema ?? (_schema = new SchemaDescriptor(ExceptionInfo.Return<IntPtr>(_handle, RowGroupMetaData_Schema)));
+        public SchemaDescriptor Schema => _schema ??= new SchemaDescriptor(ExceptionInfo.Return<IntPtr>(_handle, RowGroupMetaData_Schema));
         public long TotalByteSize => ExceptionInfo.Return<long>(_handle, RowGroupMetaData_Total_Byte_Size);
 
         public ColumnChunkMetaData GetColumnChunkMetaData(int i)
@@ -36,6 +36,6 @@ namespace ParquetSharp
         private static extern IntPtr RowGroupMetaData_Total_Byte_Size(IntPtr rowGroupMetaData, out long totalByteSize);
 
         private readonly IntPtr _handle;
-        private SchemaDescriptor _schema;
+        private SchemaDescriptor? _schema;
     }
 }

--- a/csharp/RowGroupReader.cs
+++ b/csharp/RowGroupReader.cs
@@ -15,9 +15,7 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
-        public RowGroupMetaData MetaData =>
-            _metaData
-            ?? (_metaData = new RowGroupMetaData(ExceptionInfo.Return<IntPtr>(_handle, RowGroupReader_Metadata)));
+        public RowGroupMetaData MetaData => _metaData ??= new RowGroupMetaData(ExceptionInfo.Return<IntPtr>(_handle, RowGroupReader_Metadata));
 
         public ColumnReader Column(int i) => ColumnReader.Create(
             ExceptionInfo.Return<int, IntPtr>(_handle, i, RowGroupReader_Column),
@@ -33,6 +31,6 @@ namespace ParquetSharp
         private static extern IntPtr RowGroupReader_Metadata(IntPtr rowGroupReader, out IntPtr rowGroupMetaData);
 
         private readonly ParquetHandle _handle;
-        private RowGroupMetaData _metaData;
+        private RowGroupMetaData? _metaData;
     }
 }

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -14,8 +14,8 @@ namespace ParquetSharp.RowOriented
     /// </summary>
     public static class ParquetFile
     {
-        public static Action<Expression> OnReadExpressionCreated;
-        public static Action<Expression> OnWriteExpressionCreated;
+        public static Action<Expression>? OnReadExpressionCreated;
+        public static Action<Expression>? OnWriteExpressionCreated;
 
         /// <summary>
         /// Create a row-oriented reader from a file.
@@ -56,9 +56,9 @@ namespace ParquetSharp.RowOriented
         /// </summary>
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             string path,
-            string[] columnNames = null,
+            string[]? columnNames = null,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string> keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
             return new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate);
@@ -67,8 +67,8 @@ namespace ParquetSharp.RowOriented
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             string path,
             WriterProperties writerProperties,
-            string[] columnNames = null,
-            IReadOnlyDictionary<string, string> keyValueMetadata = null)
+            string[]? columnNames = null,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
             return new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate);
@@ -79,9 +79,9 @@ namespace ParquetSharp.RowOriented
         /// </summary>
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             OutputStream outputStream,
-            string[] columnNames = null,
+            string[]? columnNames = null,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string> keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
             return new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate);
@@ -90,19 +90,19 @@ namespace ParquetSharp.RowOriented
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             OutputStream outputStream,
             WriterProperties writerProperties,
-            string[] columnNames = null,
-            IReadOnlyDictionary<string, string> keyValueMetadata = null)
+            string[]? columnNames = null,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
             return new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate);
         }
 
-        private static ParquetRowReader<TTuple>.ReadAction GetOrCreateReadDelegate<TTuple>((string name, string mappedColumn, Type type, MemberInfo info)[] fields)
+        private static ParquetRowReader<TTuple>.ReadAction GetOrCreateReadDelegate<TTuple>((string name, string? mappedColumn, Type type, MemberInfo info)[] fields)
         {
             return (ParquetRowReader<TTuple>.ReadAction) ReadDelegatesCache.GetOrAdd(typeof(TTuple), k => CreateReadDelegate<TTuple>(fields));
         }
 
-        private static (Column[] columns, ParquetRowWriter<TTuple>.WriteAction writeDelegate) GetOrCreateWriteDelegate<TTuple>(string[] columnNames)
+        private static (Column[] columns, ParquetRowWriter<TTuple>.WriteAction writeDelegate) GetOrCreateWriteDelegate<TTuple>(string[]? columnNames)
         {
             var (columns, writeDelegate) = WriteDelegates.GetOrAdd(typeof(TTuple), k => CreateWriteDelegate<TTuple>());
             if (columnNames != null)
@@ -121,7 +121,7 @@ namespace ParquetSharp.RowOriented
         /// <summary>
         /// Returns a delegate to read rows from individual Parquet columns.
         /// </summary>
-        private static ParquetRowReader<TTuple>.ReadAction CreateReadDelegate<TTuple>((string name, string mappedColumn, Type type, MemberInfo info)[] fields)
+        private static ParquetRowReader<TTuple>.ReadAction CreateReadDelegate<TTuple>((string name, string? mappedColumn, Type type, MemberInfo info)[] fields)
         {
             // Parameters
             var reader = Expression.Parameter(typeof(ParquetRowReader<TTuple>), "reader");
@@ -245,9 +245,9 @@ namespace ParquetSharp.RowOriented
             );
         }
 
-        private static (string name, string mappedColumn, Type type, MemberInfo info)[] GetFieldsAndProperties(Type type)
+        private static (string name, string? mappedColumn, Type type, MemberInfo info)[] GetFieldsAndProperties(Type type)
         {
-            var list = new List<(string name, string mappedColumn, Type type, MemberInfo info)>();
+            var list = new List<(string name, string? mappedColumn, Type type, MemberInfo info)>();
             var flags = BindingFlags.Public | BindingFlags.Instance;
 
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTuple<,,,,,,,>))
@@ -286,7 +286,7 @@ namespace ParquetSharp.RowOriented
             return list.OrderBy(x => x.info.MetadataToken).ToArray();
         }
 
-        private static Column GetColumn((string name, string mappedColumn, Type type, MemberInfo info) field)
+        private static Column GetColumn((string name, string? mappedColumn, Type type, MemberInfo info) field)
         {
             var isDecimal = field.type == typeof(decimal) || field.type == typeof(decimal?);
             var decimalScale = field.info.GetCustomAttributes(typeof(ParquetDecimalScaleAttribute))
@@ -303,7 +303,7 @@ namespace ParquetSharp.RowOriented
                 throw new ArgumentException($"field '{field.name}' has no {nameof(ParquetDecimalScaleAttribute)} despite being a decimal type");
             }
 
-            return new Column(field.type, field.mappedColumn ?? field.name, isDecimal ? LogicalType.Decimal(29, decimalScale.Scale) : null);
+            return new Column(field.type, field.mappedColumn ?? field.name, isDecimal ? LogicalType.Decimal(29, decimalScale!.Scale) : null);
         }
 
         private static readonly ConcurrentDictionary<Type, Delegate> ReadDelegatesCache =

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp.Schema
 {
     public sealed class GroupNode : Node
     {
-        public GroupNode(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType logicalType = null)
+        public GroupNode(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType? logicalType = null)
             : this(Make(name, repetition, fields, logicalType))
         {
         }
@@ -22,7 +22,7 @@ namespace ParquetSharp.Schema
 
         public Node Field(int i)
         {
-            return Create(ExceptionInfo.Return<int, IntPtr>(Handle, i, GroupNode_Field));
+            return Create(ExceptionInfo.Return<int, IntPtr>(Handle, i, GroupNode_Field)) ?? throw new InvalidOperationException();
         }
 
         public int FieldIndex(string name)
@@ -44,7 +44,7 @@ namespace ParquetSharp.Schema
                 LogicalType is NoneLogicalType ? null : LogicalType);
         }
 
-        private static unsafe IntPtr Make(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType logicalType)
+        private static unsafe IntPtr Make(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType? logicalType)
         {
             var handles = fields.Select(f => f.Handle.IntPtr).ToArray();
 

--- a/csharp/Schema/Node.cs
+++ b/csharp/Schema/Node.cs
@@ -27,7 +27,7 @@ namespace ParquetSharp.Schema
         public LogicalType LogicalType => LogicalType.Create(ExceptionInfo.Return<IntPtr>(Handle, Node_Logical_Type));
         public string Name => ExceptionInfo.ReturnString(Handle, Node_Name);
         public NodeType NodeType => ExceptionInfo.Return<NodeType>(Handle, Node_Node_Type);
-        public Node Parent => Create(ExceptionInfo.Return<IntPtr>(Handle, Node_Parent));
+        public Node? Parent => Create(ExceptionInfo.Return<IntPtr>(Handle, Node_Parent));
         public ColumnPath Path => new ColumnPath(ExceptionInfo.Return<IntPtr>(Handle, Node_Path));
         public Repetition Repetition => ExceptionInfo.Return<Repetition>(Handle, Node_Repetition);
 
@@ -36,12 +36,12 @@ namespace ParquetSharp.Schema
         /// </summary>
         public abstract Node DeepClone();
 
-        public bool Equals(Node other)
+        public bool Equals(Node? other)
         {
             return other != null && ExceptionInfo.Return<bool>(Handle, other.Handle, Node_Equals);
         }
 
-        internal static Node Create(IntPtr handle)
+        internal static Node? Create(IntPtr handle)
         {
             if (handle == IntPtr.Zero)
             {
@@ -50,15 +50,12 @@ namespace ParquetSharp.Schema
 
             var nodeType = ExceptionInfo.Return<NodeType>(handle, Node_Node_Type);
 
-            switch (nodeType)
+            return nodeType switch
             {
-                case NodeType.Primitive:
-                    return new PrimitiveNode(handle);
-                case NodeType.Group:
-                    return new GroupNode(handle);
-                default:
-                    throw new ArgumentOutOfRangeException($"unknown node type {nodeType}");
-            }
+                NodeType.Primitive => new PrimitiveNode(handle),
+                NodeType.Group => new GroupNode(handle),
+                _ => throw new ArgumentOutOfRangeException($"unknown node type {nodeType}")
+            };
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/Schema/PrimitiveNode.cs
+++ b/csharp/Schema/PrimitiveNode.cs
@@ -47,9 +47,10 @@ namespace ParquetSharp.Schema
             int primitiveLength)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
+            if (logicalType == null) throw new ArgumentNullException(nameof(logicalType));
 
-            ExceptionInfo.Check(PrimitiveNode_Make(name, repetition, logicalType?.Handle.IntPtr ?? IntPtr.Zero, physicalType, primitiveLength, out var primitiveNode));
-            GC.KeepAlive(logicalType?.Handle);
+            ExceptionInfo.Check(PrimitiveNode_Make(name, repetition, logicalType.Handle.IntPtr, physicalType, primitiveLength, out var primitiveNode));
+            GC.KeepAlive(logicalType.Handle);
             return primitiveNode;
         }
 

--- a/csharp/SchemaDescriptor.cs
+++ b/csharp/SchemaDescriptor.cs
@@ -11,10 +11,10 @@ namespace ParquetSharp
             _handle = schemaDescriptorHandle;
         }
 
-        public GroupNode GroupNode => (GroupNode) Node.Create(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Group_Node));
+        public GroupNode GroupNode => (GroupNode) (Node.Create(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Group_Node)) ?? throw new InvalidOperationException());
         public string Name => Marshal.PtrToStringAnsi(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Name));
         public int NumColumns => ExceptionInfo.Return<int>(_handle, SchemaDescriptor_Num_Columns);
-        public Node SchemaRoot => Node.Create(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Schema_Root));
+        public Node SchemaRoot => Node.Create(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Schema_Root)) ?? throw new InvalidOperationException();
 
         public ColumnDescriptor Column(int i)
         {
@@ -35,7 +35,7 @@ namespace ParquetSharp
 
         public Node ColumnRoot(int i)
         {
-            return Node.Create(ExceptionInfo.Return<int, IntPtr>(_handle, i, SchemaDescriptor_Get_Column_Root));
+            return Node.Create(ExceptionInfo.Return<int, IntPtr>(_handle, i, SchemaDescriptor_Get_Column_Root)) ?? throw new InvalidOperationException();
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/Statistics.cs
+++ b/csharp/Statistics.cs
@@ -5,7 +5,7 @@ namespace ParquetSharp
 {
     public abstract class Statistics : IDisposable
     {
-        internal static Statistics Create(IntPtr handle)
+        internal static Statistics? Create(IntPtr handle)
         {
             if (handle == IntPtr.Zero)
             {
@@ -18,27 +18,18 @@ namespace ParquetSharp
             {
                 var type = ExceptionInfo.Return<PhysicalType>(handle, Statistics_Physical_Type);
 
-                switch (type)
+                return type switch
                 {
-                    case PhysicalType.Boolean:
-                        return new Statistics<bool>(parquetHandle);
-                    case PhysicalType.Int32:
-                        return new Statistics<int>(parquetHandle);
-                    case PhysicalType.Int64:
-                        return new Statistics<long>(parquetHandle);
-                    case PhysicalType.Int96:
-                        return new Statistics<Int96>(parquetHandle);
-                    case PhysicalType.Float:
-                        return new Statistics<float>(parquetHandle);
-                    case PhysicalType.Double:
-                        return new Statistics<double>(parquetHandle);
-                    case PhysicalType.ByteArray:
-                        return new Statistics<ByteArray>(parquetHandle);
-                    case PhysicalType.FixedLenByteArray:
-                        return new Statistics<FixedLenByteArray>(parquetHandle);
-                    default:
-                        throw new NotSupportedException($"Physical type {type} is not supported");
-                }
+                    PhysicalType.Boolean => new Statistics<bool>(parquetHandle),
+                    PhysicalType.Int32 => new Statistics<int>(parquetHandle),
+                    PhysicalType.Int64 => new Statistics<long>(parquetHandle),
+                    PhysicalType.Int96 => new Statistics<Int96>(parquetHandle),
+                    PhysicalType.Float => new Statistics<float>(parquetHandle),
+                    PhysicalType.Double => new Statistics<double>(parquetHandle),
+                    PhysicalType.ByteArray => new Statistics<ByteArray>(parquetHandle),
+                    PhysicalType.FixedLenByteArray => new Statistics<FixedLenByteArray>(parquetHandle),
+                    _ => throw new NotSupportedException($"Physical type {type} is not supported")
+                };
             }
 
             catch

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -205,7 +205,7 @@ namespace ParquetSharp
             return this;
         }
 
-        public WriterPropertiesBuilder Encryption(FileEncryptionProperties fileEncryptionProperties)
+        public WriterPropertiesBuilder Encryption(FileEncryptionProperties? fileEncryptionProperties)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Encryption(_handle.IntPtr, fileEncryptionProperties?.Handle.IntPtr ?? IntPtr.Zero));
             GC.KeepAlive(_handle);


### PR DESCRIPTION
Dual target netstandard 2.0 and 2.1. 
Switch project to C# 8.
Enable nullables.
Throw InvalidOperationException whenever encountering an internal-yet-unexpected null.

NetStandard 2.1 is needed to use nullables. Such that .NET Core 3.0+ projects will see the nullable annotations. Yet NetStandard2.0 is needed for .NET Framework compatibility (and .NET Core 2.0+).