### PR TITLE
Use fixed culture when testing OverflowException

### DIFF
--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -48,6 +48,7 @@ namespace ParquetSharp.Test
         }
 
         [Test]
+        [SetCulture("en-US")]
         public static void TestScaleOverflow()
         {
             var exception = Assert.Throws<OverflowException>(() =>


### PR DESCRIPTION
I have changed the TestScaleOverflow test to use an fixed culture (en-US), as otherwise the test may fail depending on the users local culture.

An example is Danish where "," is the decimal separator instead of "." 