### PR TITLE
Add support for .NET 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,32 +3,34 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+    # Run daily at 00:00 so we get notified if CI is broken before a pull request
+    # is submitted.
+    - cron:  '0 0 * * *'
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_NOLOGO: true
-  dotnet_3_version: '3.1.414'
-  dotnet_5_version: '5.0.402'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:
 
   # Note that vcpkg dependencies takes the majority of the build time.
   # We cache them using GitHub Actions cache, making the scripts below a bit more complex.
   check-format:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Check format
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET SDK v6.0.x
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: ${{ env.dotnet_5_version }}
+          dotnet-version: 6.0.x
       - name: Code formating check
         run: |
           dotnet tool restore
-          dotnet jb cleanupcode "csharp" "csharp.test" "csharp.benchmark" --profile="Built-in: Reformat Code" --settings="ParquetSharp.DotSettings" --dotnetcoresdk=${{ env.dotnet_5_version }} --verbosity=WARN
+          dotnet jb cleanupcode "csharp" "csharp.test" "csharp.benchmark" --profile="Built-in: Reformat Code" --settings="ParquetSharp.DotSettings" --verbosity=WARN
 
           files=($(git diff --name-only))
           if [ ${#files[@]} -gt 0 ]
@@ -44,10 +46,10 @@ jobs:
     # Other jobs will be skipped too, as they depend on this one.
     # This prevents duplicate CI runs for our own pull requests, whilst preserving the ability to
     # run the CI for each branch push to a fork, and for each pull request originating from a fork.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-2022]
+        os: [ubuntu-18.04, macos-10.15, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
@@ -121,16 +123,10 @@ jobs:
       run: brew install bison
 
     # .NET Core Setup (and also MSBuild for Windows).
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET SDK v6.0.x
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: ${{ env.dotnet_3_version }}
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.dotnet_5_version }}
-    - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ env.dotnet_5_version }}
+        dotnet-version: 6.0.x
     - name: Setup MSBuild
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v1
@@ -187,12 +183,10 @@ jobs:
       run: |
         mkdir bin
         cp -rv artifacts/*-native-library/* bin/
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET SDK v6.0.x
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: ${{ env.dotnet_5_version }}
-    - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ env.dotnet_5_version }}
+        dotnet-version: 6.0.x
     - name: Build NuGet package
       run: dotnet build csharp --configuration=Release
     - name: Upload NuGet artifact
@@ -205,18 +199,18 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-2022]
-        dotnet: [3, 5]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2022]
+        dotnet: [netcoreapp3.1, net5.0, net6.0]
         arch: [x64]
         include:
         - os: windows-2022
-          dotnet: 4
+          dotnet: net472
           arch: x64
         - os: ubuntu-20.04
-          dotnet: 5
+          dotnet: net6.0
           arch: arm64
       fail-fast: false
-    name: Test NuGet package (.NET ${{ matrix.dotnet }} ${{ matrix.arch }} on ${{ matrix.os }})
+    name: Test NuGet package (${{ matrix.dotnet }} ${{ matrix.arch }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: build-nuget
     steps:
@@ -231,33 +225,20 @@ jobs:
       with:
         name: nuget-package
         path: nuget
-    - name: Setup .NET variables
-      id: dotnet
-      shell: bash
-      run: |
-        major=${{ matrix.dotnet }}
-        case $major in
-          3)
-            framework=netcoreapp3.1
-            ;;
-          4)
-            framework=net472
-            # We build for .NET framework with .NET Core 3.1 SDK
-            major=3
-            ;;
-          5)
-            framework=net5.0
-            ;;
-        esac
-        version=dotnet_${major}_version
-        echo "::set-output name=version::${!version}"
-        echo "::set-output name=framework::$framework"
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET Core SDK v3.1.x
+      if: matrix.dotnet == 'netcoreapp3.1'
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: ${{ steps.dotnet.outputs.version }}
-    - name: Pin .NET Core SDK
-      run: dotnet new globaljson --sdk-version ${{ steps.dotnet.outputs.version }}
+        dotnet-version: 3.1.x
+    - name: Setup .NET SDK v5.0.x
+      if: matrix.dotnet == 'net5.0'
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 5.0.x
+    - name: Setup .NET SDK v6.0.x
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
     - name: Add local NuGet feed
       run: |
         dotnet new nugetconfig
@@ -273,10 +254,10 @@ jobs:
         platforms: arm64
     - name: Build & Run .NET unit tests (x64)
       if: matrix.arch == 'x64'
-      run: dotnet test csharp.test --configuration=Release --framework ${{ steps.dotnet.outputs.framework }}
+      run: dotnet test csharp.test --configuration=Release --framework ${{ matrix.dotnet }}
     - name: Build & Run .NET unit tests (arm64)
       if: matrix.arch == 'arm64'
-      run: docker run --rm --platform linux/arm64/v8 -v $PWD:$PWD -w $PWD mcr.microsoft.com/dotnet/sdk:${{ steps.dotnet.outputs.version }} dotnet test csharp.test --configuration=Release --framework ${{ steps.dotnet.outputs.framework }}
+      run: docker run --rm --platform linux/arm64/v8 -v $PWD:$PWD -w $PWD mcr.microsoft.com/dotnet/sdk:6.0 dotnet test csharp.test --configuration=Release --framework ${{ matrix.dotnet }}
 
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:
@@ -313,6 +294,10 @@ jobs:
       with:
         name: nuget-package
         path: nuget
+    - name: Setup .NET SDK v6.0.x
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
     # if version contains "-" treat it as pre-release
     # example: 1.0.0-beta1
     - name: Create release

--- a/csharp.benchmark/ParquetSharp.Benchmark.csproj
+++ b/csharp.benchmark/ParquetSharp.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp.Benchmark</AssemblyName>

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp.Test</AssemblyName>

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp.Test</AssemblyName>

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+    <!-- Avoid building for older frameworks when testing locally. -->
+    <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
     <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <LangVersion>9.0</LangVersion>

--- a/csharp.test/Program.cs
+++ b/csharp.test/Program.cs
@@ -15,7 +15,9 @@ namespace ParquetSharp.Test
             {
                 Console.WriteLine("Working directory: {0}", Environment.CurrentDirectory);
 
+#if NETFRAMEWORK
                 AppDomain.CurrentDomain.UnhandledException += UncaughtExceptionHandler;
+#endif
 
                 //TestColumn.TestPrimitives();
                 //TestParquetFileWriter.TestReadWriteParquetMultipleTasks();
@@ -35,7 +37,9 @@ namespace ParquetSharp.Test
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
 
+#if NETFRAMEWORK
                 AppDomain.CurrentDomain.UnhandledException -= UncaughtExceptionHandler;
+#endif
 
                 return 0;
             }
@@ -52,11 +56,13 @@ namespace ParquetSharp.Test
             return 1;
         }
 
+#if NETFRAMEWORK
         [HandleProcessCorruptedStateExceptions]
         private static void UncaughtExceptionHandler(object sender, UnhandledExceptionEventArgs args)
         {
             Console.Error.WriteLine("FATAL: UncaughtExceptionHandler: {0}", args.ExceptionObject);
             Environment.Exit(1);
         }
+#endif
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "6.0.100",
+      "rollForward": "latestMinor"
+    }
+  }


### PR DESCRIPTION
This PR adds support for .NET 6, both in project files and in the CI.

Summary of the changes:
- require .NET 6 SDK to build via `global.json`
- add `net6.0` to test target frameworks, and only build for it by default
- switch target framework to `net6.0` for benchmarks
- use `HandleProcessCorruptedStateExceptions` on .NET Framework only (it never worked on .NET Core and is unavailable on .NET 6)
- always use the latest 6.0.x SDK instead of a pinned version in CI
- daily CI runs of the CI to get notified of potential build failures when a new version of the SDK is released
- CI runs on both macOS 10.15 and 11.0