### PR TITLE
Be consistent in the Equals/CompareTo interfaces for Date and DateTimeNanos

### DIFF
--- a/csharp/Date.cs
+++ b/csharp/Date.cs
@@ -40,7 +40,7 @@ namespace ParquetSharp
 
         public override bool Equals(object obj)
         {
-            return !(obj is null) && obj is Date date && Equals(date);
+            return obj is Date date && Equals(date);
         }
 
         public override int GetHashCode()

--- a/csharp/DateTimeNanos.cs
+++ b/csharp/DateTimeNanos.cs
@@ -34,6 +34,16 @@ namespace ParquetSharp
             return Ticks == other.Ticks;
         }
 
+        public override bool Equals(object obj)
+        {
+            return obj is DateTimeNanos date && Equals(date);
+        }
+
+        public override int GetHashCode()
+        {
+            return Ticks.GetHashCode();
+        }
+
         public int CompareTo(object obj)
         {
             return obj switch


### PR DESCRIPTION
If `Date` implements it, `DateTimeNanos` should too.