### PR TITLE
Add proper UTF8 Support

### DIFF
--- a/csharp.test/TestColumnPath.cs
+++ b/csharp.test/TestColumnPath.cs
@@ -24,6 +24,25 @@ namespace ParquetSharp.Test
         }
 
         [Test]
+        public static void TestDotRepresentationsUtf8()
+        {
+            const string part1 = "2H₂ + O₂ ⇌ 2H₂O, R = 47 kΩ, ⌀ 200 mm";
+
+            using var p0 = new ColumnPath("root.part0." + part1);
+            using var p1 = new ColumnPath(new[] {"root", "part0", part1});
+
+            Assert.AreEqual("root.part0." + part1, p0.ToDotString());
+            Assert.AreEqual("root.part0." + part1, p1.ToDotString());
+
+            Assert.AreEqual(new[] {"root", "part0", part1}, p0.ToDotVector());
+            Assert.AreEqual(new[] {"root", "part0", part1}, p1.ToDotVector());
+
+            using var p2 = p0.Extend("α ∧ ¬β");
+
+            Assert.AreEqual("root.part0." + part1 + ".α ∧ ¬β", p2.ToDotString());
+        }
+
+        [Test]
         public static void TestNodeRepresentation()
         {
             var columns = new Column[] {new Column<int[]>("value")};
@@ -43,6 +62,31 @@ namespace ParquetSharp.Test
             Assert.AreEqual("value", schema.Field(0).Path.ToDotString());
             Assert.AreEqual("value.list", ((GroupNode) schema.Field(0)).Field(0).Path.ToDotString());
             Assert.AreEqual("value.list.item", ((GroupNode) ((GroupNode) schema.Field(0)).Field(0)).Field(0).Path.ToDotString());
+        }
+
+        [Test]
+        public static void TestNodeRepresentationUtf8()
+        {
+            const string name = "2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 mm";
+
+            var columns = new Column[] {new Column<int[]>(name)};
+
+            using var schema = Column.CreateSchemaNode(columns);
+            using var p0 = new ColumnPath(schema);
+            using var p1 = new ColumnPath(schema.Field(0));
+            using var p2 = new ColumnPath(((GroupNode) schema.Field(0)).Field(0));
+            using var p3 = new ColumnPath(((GroupNode) ((GroupNode) schema.Field(0)).Field(0)).Field(0));
+
+            Assert.AreEqual("", p0.ToDotString());
+            Assert.AreEqual(name, p1.ToDotString());
+            Assert.AreEqual(name + ".list", p2.ToDotString());
+            Assert.AreEqual(name + ".list.item", p3.ToDotString());
+            Assert.AreEqual(new[] {name, "list", "item"}, p3.ToDotVector());
+
+            Assert.AreEqual("", schema.Path.ToDotString());
+            Assert.AreEqual(name + "", schema.Field(0).Path.ToDotString());
+            Assert.AreEqual(name+ ".list", ((GroupNode) schema.Field(0)).Field(0).Path.ToDotString());
+            Assert.AreEqual(name + ".list.item", ((GroupNode) ((GroupNode) schema.Field(0)).Field(0)).Field(0).Path.ToDotString());
         }
     }
 }

--- a/csharp.test/TestNode.cs
+++ b/csharp.test/TestNode.cs
@@ -10,8 +10,8 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestDeepClone()
         {
-            var node = new ExampleSchemaBuilder().Build();
-            var cloned = node.DeepClone();
+            using var node = new ExampleSchemaBuilder().Build();
+            using var cloned = node.DeepClone();
 
             Assert.AreEqual(node, cloned);
 
@@ -21,53 +21,64 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestEquality()
         {
-            var exampleSchema = new ExampleSchemaBuilder().Build();
+            using var exampleSchema = new ExampleSchemaBuilder().Build();
 
-            var exampleSchemaDuplicate = new ExampleSchemaBuilder().Build();
+            using var exampleSchemaDuplicate = new ExampleSchemaBuilder().Build();
             Assert.AreEqual(exampleSchema, exampleSchemaDuplicate);
 
-            var schemaWithDifferentName = new ExampleSchemaBuilder().WithDifferentPrimitiveName().Build();
+            using var schemaWithDifferentName = new ExampleSchemaBuilder().WithDifferentPrimitiveName().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentName);
 
-            var schemaWithDifferentPhysicalType = new ExampleSchemaBuilder().WithDifferentPhysicalType().Build();
+            using var schemaWithDifferentPhysicalType = new ExampleSchemaBuilder().WithDifferentPhysicalType().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentPhysicalType);
 
