### PR TITLE
Fix vcpkg binary caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       if: steps.get-cached-vcpkg.outputs.cache-hit != 'true' && (success() || failure())
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ steps.vcpkg-triplet.outputs.triplet }}-vcpkg-arrow-logs
+        name: ${{ steps.vcpkg-info.outputs.triplet }}-vcpkg-arrow-logs
         path: ${{ steps.vcpkg-info.outputs.root }}/buildtrees/arrow/*.log
     - name: Build .NET benchmarks & unit tests
       run: |
@@ -141,7 +141,7 @@ jobs:
     - name: Upload native ParquetSharp library
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ steps.vcpkg-triplet.outputs.triplet }}-native-library
+        name: ${{ steps.vcpkg-info.outputs.triplet }}-native-library
         path: bin
 
   # Download all native shared libraries and create the nuget package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,22 @@ jobs:
         echo "::set-output name=root::$VCPKG_INSTALLATION_ROOT"
       shell: bash
 
+    # Get cmake version, which is used by vcpkg binary caching
+    - name: Get cmake version
+      id: cmake-info
+      run: echo "::set-output name=version::$(cmake --version | head -n1 | awk '{print $3}')"
+      shell: bash
+
     # Check for cached vcpkg dependencies (use these if we can).
     - name: Get cached vcpkg dependencies
       id: get-cached-vcpkg
       uses: actions/cache@v3
       with:
         path: cache/vcpkg
-        key: vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-${{ hashFiles('vcpkg-configuration.json') }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake${{ steps.cmake-info.outputs.version }}-${{ hashFiles('vcpkg-configuration.json') }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-${{ hashFiles('vcpkg-configuration.json') }}-
+          vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake${{ steps.cmake-info.outputs.version }}-${{ hashFiles('vcpkg-configuration.json') }}-
+          vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake${{ steps.cmake-info.outputs.version }}-
           vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-
 
     # Install arm64 cross-compilation toolchain if required


### PR DESCRIPTION
The `vcpkg` binary caching in our CI currently gets [broken](https://github.com/G-Research/ParquetSharp/runs/6121033684?check_suite_focus=true) when a cache entry gets [generated](https://github.com/G-Research/ParquetSharp/runs/6121033684?check_suite_focus=true) with a given version of `cmake` and then gets [used](https://github.com/G-Research/ParquetSharp/runs/6121033684?check_suite_focus=true#step:4:18) with a different version, e.g. when the runner virtual environment gets upgraded (`macOS-11` [20220410.1](https://github.com/actions/virtual-environments/blob/macOS-11/20220410.1/images/macos/macos-11-Readme.md#tools) vs [20220419.3](https://github.com/actions/virtual-environments/blob/macOS-11/20220419.3/images/macos/macos-11-Readme.md#tools)).
The broken cache entry then keeps on getting used for every subsequent run, resulting in a much slower CI feedback loop.

This PR aims at fixing this by adding the `cmake` version to the cache key.

Unrelated to this, the artifact names got mangled together during #265 (specifically my commit f78df21). This PR fixes that too.