### PR TITLE
Allow updating key-value metadata after ParquetFileWriter creation

### DIFF
--- a/cpp/KeyValueMetadata.cpp
+++ b/cpp/KeyValueMetadata.cpp
@@ -9,7 +9,7 @@ using namespace parquet;
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Make(const int64_t size, const char** keys, const char** values, std::shared_ptr<const KeyValueMetadata>** key_value_metadata)
+	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Make(const int64_t size, const char** keys, const char** values, std::shared_ptr<KeyValueMetadata>** key_value_metadata)
 	{
 		TRYCATCH
 		(
@@ -22,8 +22,13 @@ extern "C"
 				values_vector[i] = values[i];
 			}
 
-			*key_value_metadata = new std::shared_ptr<const KeyValueMetadata>(new KeyValueMetadata(keys_vector, values_vector));
+			*key_value_metadata = new std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata(keys_vector, values_vector));
 		)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_MakeEmpty(std::shared_ptr<KeyValueMetadata>** key_value_metadata)
+	{
+		TRYCATCH(*key_value_metadata = new std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata());)
 	}
 
 	PARQUETSHARP_EXPORT void KeyValueMetadata_Free(const std::shared_ptr<const KeyValueMetadata>* key_value_metadata)
@@ -34,6 +39,18 @@ extern "C"
 	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Size(const std::shared_ptr<const KeyValueMetadata>* key_value_metadata, int64_t* size)
 	{
 		TRYCATCH(*size = (*key_value_metadata)->size();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Set(const std::shared_ptr<KeyValueMetadata>* key_value_metadata, const char* key, const char* value)
+	{
+		TRYCATCH
+		(
+			::arrow::Status status = (*key_value_metadata)->Set(key, value);
+			if (!status.ok()) {
+				std::string code = status.CodeAsString();
+				return new ExceptionInfo(code.c_str(), status.message().c_str());
+			}
+		)
 	}
 
 	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Get_Entries(const std::shared_ptr<const KeyValueMetadata>* key_value_metadata, const char*** keys, const char*** values)

--- a/cpp/KeyValueMetadata.cpp
+++ b/cpp/KeyValueMetadata.cpp
@@ -9,23 +9,6 @@ using namespace parquet;
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Make(const int64_t size, const char** keys, const char** values, std::shared_ptr<KeyValueMetadata>** key_value_metadata)
-	{
-		TRYCATCH
-		(
-			std::vector<std::string> keys_vector(size);
-			std::vector<std::string> values_vector(size);
-
-			for (int64_t i = 0; i != size; ++i)
-			{
-				keys_vector[i] = keys[i];
-				values_vector[i] = values[i];
-			}
-
-			*key_value_metadata = new std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata(keys_vector, values_vector));
-		)
-	}
-
 	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_MakeEmpty(std::shared_ptr<KeyValueMetadata>** key_value_metadata)
 	{
 		TRYCATCH(*key_value_metadata = new std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata());)
@@ -41,15 +24,10 @@ extern "C"
 		TRYCATCH(*size = (*key_value_metadata)->size();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Set(const std::shared_ptr<KeyValueMetadata>* key_value_metadata, const char* key, const char* value)
+	PARQUETSHARP_EXPORT ExceptionInfo* KeyValueMetadata_Append(const std::shared_ptr<KeyValueMetadata>* key_value_metadata, const char* key, const char* value)
 	{
-		TRYCATCH
-		(
-			::arrow::Status status = (*key_value_metadata)->Set(key, value);
-			if (!status.ok()) {
-				std::string code = status.CodeAsString();
-				return new ExceptionInfo(code.c_str(), status.message().c_str());
-			}
+		TRYCATCH(
+			(*key_value_metadata)->Append(key, value);
 		)
 	}
 

--- a/cpp/ParquetFileWriter.cpp
+++ b/cpp/ParquetFileWriter.cpp
@@ -86,15 +86,6 @@ extern "C"
 		TRYCATCH(*descr = writer->descr(i);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ParquetFileWriter_Key_Value_Metadata(ParquetFileWriter* writer, const std::shared_ptr<const KeyValueMetadata>** key_value_metadata)
-	{
-		TRYCATCH
-		(
-			const auto& m = writer->key_value_metadata();
-			*key_value_metadata = m ? new std::shared_ptr(m) : nullptr;
-		)
-	}
-
 	PARQUETSHARP_EXPORT ExceptionInfo* ParquetFileWriter_Metadata(ParquetFileWriter* writer, const std::shared_ptr<FileMetaData>** metadata)
 	{
 		TRYCATCH

--- a/csharp.test/TestKeyValueMetadata.cs
+++ b/csharp.test/TestKeyValueMetadata.cs
@@ -1,0 +1,154 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ParquetSharp.IO;
+using NUnit.Framework;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestKeyValueMetadata
+    {
+        [Test]
+        public static void TestSpecifyingKeyValueMetadataUpFront()
+        {
+            var columns = new Column[] {new Column<int>("values")};
+            var values = Enumerable.Range(0, 100).ToArray();
+
+            var expectedKeyValueMetadata = new Dictionary<string, string>
+            {
+                {"key1", "value1"},
+                {"key2", "value2"},
+            };
+
+            using var buffer = new ResizableBuffer();
+            using (var output = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(output, columns, keyValueMetadata: expectedKeyValueMetadata);
+                using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+
+                using var colWriter = rowGroupWriter.Column(0).LogicalWriter<int>();
+                colWriter.WriteBatch(values);
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            var keyValueMetadata = fileReader.FileMetaData.KeyValueMetadata;
+
+            Assert.That(keyValueMetadata, Is.EqualTo(expectedKeyValueMetadata));
+
+            fileReader.Close();
+        }
+
+        [Test]
+        public static void TestSpecifyingKeyValueMetadataAfterWritingData()
+        {
+            var columns = new Column[] {new Column<int>("values")};
+            var values = Enumerable.Range(0, 100).ToArray();
+
+            var expectedKeyValueMetadata = new Dictionary<string, string>
+            {
+                {"key1", "value1"},
+                {"key2", "value2"},
+            };
+
+            using var buffer = new ResizableBuffer();
+            using (var output = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(output, columns);
+                using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+
+                using (var colWriter = rowGroupWriter.Column(0).LogicalWriter<int>())
+                {
+                    colWriter.WriteBatch(values);
+                }
+
+                fileWriter.UpdateKeyValueMetadata(expectedKeyValueMetadata);
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            var keyValueMetadata = fileReader.FileMetaData.KeyValueMetadata;
+
+            Assert.That(keyValueMetadata, Is.EqualTo(expectedKeyValueMetadata));
+
+            fileReader.Close();
+        }
+
+        [Test]
+        public static void TestUpdatingKeyValueMetadata()
+        {
+            var columns = new Column[] {new Column<int>("values")};
+            var values = Enumerable.Range(0, 100).ToArray();
+
+            var initialKeyValueMetadata = new Dictionary<string, string>
+            {
+                {"key1", "value1"},
+                {"key2", "value2"},
+            };
+            var keyValueMetadataUpdate = new Dictionary<string, string>
+            {
+                {"key1", "override1"},
+                {"key3", "value3"},
+            };
+            var expectedKeyValueMetadata = new Dictionary<string, string>
+            {
+                {"key1", "override1"},
+                {"key2", "value2"},
+                {"key3", "value3"},
+            };
+
+            using var buffer = new ResizableBuffer();
+            using (var output = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(output, columns, keyValueMetadata: initialKeyValueMetadata);
+                using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+
+                using (var colWriter = rowGroupWriter.Column(0).LogicalWriter<int>())
+                {
+                    colWriter.WriteBatch(values);
+                }
+
+                fileWriter.UpdateKeyValueMetadata(keyValueMetadataUpdate);
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            var keyValueMetadata = fileReader.FileMetaData.KeyValueMetadata;
+
+            Assert.That(keyValueMetadata, Is.EqualTo(expectedKeyValueMetadata));
+
+            fileReader.Close();
+        }
+
+        [Test]
+        public static void TestNoMetadata()
+        {
+            var columns = new Column[] {new Column<int>("values")};
+            var values = Enumerable.Range(0, 100).ToArray();
+
+            using var buffer = new ResizableBuffer();
+            using (var output = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(output, columns);
+                using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+
+                using var colWriter = rowGroupWriter.Column(0).LogicalWriter<int>();
+                colWriter.WriteBatch(values);
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            var keyValueMetadata = fileReader.FileMetaData.KeyValueMetadata;
+
+            Assert.That(keyValueMetadata, Is.Empty);
+
+            fileReader.Close();
+        }
+    }
+}

--- a/csharp/KeyValueMetadata.cs
+++ b/csharp/KeyValueMetadata.cs
@@ -6,8 +6,7 @@ namespace ParquetSharp
 {
     internal sealed class KeyValueMetadata : IDisposable
     {
-        public KeyValueMetadata(IReadOnlyDictionary<string, string>? keyValueMetadata)
-            : this(keyValueMetadata == null ? MakeEmpty() : Make(keyValueMetadata))
+        public KeyValueMetadata() : this(MakeEmpty())
         {
         }
 
@@ -21,14 +20,17 @@ namespace ParquetSharp
             Handle.Dispose();
         }
 
-        public long Size => ExceptionInfo.Return<long>(Handle, KeyValueMetadata_Size);
+        private long Size => ExceptionInfo.Return<long>(Handle, KeyValueMetadata_Size);
 
-        public void Set(string key, string value)
+        public void SetData(IReadOnlyDictionary<string, string> keyValueMetadata)
         {
             using var byteBuffer = new ByteBuffer(1024);
-            var keyPtr = StringUtil.ToCStringUtf8(key, byteBuffer);
-            var valuePtr = StringUtil.ToCStringUtf8(value, byteBuffer);
-            ExceptionInfo.Check(KeyValueMetadata_Set(Handle.IntPtr, keyPtr, valuePtr));
+            foreach (var entry in keyValueMetadata)
+            {
+                var keyPtr = StringUtil.ToCStringUtf8(entry.Key, byteBuffer);
+                var valuePtr = StringUtil.ToCStringUtf8(entry.Value, byteBuffer);
+                ExceptionInfo.Check(KeyValueMetadata_Append(Handle.IntPtr, keyPtr, valuePtr));
+            }
         }
 
         public unsafe IReadOnlyDictionary<string, string> ToDictionary()
@@ -58,37 +60,11 @@ namespace ParquetSharp
             }
         }
 
-        private static unsafe IntPtr Make(IReadOnlyDictionary<string, string> keyValueMetadata)
-        {
-            using var byteBuffer = new ByteBuffer(1024);
-            var keys = new IntPtr[keyValueMetadata.Count];
-            var values = new IntPtr[keyValueMetadata.Count];
-            var i = 0;
-
-            foreach (var entry in keyValueMetadata)
-            {
-                keys[i] = StringUtil.ToCStringUtf8(entry.Key, byteBuffer);
-                values[i] = StringUtil.ToCStringUtf8(entry.Value, byteBuffer);
-
-                ++i;
-            }
-
-            fixed (IntPtr* pKeys = keys)
-            fixed (IntPtr* pValues = values)
-            {
-                ExceptionInfo.Check(KeyValueMetadata_Make(values.Length, new IntPtr(pKeys), new IntPtr(pValues), out var handle));
-                return handle;
-            }
-        }
-
         private static IntPtr MakeEmpty()
         {
             ExceptionInfo.Check(KeyValueMetadata_MakeEmpty(out var handle));
             return handle;
         }
-
-        [DllImport(ParquetDll.Name)]
-        private static extern IntPtr KeyValueMetadata_Make(long size, IntPtr keys, IntPtr values, out IntPtr keyValueMetadata);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr KeyValueMetadata_MakeEmpty(out IntPtr keyValueMetadata);
@@ -100,7 +76,7 @@ namespace ParquetSharp
         private static extern IntPtr KeyValueMetadata_Size(IntPtr keyValueMetadata, out long size);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr KeyValueMetadata_Set(IntPtr keyValueMetadata, IntPtr key, IntPtr value);
+        private static extern IntPtr KeyValueMetadata_Append(IntPtr keyValueMetadata, IntPtr key, IntPtr value);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr KeyValueMetadata_Get_Entries(IntPtr keyValueMetadata, out IntPtr keys, out IntPtr values);

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -16,8 +16,12 @@ namespace ParquetSharp
         {
             using var schema = Column.CreateSchemaNode(columns);
             using var writerProperties = CreateWriterProperties(compression);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(path, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(path, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -29,8 +33,12 @@ namespace ParquetSharp
         {
             using var schema = Column.CreateSchemaNode(columns);
             using var writerProperties = CreateWriterProperties(compression);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -43,8 +51,12 @@ namespace ParquetSharp
         {
             using var schema = Column.CreateSchemaNode(columns, LogicalTypeFactory = logicalTypeFactory ?? LogicalTypeFactory.Default);
             using var writerProperties = CreateWriterProperties(compression);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(path, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(path, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -57,8 +69,12 @@ namespace ParquetSharp
         {
             using var schema = Column.CreateSchemaNode(columns, LogicalTypeFactory = logicalTypeFactory ?? LogicalTypeFactory.Default);
             using var writerProperties = CreateWriterProperties(compression);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -69,8 +85,12 @@ namespace ParquetSharp
             IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             using var schema = Column.CreateSchemaNode(columns);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(path, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(path, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -81,8 +101,12 @@ namespace ParquetSharp
             IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             using var schema = Column.CreateSchemaNode(columns);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -94,8 +118,12 @@ namespace ParquetSharp
             IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             using var schema = Column.CreateSchemaNode(columns, LogicalTypeFactory = logicalTypeFactory ?? LogicalTypeFactory.Default);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(path, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(path, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -107,8 +135,12 @@ namespace ParquetSharp
             IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             using var schema = Column.CreateSchemaNode(columns, LogicalTypeFactory = logicalTypeFactory ?? LogicalTypeFactory.Default);
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = columns;
         }
 
@@ -118,8 +150,12 @@ namespace ParquetSharp
             WriterProperties writerProperties,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(path, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(path, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = null;
         }
 
@@ -129,8 +165,12 @@ namespace ParquetSharp
             WriterProperties writerProperties,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
-            _keyValueMetadata = new KeyValueMetadata(keyValueMetadata);
-            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _keyValueMetadata);
+            if (keyValueMetadata != null)
+            {
+                _keyValueMetadata = keyValueMetadata;
+                _parquetKeyValueMetadata = new KeyValueMetadata();
+            }
+            _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
             Columns = null;
         }
 
@@ -142,7 +182,9 @@ namespace ParquetSharp
             //
             // See https://github.com/G-Research/ParquetSharp/issues/104.
 
-            _keyValueMetadata.Dispose();
+            // In case a user hasn't called close, make sure we set key-value metadata before the file is closed internally
+            SetKeyValueMetadata();
+            _parquetKeyValueMetadata?.Dispose();
             _fileMetaData?.Dispose();
             _handle.Dispose();
         }
@@ -154,6 +196,7 @@ namespace ParquetSharp
         /// </summary>
         public void Close()
         {
+            SetKeyValueMetadata();
             ExceptionInfo.Check(ParquetFileWriter_Close(_handle.IntPtr));
             GC.KeepAlive(_handle);
         }
@@ -168,21 +211,6 @@ namespace ParquetSharp
             return new(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileWriter_AppendBufferedRowGroup), this);
         }
 
-        /// <summary>
-        /// Update the key-value metadata with new metadata entries.
-        /// This can be called any time before the writer is closed so that the updated metadata will
-        /// be written in the file footer.
-        /// Where the metadata key matches an existing key, values will be overridden,
-        /// otherwise a new entry is added.
-        /// </summary>
-        public void UpdateKeyValueMetadata(IReadOnlyDictionary<string, string> keyValueMetadata)
-        {
-            foreach (var kvp in keyValueMetadata)
-            {
-                _keyValueMetadata.Set(kvp.Key, kvp.Value);
-            }
-        }
-
         internal int NumColumns => ExceptionInfo.Return<int>(_handle, ParquetFileWriter_Num_Columns); // 2021-04-08: calling this results in a segfault when the writer has been closed
         internal long NumRows => ExceptionInfo.Return<long>(_handle, ParquetFileWriter_Num_Rows); // 2021-04-08: calling this results in a segfault when the writer has been closed
         internal int NumRowGroups => ExceptionInfo.Return<int>(_handle, ParquetFileWriter_Num_Row_Groups); // 2021-04-08: calling this results in a segfault when the writer has been closed
@@ -193,18 +221,24 @@ namespace ParquetSharp
         public SchemaDescriptor Schema => new(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileWriter_Schema));
         public ColumnDescriptor ColumnDescriptor(int i) => new(ExceptionInfo.Return<int, IntPtr>(_handle, i, ParquetFileWriter_Descr));
 
+        /// <summary>
+        /// Returns a read-only copy of the current key-value metadata to be written
+        /// </summary>
         public IReadOnlyDictionary<string, string> KeyValueMetadata
         {
             get
             {
-                var kvmHandle = ExceptionInfo.Return<IntPtr>(_handle, ParquetFileWriter_Key_Value_Metadata);
-                if (kvmHandle == IntPtr.Zero)
+                if (_keyValueMetadata == null)
                 {
                     return new Dictionary<string, string>();
                 }
 
-                using var keyValueMetadata = new KeyValueMetadata(kvmHandle);
-                return keyValueMetadata.ToDictionary();
+                var metadata = new Dictionary<string, string>(_keyValueMetadata.Count);
+                foreach (var kvp in _keyValueMetadata)
+                {
+                    metadata[kvp.Key] = kvp.Value;
+                }
+                return metadata;
             }
         }
 
@@ -222,18 +256,37 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// Sets Parquet key value metadata by copying values from the key-value metadata dictionary.
+        /// We delay doing this until the file is closed to allow users to modify the key-value metadata after
+        /// data is written.
+        /// </summary>
+        private void SetKeyValueMetadata()
+        {
+            if (_keyValueMetadataSet)
+            {
+                return;
+            }
+
+            if (_keyValueMetadata != null && _parquetKeyValueMetadata != null)
+            {
+                _parquetKeyValueMetadata.SetData(_keyValueMetadata);
+            }
+            _keyValueMetadataSet = true;
+        }
+
         private static ParquetHandle CreateParquetFileWriter(
             string path,
             GroupNode schema,
             WriterProperties writerProperties,
-            KeyValueMetadata keyValueMetadata)
+            KeyValueMetadata? keyValueMetadata)
         {
             if (path == null) throw new ArgumentNullException(nameof(path));
             if (schema == null) throw new ArgumentNullException(nameof(schema));
             if (writerProperties == null) throw new ArgumentNullException(nameof(writerProperties));
 
             ExceptionInfo.Check(ParquetFileWriter_OpenFile(
-                path, schema.Handle.IntPtr, writerProperties.Handle.IntPtr, keyValueMetadata.Handle.IntPtr, out var writer));
+                path, schema.Handle.IntPtr, writerProperties.Handle.IntPtr, keyValueMetadata?.Handle.IntPtr ?? IntPtr.Zero, out var writer));
 
             // Keep alive schema and writerProperties until this point, otherwise the GC might kick in while we're in OpenFile().
             GC.KeepAlive(schema);
@@ -246,7 +299,7 @@ namespace ParquetSharp
             OutputStream outputStream,
             GroupNode schema,
             WriterProperties writerProperties,
-            KeyValueMetadata keyValueMetadata)
+            KeyValueMetadata? keyValueMetadata)
         {
             if (outputStream == null) throw new ArgumentNullException(nameof(outputStream));
             if (outputStream.Handle == null) throw new ArgumentNullException(nameof(outputStream.Handle));
@@ -254,7 +307,7 @@ namespace ParquetSharp
             if (writerProperties == null) throw new ArgumentNullException(nameof(writerProperties));
 
             ExceptionInfo.Check(ParquetFileWriter_Open(
-                outputStream.Handle.IntPtr, schema.Handle.IntPtr, writerProperties.Handle.IntPtr, keyValueMetadata.Handle.IntPtr, out var writer));
+                outputStream.Handle.IntPtr, schema.Handle.IntPtr, writerProperties.Handle.IntPtr, keyValueMetadata?.Handle.IntPtr ?? IntPtr.Zero, out var writer));
 
             // Keep alive schema and writerProperties until this point, otherwise the GC might kick in while we're in Open().
             GC.KeepAlive(schema);
@@ -307,15 +360,14 @@ namespace ParquetSharp
         private static extern IntPtr ParquetFileWriter_Descr(IntPtr writer, int i, out IntPtr descr);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr ParquetFileWriter_Key_Value_Metadata(IntPtr writer, out IntPtr keyValueMetadata);
-
-        [DllImport(ParquetDll.Name)]
         private static extern IntPtr ParquetFileWriter_Metadata(IntPtr writer, out IntPtr metadata);
 
         private readonly ParquetHandle _handle;
-        private readonly KeyValueMetadata _keyValueMetadata;
+        private readonly KeyValueMetadata? _parquetKeyValueMetadata;
+        private readonly IReadOnlyDictionary<string, string>? _keyValueMetadata;
         internal readonly Column[]? Columns;
         private FileMetaData? _fileMetaData;
         private WriterProperties? _writerProperties;
+        private bool _keyValueMetadataSet;
     }
 }

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -8,6 +8,14 @@ namespace ParquetSharp
 {
     public sealed class ParquetFileWriter : IDisposable
     {
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="path">Location to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="compression">Compression to use for all columns</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             string path,
             Column[] columns,
@@ -25,6 +33,14 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="outputStream">Stream to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="compression">Compression to use for all columns</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             OutputStream outputStream,
             Column[] columns,
@@ -42,6 +58,15 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="path">Location to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="logicalTypeFactory">Custom type factory used to map from dotnet types to Parquet types</param>
+        /// <param name="compression">Compression to use for all columns</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             string path,
             Column[] columns,
@@ -60,6 +85,15 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="outputStream">Stream to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="logicalTypeFactory">Custom type factory used to map from dotnet types to Parquet types</param>
+        /// <param name="compression">Compression to use for all columns</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             OutputStream outputStream,
             Column[] columns,
@@ -78,6 +112,14 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="path">Location to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="writerProperties">Writer properties to use</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             string path,
             Column[] columns,
@@ -94,6 +136,14 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="outputStream">Stream to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="writerProperties">Writer properties to use</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             OutputStream outputStream,
             Column[] columns,
@@ -110,6 +160,15 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="path">Location to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="logicalTypeFactory">Custom type factory used to map from dotnet types to Parquet types</param>
+        /// <param name="writerProperties">Writer properties to use</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             string path,
             Column[] columns,
@@ -127,6 +186,15 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="outputStream">Stream to write to</param>
+        /// <param name="columns">Definitions of columns to be written</param>
+        /// <param name="logicalTypeFactory">Custom type factory used to map from dotnet types to Parquet types</param>
+        /// <param name="writerProperties">Writer properties to use</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             OutputStream outputStream,
             Column[] columns,
@@ -144,6 +212,14 @@ namespace ParquetSharp
             Columns = columns;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="path">Location to write to</param>
+        /// <param name="schema">Root schema node defining the structure of the file</param>
+        /// <param name="writerProperties">Writer properties to use</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             string path,
             GroupNode schema,
@@ -159,6 +235,14 @@ namespace ParquetSharp
             Columns = null;
         }
 
+        /// <summary>
+        /// Open a new ParquetFileWriter
+        /// </summary>
+        /// <param name="outputStream">Stream to write to</param>
+        /// <param name="schema">Root schema node defining the structure of the file</param>
+        /// <param name="writerProperties">Writer properties to use</param>
+        /// <param name="keyValueMetadata">Optional dictionary of key-value metadata.
+        /// This isn't read until the file is closed, to allow metadata to be modified after data is written.</param>
         public ParquetFileWriter(
             OutputStream outputStream,
             GroupNode schema,


### PR DESCRIPTION
This PR changes ParquetFileWriter so that it doesn't read the KeyValueMetadata dictionary until the file is closed, to allow metadata entries to be added or updated at any time before the file is closed.

Internally, the Arrow C++ ParquetFileWriter takes a `std::shared_ptr<const KeyValueMetadata>` and then doesn't read the entries from the metadata until the file is closed and the footer is written, so this behaviour closely maps to the C++ API.

This changes behaviour and has the potential to be a breaking change if anyone is relying on being able to modify the metadata dictionary after passing it to the ParquetFileWriter constructor without this affecting the written metadata. That seems fairly unlikely though.