### PR TITLE
Promote 6.0.1-beta1 to stable release

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>6.0.1-beta1</Version>
+    <Version>6.0.1</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>


### PR DESCRIPTION
Because of changes in vcpkg/msys2, the build was not reproducible anymore. @adamreeve fixed it in #265.
This means that even though none of our code changed between 6.0.1-beta1 and now, some of our indirect dependencies got upgraded. Here is the list:
- boost: 1.77.0 -> 1.78.0
- openssl: 1.1.1l -> 1.1.1n
- zstd: 1.5.0 -> 1.5.2