### PR TITLE
Support Windows Server 2022 CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-2022]
         arch: [x64, arm64]
         exclude:
-        - os: windows-latest
+        - os: windows-2022
           arch: arm64
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
@@ -207,11 +207,11 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-2022]
         dotnet: [3, 5]
         arch: [x64]
         include:
-        - os: windows-latest
+        - os: windows-2022
           dotnet: 4
           arch: x64
         - os: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ In the 5.0.X versions, reading nested structures was introduced. However, nestin
 ## Building
 
 Building ParquetSharp for Windows requires the following dependencies:
-- Visual Studio 2019 (16.4 or higher)
+- Visual Studio 2022 (17.0 or higher)
 - Apache Arrow (6.0.1)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://github.com/Microsoft/vcpkg). Note that the Windows build needs to be done in a Visual Studio x64 Native Tools Command Prompt for the build script to succeed.
 
-**Windows (Visual Studio 2019 Win64 solution)**
+**Windows (Visual Studio 2022 Win64 solution)**
 ```
 > vcpkg_windows.bat
 > build_windows.bat

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,5 +1,5 @@
 set triplet=x64-windows-static
-cmake -B build/%triplet% -S . -D VCPKG_TARGET_TRIPLET=%triplet% -D CMAKE_TOOLCHAIN_FILE=../vcpkg.%triplet%/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 16 2019" -A "x64" || goto :error
+cmake -B build/%triplet% -S . -D VCPKG_TARGET_TRIPLET=%triplet% -D CMAKE_TOOLCHAIN_FILE=../vcpkg.%triplet%/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 17 2022" -A "x64" || goto :error
 msbuild build/%triplet%/ParquetSharp.sln -t:ParquetSharpNative:Rebuild -p:Configuration=Release || goto :error
 
 exit /b


### PR DESCRIPTION
GitHub has started rolling out Windows Server 2022 to GitHub actions jobs running on `windows-latest`: https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/

This image includes Visual Studio 2022 instead of 2019, so I've updated the build script to expect VS 2022, and explicitly set the Windows image to windows-2022 in the CI configuration so we're pinned to one version rather than randomly getting either 2019 or 2022 during the roll out.

Alternatively we could just stick with 2019, but I think it's best to keep up to date.