-            var schemaWithDifferentLogicalType = new ExampleSchemaBuilder().WithDifferentPrimitiveLogicalType().Build();
+            using var schemaWithDifferentLogicalType = new ExampleSchemaBuilder().WithDifferentPrimitiveLogicalType().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentLogicalType);
 
-            var schemaWithDifferentRepetition = new ExampleSchemaBuilder().WithDifferentPrimitiveRepetition().Build();
+            using var schemaWithDifferentRepetition = new ExampleSchemaBuilder().WithDifferentPrimitiveRepetition().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentRepetition);
 
-            var schemaWithDifferentLength = new ExampleSchemaBuilder().WithDifferentLength().Build();
+            using var schemaWithDifferentLength = new ExampleSchemaBuilder().WithDifferentLength().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentLength);
 
-            var schemaWithDifferentPrecision = new ExampleSchemaBuilder().WithDifferentPrecision().Build();
+            using var schemaWithDifferentPrecision = new ExampleSchemaBuilder().WithDifferentPrecision().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentPrecision);
 
-            var schemaWithDifferentScale = new ExampleSchemaBuilder().WithDifferentScale().Build();
+            using var schemaWithDifferentScale = new ExampleSchemaBuilder().WithDifferentScale().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentScale);
 
-            var schemaWithAdditionalField = new ExampleSchemaBuilder().WithAdditionalField().Build();
+            using var schemaWithAdditionalField = new ExampleSchemaBuilder().WithAdditionalField().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithAdditionalField);
 
-            var schemaWithDifferentGroupName = new ExampleSchemaBuilder().WithDifferentGroupName().Build();
+            using var schemaWithDifferentGroupName = new ExampleSchemaBuilder().WithDifferentGroupName().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentGroupName);
 
-            var schemaWithDifferentGroupRepetition = new ExampleSchemaBuilder().WithDifferentGroupRepetition().Build();
+            using var schemaWithDifferentGroupRepetition = new ExampleSchemaBuilder().WithDifferentGroupRepetition().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentGroupRepetition);
 
-            var schemaWithDifferentGroupLogicalType = new ExampleSchemaBuilder().WithDifferentGroupLogicalType().Build();
+            using var schemaWithDifferentGroupLogicalType = new ExampleSchemaBuilder().WithDifferentGroupLogicalType().Build();
             Assert.AreNotEqual(exampleSchema, schemaWithDifferentGroupLogicalType);
         }
 
         [Test]
         public static void TestEqualityWithDifferentNodeTypes()
         {
-            var groupNode = new GroupNode("group", Repetition.Required, new Node[0]);
-            var primitiveNode = new PrimitiveNode("primitive", Repetition.Required, LogicalType.Int(32, true), PhysicalType.Int32);
+            using var groupNode = new GroupNode("group", Repetition.Required, new Node[0]);
+            using var primitiveNode = new PrimitiveNode("primitive", Repetition.Required, LogicalType.Int(32, true), PhysicalType.Int32);
 
             Assert.AreNotEqual(groupNode, primitiveNode);
             Assert.AreNotEqual(primitiveNode, groupNode);
+        }
+
+        [Test]
+        public static void TestNodeUtf8Name()
+        {
+            const string name = "2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 mm";
+            using var groupNode = new GroupNode(name, Repetition.Required, new Node[0]);
+            using var primitiveNode = new PrimitiveNode(name, Repetition.Required, LogicalType.Int(32, true), PhysicalType.Int32);
+
+            Assert.AreEqual(name, groupNode.Name);
+            Assert.AreEqual(name, primitiveNode.Name);
         }
 
         /// <summary>

--- a/csharp.test/TestParquetFileWriter.cs
+++ b/csharp.test/TestParquetFileWriter.cs
@@ -33,7 +33,8 @@ namespace ParquetSharp.Test
 
             var kvm = (IReadOnlyDictionary<string, string>) new Dictionary<string, string>
             {
-                {"some key", "some value"}
+                {"some key", "some value"},
+                {"α ∧ ¬β", "2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 mm"}
             };
 
             using var buffer = new ResizableBuffer();

