### PR TITLE
Automatic NuGet and release publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,6 @@ jobs:
         dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
     - name: Build & Run .NET unit tests
       run: dotnet test csharp.test --configuration=Release --framework ${{ steps.dotnet.outputs.framework }}
-    outputs:
-      version: ${{ steps.get-version.outputs.version }}
 
   # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
   publish-release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,12 +250,21 @@ jobs:
     - name: Build & Run .NET unit tests
       run: dotnet test csharp.test --configuration=Release --framework ${{ steps.dotnet.outputs.framework }}
 
+  # Virtual job that can be configured as a required check before a PR can be merged.
+  all-required-checks-done:
+    needs:
+      - check-format
+      - test-nuget
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All required checks done"
+
   # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
   publish-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !github.event.repository.fork
     name: Publish release
     runs-on: ubuntu-latest
-    needs: test-nuget
+    needs: all-required-checks-done
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,3 +249,45 @@ jobs:
         dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
     - name: Build & Run .NET unit tests
       run: dotnet test csharp.test --configuration=Release --framework ${{ steps.dotnet.outputs.framework }}
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+
+  # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
+  publish-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !github.event.repository.fork
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: test-nuget
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Check version
+      id: check-version
+      shell: pwsh
+      run: |
+        $version = (Select-Xml -Path ./csharp/ParquetSharp.csproj -XPath '/Project/PropertyGroup/Version/text()').node.Value
+        $tag = "${{ github.ref }}".SubString(10)
+        if (-not ($tag -eq $version)) {
+          echo "::error ::There is a mismatch between the project version ($version) and the tag ($tag)"
+          exit 1
+        }
+        echo "::set-output name=version::$version"
+    - name: Download NuGet artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: nuget-package
+        path: nuget
+    # if version contains "-" treat it as pre-release
+    # example: 1.0.0-beta1
+    - name: Create release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: ParquetSharp ${{ steps.check-version.outputs.version }}
+        draft: true
+        prerelease: ${{ contains(steps.check-version.outputs.version, '-') }}
+        files: |
+          nuget/ParquetSharp.${{ steps.check-version.outputs.version }}.nupkg
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish to NuGet
+      run: dotnet nuget push nuget/ParquetSharp.${{ steps.check-version.outputs.version }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This PR enables the automatic creation of a draft GitHub release with the NuGet Package when a tag is created, as well as uploading the package to nuget.org.

#### Pre-requisites for merging
- [x] creation of `NUGET_API_KEY` secret with upload rights to nuget.org