### PR TITLE
Improve error message when getting a LogicalColumnReader or Writer with the wrong type

### DIFF
--- a/csharp.test/TestLogicalColumnReader.cs
+++ b/csharp.test/TestLogicalColumnReader.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using ParquetSharp.IO;
+using NUnit.Framework;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestLogicalColumnReader
+    {
+        [Test]
+        public static void TestInvalidCastErrorMessage()
+        {
+            const int numRows = 10;
+            var schemaColumns = new Column[] {new Column<int?>("col")};
+            var values = Enumerable.Range(0, numRows).Select(val => (int?) val).ToArray();
+
+            using var buffer = new ResizableBuffer();
+
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var writer = new ParquetFileWriter(outStream, schemaColumns);
+                using var rowGroupWriter = writer.AppendRowGroup();
+                using var colWriter = rowGroupWriter.NextColumn().LogicalWriter<int?>();
+
+                colWriter.WriteBatch(values);
+
+                writer.Close();
+            }
+
+            using var inStream = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(inStream);
+            using var rowGroupReader = fileReader.RowGroup(0);
+            using var column = rowGroupReader.Column(0);
+
+            var exception = Assert.Throws<InvalidCastException>(() => column.LogicalReader<int>())!;
+
+            Assert.That(exception.Message, Is.EqualTo(
+                "Tried to get a LogicalColumnReader for column 0 with an element type of 'System.Int32' " +
+                "but the actual element type is 'System.Nullable`1[System.Int32]'."));
+        }
+    }
+}

--- a/csharp.test/TestLogicalColumnWriter.cs
+++ b/csharp.test/TestLogicalColumnWriter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using ParquetSharp.IO;
+using NUnit.Framework;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestLogicalColumnWriter
+    {
+        [Test]
+        public static void TestInvalidCastErrorMessage()
+        {
+            var schemaColumns = new Column[] {new Column<int?>("col")};
+
+            using var buffer = new ResizableBuffer();
+
+            using var outStream = new BufferOutputStream(buffer);
+            using var writer = new ParquetFileWriter(outStream, schemaColumns);
+            using var rowGroupWriter = writer.AppendRowGroup();
+            using var colWriter = rowGroupWriter.NextColumn();
+
+            var exception = Assert.Throws<InvalidCastException>(() => colWriter.LogicalWriter<int>())!;
+
+            Assert.That(exception.Message, Is.EqualTo(
+                "Tried to get a LogicalColumnWriter for column 0 with an element type of 'System.Int32' " +
+                "but the actual element type is 'System.Nullable`1[System.Int32]'."));
+
+            writer.Close();
+        }
+    }
+}

--- a/csharp.test/TestLogicalTypeFactory.cs
+++ b/csharp.test/TestLogicalTypeFactory.cs
@@ -37,7 +37,8 @@ namespace ParquetSharp.Test
             {
                 using var reader = groupReader.Column(0).LogicalReader<VolumeInDollars>();
             });
-            StringAssert.StartsWith("Unable to cast object of type 'ParquetSharp.LogicalColumnReader`3[System.Single,System.Single,System.Single]", exception?.Message);
+            StringAssert.StartsWith("Tried to get a LogicalColumnReader for column 0", exception?.Message);
+            StringAssert.Contains("actual element type is 'System.Single'", exception?.Message);
         }
 
         [Test]
@@ -83,7 +84,8 @@ namespace ParquetSharp.Test
             {
                 using var writer = groupWriter.NextColumn().LogicalWriter<VolumeInDollars>();
             });
-            StringAssert.StartsWith("Unable to cast object of type 'ParquetSharp.LogicalColumnWriter`3[System.Single,System.Single,System.Single]", exception?.Message);
+            StringAssert.StartsWith("Tried to get a LogicalColumnWriter for column 0", exception?.Message);
+            StringAssert.Contains("actual element type is 'System.Single'", exception?.Message);
         }
 
         [Test]

--- a/csharp.test/TestParquetFileReader.cs
+++ b/csharp.test/TestParquetFileReader.cs
@@ -55,7 +55,7 @@ namespace ParquetSharp.Test
                 }
             });
 
-            StringAssert.StartsWith("Unable to cast object of type", exception?.Message);
+            StringAssert.StartsWith("Tried to get a LogicalColumnReader", exception?.Message);
         }
 
         [Test]

--- a/csharp/LogicalColumnReader.cs
+++ b/csharp/LogicalColumnReader.cs
@@ -37,6 +37,22 @@ namespace ParquetSharp
             {
                 return (LogicalColumnReader<TElement>) reader;
             }
+            catch (InvalidCastException exception)
+            {
+                var logicalReaderType = reader.GetType();
+                reader.Dispose();
+                if (logicalReaderType.GetGenericTypeDefinition() != typeof(LogicalColumnReader<,,>))
+                {
+                    throw;
+                }
+                var elementType = logicalReaderType.GetGenericArguments()[2];
+                var expectedElementType = typeof(TElement);
+                var message =
+                    $"Tried to get a LogicalColumnReader for column {columnReader.ColumnIndex} " +
+                    $"with an element type of '{expectedElementType}' " +
+                    $"but the actual element type is '{elementType}'.";
+                throw new InvalidCastException(message, exception);
+            }
             catch
             {
                 reader.Dispose();

--- a/csharp/LogicalColumnWriter.cs
+++ b/csharp/LogicalColumnWriter.cs
@@ -37,6 +37,22 @@ namespace ParquetSharp
             {
                 return (LogicalColumnWriter<TElementType>) writer;
             }
+            catch (InvalidCastException exception)
+            {
+                var logicalWriterType = writer.GetType();
+                writer.Dispose();
+                if (logicalWriterType.GetGenericTypeDefinition() != typeof(LogicalColumnWriter<,,>))
+                {
+                    throw;
+                }
+                var elementType = logicalWriterType.GetGenericArguments()[2];
+                var expectedElementType = typeof(TElementType);
+                var message =
+                    $"Tried to get a LogicalColumnWriter for column {columnWriter.ColumnIndex} " +
+                    $"with an element type of '{expectedElementType}' " +
+                    $"but the actual element type is '{elementType}'.";
+                throw new InvalidCastException(message, exception);
+            }
             catch
             {
                 writer.Dispose();


### PR DESCRIPTION
This is a pretty common error for users to encounter and the current error message looks like this: ```Unable to cast object of type 'ParquetSharp.LogicalColumnReader`3[System.Int32,System.Nullable`1[System.Int32],System.Nullable`1[System.Int32]]' to type 'ParquetSharp.LogicalColumnReader`1[System.Int32]'```. Unless you're familiar with the ParquetSharp code or have run into this before it's not very obvious what has gone wrong. 