--- a/csharp/AadPrefixVerifier.cs
+++ b/csharp/AadPrefixVerifier.cs
@@ -47,7 +47,7 @@ namespace ParquetSharp
             try
             {
                 var obj = (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target;
-                var aadPrefixStr = Marshal.PtrToStringAnsi(aadPrefix);
+                var aadPrefixStr = StringUtil.PtrToStringUtf8(aadPrefix);
                 obj.Verify(aadPrefixStr);
             }
             catch (Exception ex)

--- a/csharp/ApplicationVersion.cs
+++ b/csharp/ApplicationVersion.cs
@@ -7,16 +7,16 @@ namespace ParquetSharp
     {
         internal ApplicationVersion(CStruct cstruct)
         {
-            Application = Marshal.PtrToStringAnsi(cstruct.Application);
-            Build = Marshal.PtrToStringAnsi(cstruct.Build);
+            Application = StringUtil.PtrToStringUtf8(cstruct.Application);
+            Build = StringUtil.PtrToStringUtf8(cstruct.Build);
 
             Major = cstruct.Major;
             Minor = cstruct.Minor;
             Patch = cstruct.Patch;
 
-            Unknown = Marshal.PtrToStringAnsi(cstruct.Unknown);
-            PreRelease = Marshal.PtrToStringAnsi(cstruct.PreRelease);
-            BuildInfo = Marshal.PtrToStringAnsi(cstruct.BuildInfo);
+            Unknown = StringUtil.PtrToStringUtf8(cstruct.Unknown);
+            PreRelease = StringUtil.PtrToStringUtf8(cstruct.PreRelease);
+            BuildInfo = StringUtil.PtrToStringUtf8(cstruct.BuildInfo);
         }
 
         public readonly string Application;

--- a/csharp/ColumnCryptoMetaData.cs
+++ b/csharp/ColumnCryptoMetaData.cs
@@ -21,7 +21,7 @@ namespace ParquetSharp
 
         public ColumnPath ColumnPath => new ColumnPath(ExceptionInfo.Return<IntPtr>(_handle, ColumnCryptoMetaData_Path_In_Schema));
         public bool EncryptedWithFooterKey => ExceptionInfo.Return<bool>(_handle, ColumnCryptoMetaData_Encrypted_With_Footer_Key);
-        public string KeyMetadata => Marshal.PtrToStringAnsi(ExceptionInfo.Return<IntPtr>(_handle, ColumnCryptoMetaData_Key_Metadata));
+        public string KeyMetadata => ExceptionInfo.ReturnString(_handle, ColumnCryptoMetaData_Key_Metadata);
 
         [DllImport(ParquetDll.Name)] 
         private static extern void ColumnCryptoMetaData_Free(IntPtr columnCryptoMetaData);

--- a/csharp/ColumnDecryptionPropertiesBuilder.cs
+++ b/csharp/ColumnDecryptionPropertiesBuilder.cs
@@ -52,8 +52,8 @@ namespace ParquetSharp
             return handle;
         }
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Create(string name, out IntPtr builder);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnDecryptionPropertiesBuilder_Create([MarshalAs(UnmanagedType.LPUTF8Str)] string name, out IntPtr builder);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnDecryptionPropertiesBuilder_Create_From_Column_Path(IntPtr path, out IntPtr builder);
@@ -61,7 +61,7 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern void ColumnDecryptionPropertiesBuilder_Free(IntPtr builder);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnDecryptionPropertiesBuilder_Key(IntPtr builder, in AesKey key);
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/ColumnDescriptor.cs
+++ b/csharp/ColumnDescriptor.cs
@@ -21,7 +21,7 @@ namespace ParquetSharp
         public LogicalType LogicalType => LogicalType.Create(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Logical_Type));
         public short MaxDefinitionLevel => ExceptionInfo.Return<short>(_handle, ColumnDescriptor_Max_Definition_Level);
         public short MaxRepetitionLevel => ExceptionInfo.Return<short>(_handle, ColumnDescriptor_Max_Repetition_Level);
