### PR TITLE
Build linux-x64 in a CentOS 7 container for backwards compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,17 @@ jobs:
           vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake${{ steps.cmake-info.outputs.version }}-
           vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-
 
+    # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.
+    - name: Start CentOS container and install toolchain
+      if: runner.os == 'Linux' && matrix.arch == 'x64'
+      run: |
+        docker run -d --name centos --entrypoint tail -v $PWD:$PWD -v $VCPKG_INSTALLATION_ROOT:$VCPKG_INSTALLATION_ROOT centos:7 -f /dev/null
+        docker exec centos sh -c "yum install -y centos-release-scl epel-release && \
+                                  yum install -y devtoolset-7 rh-git227 flex bison && \
+                                  curl -fsSL -o /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v${{ steps.cmake-info.outputs.version }}/cmake-${{ steps.cmake-info.outputs.version }}-linux-x86_64.sh && \
+                                  sh /tmp/cmake.sh --skip-license --prefix=/usr/local && \
+                                  rm /tmp/cmake.sh"
+
     # Install arm64 cross-compilation toolchain if required
     - name: Install arm64 cross-compilation toolchain
       if: runner.os == 'Linux' && matrix.arch == 'arm64'
@@ -127,7 +138,11 @@ jobs:
     # Compile ParquetSharp and C++ dependencies (and upload the native library as an artifact).
     - name: Compile native ParquetSharp library (Unix)
       if: runner.os == 'Linux' || runner.os == 'macOS'
-      run: ./build_unix.sh ${{ matrix.arch }}
+      run: |
+        if [ "${{ runner.os }}" == "Linux" ] && [ "${{ matrix.arch }}" == "x64" ]; then
+          exec="docker exec -w $PWD -e GITHUB_ACTIONS -e VCPKG_BINARY_SOURCES -e VCPKG_INSTALLATION_ROOT centos scl enable devtoolset-7 rh-git227 --"
+        fi
+        $exec ./build_unix.sh ${{ matrix.arch }}
       env:
         VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/cache/vcpkg,readwrite
     - name: Compile native ParquetSharp library (Windows)
@@ -150,6 +165,10 @@ jobs:
       with:
         name: ${{ steps.vcpkg-info.outputs.triplet }}-native-library
         path: bin
+
+    - name: Stop CentOS container
+      if: runner.os == 'Linux' && matrix.arch == 'x64'
+      run: docker rm -f centos
 
   # Download all native shared libraries and create the nuget package.
   # Upload nuget package as an artifact.

--- a/build_unix.sh
+++ b/build_unix.sh
@@ -21,10 +21,11 @@ esac
 case $(uname) in
   Linux)
     os=linux
+    [ -f /etc/redhat-release ] && platform=redhat-linux || platform=linux-gnu
     options="-D CMAKE_SYSTEM_PROCESSOR=$linux_arch \
-             -D CMAKE_C_COMPILER=$(which $linux_arch-linux-gnu-gcc) \
-             -D CMAKE_CXX_COMPILER=$(which $linux_arch-linux-gnu-g++) \
-             -D CMAKE_STRIP=$(which $linux_arch-linux-gnu-strip)"
+             -D CMAKE_C_COMPILER=$(which $linux_arch-$platform-gcc) \
+             -D CMAKE_CXX_COMPILER=$(which $linux_arch-$platform-g++) \
+             -D CMAKE_STRIP=$(which $linux_arch-$platform-strip 2>/dev/null || which strip)"
     ;;
   Darwin)
     os=osx


### PR DESCRIPTION
This PR aims at fixing #273 by building the linux-x64 native library within a CentOS 7 container with GCC 7. This allows linking with older versions of the system libraries, widening the Linux distributions supported by our NuGet package.

Please note that the linux-arm64 native library is still built on Ubuntu 18.04, as there is no recent cross-compiler available on CentOS 7. We will probably need to first get self-hosted linux-arm64 runners before we can support this. All of this being said, I don't expect many people to use old Linux distributions on arm64. 