### PR TITLE
Bump version of dotnet 5 SDK used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
-  dotnet_3_version: '3.1.407'
-  dotnet_5_version: '5.0.400'
+  dotnet_3_version: '3.1.414'
+  dotnet_5_version: '5.0.402'
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   dotnet_3_version: '3.1.407'
-  dotnet_5_version: '5.0.201'
+  dotnet_5_version: '5.0.400'
 
 jobs:
 


### PR DESCRIPTION
This should fix "The repository primary signature validity period has expired" errors on macOS.

See https://github.com/dotnet/core/issues/6595