-        public string Name => Marshal.PtrToStringAnsi(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Name));
+        public string Name => ExceptionInfo.ReturnString(_handle, ColumnDescriptor_Name);
         public Schema.ColumnPath Path => new Schema.ColumnPath(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Path));
         public Schema.Node SchemaNode => Schema.Node.Create(ExceptionInfo.Return<IntPtr>(_handle, ColumnDescriptor_Schema_Node)) ?? throw new InvalidOperationException();
         public PhysicalType PhysicalType => ExceptionInfo.Return<PhysicalType>(_handle, ColumnDescriptor_Physical_Type);

--- a/csharp/ColumnEncryptionPropertiesBuilder.cs
+++ b/csharp/ColumnEncryptionPropertiesBuilder.cs
@@ -66,8 +66,8 @@ namespace ParquetSharp
             return handle;
         }
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Create(string name, out IntPtr builder);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Create([MarshalAs(UnmanagedType.LPUTF8Str)] string name, out IntPtr builder);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnEncryptionPropertiesBuilder_Create_From_Column_Path(IntPtr path, out IntPtr builder);
@@ -75,14 +75,14 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern void ColumnEncryptionPropertiesBuilder_Free(IntPtr builder);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key(IntPtr builder, in AesKey key);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key_Metadata(IntPtr builder, string keyMetadata);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key_Metadata(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string keyMetadata);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key_Id(IntPtr builder, string keyId);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnEncryptionPropertiesBuilder_Key_Id(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string keyId);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnEncryptionPropertiesBuilder_Build(IntPtr builder, out IntPtr properties);

--- a/csharp/DecryptionKeyRetriever.cs
+++ b/csharp/DecryptionKeyRetriever.cs
@@ -46,7 +46,7 @@ namespace ParquetSharp
             try
             {
                 var obj = (DecryptionKeyRetriever) GCHandle.FromIntPtr(handle).Target;
-                var keyMetadataStr = Marshal.PtrToStringAnsi(keyMetadata);
+                var keyMetadataStr = StringUtil.PtrToStringUtf8(keyMetadata);
                 key = new AesKey(obj.GetKey(keyMetadataStr));
             }
             catch (Exception ex)

--- a/csharp/ExceptionInfo.cs
+++ b/csharp/ExceptionInfo.cs
@@ -22,8 +22,8 @@ namespace ParquetSharp
                 return;
             }
 
-            var type = Marshal.PtrToStringAnsi(ExceptionInfo_Type(exceptionInfo));
-            var message = Marshal.PtrToStringAnsi(ExceptionInfo_Message(exceptionInfo));
+            var type = StringUtil.PtrToStringUtf8(ExceptionInfo_Type(exceptionInfo));
+            var message = StringUtil.PtrToStringUtf8(ExceptionInfo_Message(exceptionInfo));
 
             ExceptionInfo_Free(exceptionInfo);
 
@@ -95,14 +95,14 @@ namespace ParquetSharp
 
         private static string ConvertPtrToString(IntPtr handle, Action<IntPtr>? deleter, IntPtr value)
         {
-            var str = Marshal.PtrToStringAnsi(value);
+            var str = StringUtil.PtrToStringUtf8(value);
             deleter?.Invoke(value);
             return str;
         }
 
         private static string ConvertPtrToString(ParquetHandle handle, Action<IntPtr>? deleter, IntPtr value)
         {
-            var str = Marshal.PtrToStringAnsi(value);
+            var str = StringUtil.PtrToStringUtf8(value);
             deleter?.Invoke(value);
             GC.KeepAlive(handle);
             return str;

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -50,8 +50,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern void FileDecryptionProperties_Free(IntPtr properties);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileDecryptionProperties_Column_Key(IntPtr properties, string columnPath, out AesKey columnKey);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileDecryptionProperties_Column_Key(IntPtr properties, [MarshalAs(UnmanagedType.LPUTF8Str)] string columnPath, out AesKey columnKey);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionProperties_Footer_Key(IntPtr properties, out AesKey footerKey);

--- a/csharp/FileDecryptionPropertiesBuilder.cs
+++ b/csharp/FileDecryptionPropertiesBuilder.cs
@@ -110,13 +110,13 @@ namespace ParquetSharp
 
         public FileDecryptionProperties Build() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionPropertiesBuilder_Build));
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionPropertiesBuilder_Create(out IntPtr builder);
 
         [DllImport(ParquetDll.Name)]
         private static extern void FileDecryptionPropertiesBuilder_Free(IntPtr builder);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionPropertiesBuilder_Footer_Key(IntPtr builder, in AesKey footerKey);
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/FileEncryptionProperties.cs
+++ b/csharp/FileEncryptionProperties.cs
@@ -54,8 +54,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern void FileEncryptionProperties_File_Aad_Free(IntPtr fileAad);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileEncryptionProperties_Column_Encryption_Properties(IntPtr properties,  string columnPath, out IntPtr columnEncryptionProperties);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionProperties_Column_Encryption_Properties(IntPtr properties, [MarshalAs(UnmanagedType.LPUTF8Str)] string columnPath, out IntPtr columnEncryptionProperties);
 
         internal readonly ParquetHandle Handle;
     }

--- a/csharp/FileEncryptionPropertiesBuilder.cs
+++ b/csharp/FileEncryptionPropertiesBuilder.cs
@@ -74,7 +74,7 @@ namespace ParquetSharp
 
         public FileEncryptionProperties Build() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileEncryptionPropertiesBuilder_Build));
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileEncryptionPropertiesBuilder_Create(in AesKey footerKey, out IntPtr builder);
 
         [DllImport(ParquetDll.Name)]
@@ -86,14 +86,14 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileEncryptionPropertiesBuilder_Algorithm(IntPtr builder, ParquetCipher parquetCipher);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileEncryptionPropertiesBuilder_Footer_Key_Id(IntPtr builder, string footerKeyId);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Footer_Key_Id(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string footerKeyId);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileEncryptionPropertiesBuilder_Footer_Key_Metadata(IntPtr builder, string footerKeyMetadata);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Footer_Key_Metadata(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string footerKeyMetadata);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr FileEncryptionPropertiesBuilder_Aad_Prefix(IntPtr builder, string aadPrefix);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileEncryptionPropertiesBuilder_Aad_Prefix(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string aadPrefix);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileEncryptionPropertiesBuilder_Disable_Aad_Prefix_Storage(IntPtr builder);

--- a/csharp/FileMetaData.cs
+++ b/csharp/FileMetaData.cs
@@ -17,7 +17,7 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
-        public string CreatedBy => Marshal.PtrToStringAnsi(ExceptionInfo.Return<IntPtr>(_handle, FileMetaData_Created_By));
+        public string CreatedBy => ExceptionInfo.ReturnString(_handle, FileMetaData_Created_By);
 
         public IReadOnlyDictionary<string, string> KeyValueMetadata
         {

--- a/csharp/KeyValueMetadata.cs
+++ b/csharp/KeyValueMetadata.cs
@@ -34,10 +34,8 @@ namespace ParquetSharp
 
                 for (int i = 0; i != size; ++i)
                 {
-                    // ReSharper disable PossibleNullReferenceException
-                    var k = Marshal.PtrToStringAnsi(((IntPtr*) keys)[i]);
-                    var v = Marshal.PtrToStringAnsi(((IntPtr*) values)[i]);
-                    // ReSharper restore PossibleNullReferenceException
+                    var k = StringUtil.PtrToStringUtf8(((IntPtr*) keys)[i]);
+                    var v = StringUtil.PtrToStringUtf8(((IntPtr*) values)[i]);
 
                     dict.Add(k, v);
                 }
@@ -54,41 +52,25 @@ namespace ParquetSharp
 
         private static unsafe IntPtr Make(IReadOnlyDictionary<string, string> keyValueMetadata)
         {
-            using (var byteBuffer = new ByteBuffer(1024))
+            using var byteBuffer = new ByteBuffer(1024);
+            var keys = new IntPtr[keyValueMetadata.Count];
+            var values = new IntPtr[keyValueMetadata.Count];
+            var i = 0;
+
+            foreach (var entry in keyValueMetadata)
             {
-                var keys = new IntPtr[keyValueMetadata.Count];
-                var values = new IntPtr[keyValueMetadata.Count];
-                var i = 0;
+                keys[i] = StringUtil.ToCStringUtf8(entry.Key, byteBuffer);
+                values[i] = StringUtil.ToCStringUtf8(entry.Value, byteBuffer);
 
-                foreach (var entry in keyValueMetadata)
-                {
-                    keys[i] = ToCString(entry.Key, byteBuffer);
-                    values[i] = ToCString(entry.Value, byteBuffer);
-
-                    ++i;
-                }
-
-                fixed (IntPtr* pKeys = keys)
-                fixed (IntPtr* pValues = values)
-                {
-                    ExceptionInfo.Check(KeyValueMetadata_Make(values.Length, new IntPtr(pKeys), new IntPtr(pValues), out var handle));
-                    return handle;
-                }
-            }
-        }
-
-        private static unsafe IntPtr ToCString(string str, ByteBuffer byteBuffer)
-        {
-            var ascii = System.Text.Encoding.ASCII;
-            var byteCount = ascii.GetByteCount(str);
-            var byteArray = byteBuffer.Allocate(byteCount + 1);
-
-            fixed (char* chars = str)
-            {
-                ascii.GetBytes(chars, str.Length, (byte*) byteArray.Pointer, byteCount);
+                ++i;
             }
 
-            return byteArray.Pointer;
+            fixed (IntPtr* pKeys = keys)
+            fixed (IntPtr* pValues = values)
+            {
+                ExceptionInfo.Check(KeyValueMetadata_Make(values.Length, new IntPtr(pKeys), new IntPtr(pValues), out var handle));
+                return handle;
+            }
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -57,8 +57,8 @@ namespace ParquetSharp
             return new RowGroupReader(ExceptionInfo.Return<int, IntPtr>(_handle, i, ParquetFileReader_RowGroup));
         }
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ParquetFileReader_OpenFile(string path, IntPtr readerProperties, out IntPtr reader);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ParquetFileReader_OpenFile([MarshalAs(UnmanagedType.LPUTF8Str)] string path, IntPtr readerProperties, out IntPtr reader);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ParquetFileReader_Open(IntPtr readableFileInterface, IntPtr readerProperties, out IntPtr reader);

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -193,10 +193,10 @@ namespace ParquetSharp
             return builder.Build();
         }
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ParquetFileWriter_OpenFile(string path, IntPtr schema, IntPtr writerProperties, IntPtr keyValueMetadata, out IntPtr writer);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ParquetFileWriter_OpenFile([MarshalAs(UnmanagedType.LPUTF8Str)] string path, IntPtr schema, IntPtr writerProperties, IntPtr keyValueMetadata, out IntPtr writer);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr ParquetFileWriter_Open(IntPtr outputStream, IntPtr schema, IntPtr writerProperties, IntPtr keyValueMetadata, out IntPtr writer);
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net471;netstandard2.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp</AssemblyName>

--- a/csharp/Schema/ColumnPath.cs
+++ b/csharp/Schema/ColumnPath.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace ParquetSharp.Schema
@@ -49,7 +50,7 @@ namespace ParquetSharp.Schema
 
             for (var i = 0; i != length; ++i)
             {
-                strings[i] = Marshal.PtrToStringAnsi(cstrings[i]);
+                strings[i] = StringUtil.PtrToStringUtf8(cstrings[i]);
             }
 
             ColumnPath_ToDotVector_Free(dotVector, length);
@@ -67,7 +68,10 @@ namespace ParquetSharp.Schema
 
         private static IntPtr Make(string[] dotVector)
         {
-            ExceptionInfo.Check(ColumnPath_Make(dotVector, dotVector.Length, out var handle));
+            using var byteBuffer = new ByteBuffer(1024);
+            var ptrs = dotVector.Select(s => StringUtil.ToCStringUtf8(s, byteBuffer)).ToArray();
+
+            ExceptionInfo.Check(ColumnPath_Make(ptrs, dotVector.Length, out var handle));
             return handle;
         }
 
@@ -85,17 +89,17 @@ namespace ParquetSharp.Schema
         [DllImport(ParquetDll.Name)]
         private static extern void ColumnPath_Free(IntPtr columnPath);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnPath_Make(string[] path, int length, out IntPtr columnPath);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnPath_Make(IntPtr[] path, int length, out IntPtr columnPath);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnPath_MakeFromDotString(string dotString, out IntPtr columnPath);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnPath_MakeFromDotString([MarshalAs(UnmanagedType.LPUTF8Str)] string dotString, out IntPtr columnPath);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnPath_MakeFromNode(IntPtr node, out IntPtr columnPath);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr ColumnPath_Extend(IntPtr columnPath, string nodeName, out IntPtr newColumnPath);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ColumnPath_Extend(IntPtr columnPath, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeName, out IntPtr newColumnPath);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnPath_ToDotString(IntPtr columnPath, out IntPtr dotString);

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -67,8 +67,8 @@ namespace ParquetSharp.Schema
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr GroupNode_Field_Count(IntPtr groupNode, out int fieldCount);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr GroupNode_Field_Index_By_Name(IntPtr groupNode, string name, out int index);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr GroupNode_Field_Index_By_Name(IntPtr groupNode, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, out int index);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr GroupNode_Field_Index_By_Node(IntPtr groupNode, IntPtr node, out int index);

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -57,9 +57,9 @@ namespace ParquetSharp.Schema
             }
         }
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr GroupNode_Make(
-            string name, Repetition repetition, IntPtr fields, int numFields, IntPtr logicalType, out IntPtr groupNode);
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, Repetition repetition, IntPtr fields, int numFields, IntPtr logicalType, out IntPtr groupNode);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr GroupNode_Field(IntPtr groupNode, int i, out IntPtr field);

--- a/csharp/Schema/PrimitiveNode.cs
+++ b/csharp/Schema/PrimitiveNode.cs
@@ -54,9 +54,9 @@ namespace ParquetSharp.Schema
             return primitiveNode;
         }
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr PrimitiveNode_Make(
-            string name, Repetition repetition, IntPtr logicalType, PhysicalType type, int primitiveLength, out IntPtr primitiveNode);
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name, Repetition repetition, IntPtr logicalType, PhysicalType type, int primitiveLength, out IntPtr primitiveNode);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr PrimitiveNode_Column_Order(IntPtr node, out ColumnOrder columnOrder);

--- a/csharp/SchemaDescriptor.cs
+++ b/csharp/SchemaDescriptor.cs
@@ -12,7 +12,7 @@ namespace ParquetSharp
         }
 
         public GroupNode GroupNode => (GroupNode) (Node.Create(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Group_Node)) ?? throw new InvalidOperationException());
-        public string Name => Marshal.PtrToStringAnsi(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Name));
+        public string Name => ExceptionInfo.ReturnString(_handle, SchemaDescriptor_Name);
         public int NumColumns => ExceptionInfo.Return<int>(_handle, SchemaDescriptor_Num_Columns);
         public Node SchemaRoot => Node.Create(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Schema_Root)) ?? throw new InvalidOperationException();
 

--- a/csharp/SchemaDescriptor.cs
+++ b/csharp/SchemaDescriptor.cs
@@ -44,8 +44,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr SchemaDescriptor_ColumnIndex_ByNode(IntPtr descriptor, IntPtr node, out int columnIndex);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr SchemaDescriptor_ColumnIndex_ByPath(IntPtr descriptor, string path, out int columnIndex);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaDescriptor_ColumnIndex_ByPath(IntPtr descriptor, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, out int columnIndex);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr SchemaDescriptor_Get_Column_Root(IntPtr descriptor, int i, out IntPtr columnRoot);

--- a/csharp/StringUtil.cs
+++ b/csharp/StringUtil.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    internal static class StringUtil
+    {
+        public static unsafe IntPtr ToCStringUtf8(string str, ByteBuffer byteBuffer)
+        {
+            var ascii = System.Text.Encoding.UTF8;
+            var byteCount = ascii.GetByteCount(str);
+            var byteArray = byteBuffer.Allocate(byteCount + 1);
+
+            fixed (char* chars = str)
+            {
+                ascii.GetBytes(chars, str.Length, (byte*)byteArray.Pointer, byteCount);
+            }
+
+            return byteArray.Pointer;
+        }
+
+        public static string PtrToStringUtf8(IntPtr ptr)
+        {
+            return PtrToNullableStringUtf8(ptr) ?? throw new ArgumentNullException(nameof(ptr));
+        }
+
+        public static string? PtrToNullableStringUtf8(IntPtr ptr)
+        {
+#if NETSTANDARD2_1_OR_GREATER
+            return Marshal.PtrToStringUTF8(ptr);
+#else
+            if (ptr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            unsafe
+            {
+                var s = (byte*)ptr;
+                int length;
+                for (length = 0; s[length] != '\0'; ++length)
+                {
+                }
+
+                return System.Text.Encoding.UTF8.GetString(s, length);
+            }
+#endif
+        }
+    }
+}

--- a/csharp/StringUtil.cs
+++ b/csharp/StringUtil.cs
@@ -7,13 +7,13 @@ namespace ParquetSharp
     {
         public static unsafe IntPtr ToCStringUtf8(string str, ByteBuffer byteBuffer)
         {
-            var ascii = System.Text.Encoding.UTF8;
-            var byteCount = ascii.GetByteCount(str);
+            var utf8 = System.Text.Encoding.UTF8;
+            var byteCount = utf8.GetByteCount(str);
             var byteArray = byteBuffer.Allocate(byteCount + 1);
 
             fixed (char* chars = str)
             {
-                ascii.GetBytes(chars, str.Length, (byte*)byteArray.Pointer, byteCount);
+                utf8.GetBytes(chars, str.Length, (byte*)byteArray.Pointer, byteCount);
             }
 
             return byteArray.Pointer;

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -247,8 +247,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Disable_Dictionary(IntPtr builder);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Disable_Dictionary_By_Path(IntPtr builder, string path);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Disable_Dictionary_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Disable_Dictionary_By_ColumnPath(IntPtr builder, IntPtr path);
@@ -256,8 +256,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Enable_Dictionary(IntPtr builder);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Enable_Dictionary_By_Path(IntPtr builder, string path);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Enable_Dictionary_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Enable_Dictionary_By_ColumnPath(IntPtr builder, IntPtr path);
@@ -267,8 +267,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Disable_Statistics(IntPtr builder);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Disable_Statistics_By_Path(IntPtr builder, string path);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Disable_Statistics_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Disable_Statistics_By_ColumnPath(IntPtr builder, IntPtr path);
@@ -276,8 +276,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Enable_Statistics(IntPtr builder);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Enable_Statistics_By_Path(IntPtr builder, string path);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Enable_Statistics_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Enable_Statistics_By_ColumnPath(IntPtr builder, IntPtr path);
@@ -287,8 +287,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Compression(IntPtr builder, Compression codec);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Compression_By_Path(IntPtr builder, string path, Compression codec);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Compression_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, Compression codec);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Compression_By_ColumnPath(IntPtr builder, IntPtr path, Compression codec);
@@ -296,14 +296,14 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Compression_Level(IntPtr builder, int compressionLevel);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Compression_Level_By_Path(IntPtr builder, string path, int compressionLevel);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Compression_Level_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, int compressionLevel);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Compression_Level_By_ColumnPath(IntPtr builder, IntPtr path, int compressionLevel);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Created_By(IntPtr builder, string createdBy);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Created_By(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string createdBy);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Data_Pagesize(IntPtr builder, long pgSize);
@@ -314,8 +314,8 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Encoding(IntPtr builder, Encoding encodingType);
 
-        [DllImport(ParquetDll.Name, CharSet = CharSet.Ansi)]
-        private static extern IntPtr WriterPropertiesBuilder_Encoding_By_Path(IntPtr builder, string path, Encoding encodingType);
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Encoding_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, Encoding encodingType);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Encoding_By_ColumnPath(IntPtr builder, IntPtr path, Encoding encodingType);


### PR DESCRIPTION
Fixes Issue #205.

Doing this PR requires `[MarshalAs(UnmanagedType.LPUTF8Str)]` which is only supported in net47 or higher. This means I've taken the decision to retire support for .NET Framework 4.6.1 and .NET Core 2.0 or lower. Otherwise, the code would be significantly more complicated and require explicit conversion of all strings to UTF8 before calling into the native methods. Even so, I had to backport `PtrToStringUTF8` from .NET Standard 2.1 (can't believe marshalling UTF8 wasn't properly supported until .NET Core 3.0).

The rest should be less controversial.

One area I'm not sure is `key_id` vs `key_metadata`. I think one of them is meant to be a byte array while the other should be a UTF8 string. But the documentation is lacking. This PR does not address this ambiguity (left out of scope on purpose).