### PR TITLE
Dispose of most uses of LogicalType and Node

### DIFF
--- a/csharp.test/TestByteArrayReaderCache.cs
+++ b/csharp.test/TestByteArrayReaderCache.cs
@@ -29,7 +29,8 @@ namespace ParquetSharp.Test
             // Write a file that contains a lot of duplicate strings.
             using (var output = new BufferOutputStream(buffer))
             {
-                using var fileWriter = new ParquetFileWriter(output, columns, CreateWriterProperties(enableDictionary));
+                using var writerProperties = CreateWriterProperties(enableDictionary);
+                using var fileWriter = new ParquetFileWriter(output, columns, writerProperties);
                 using var groupWriter = fileWriter.AppendRowGroup();
 
                 using var dateWriter = groupWriter.NextColumn().LogicalWriter<DateTime>();

--- a/csharp.test/TestColumnPath.cs
+++ b/csharp.test/TestColumnPath.cs
@@ -48,20 +48,28 @@ namespace ParquetSharp.Test
             var columns = new Column[] {new Column<int[]>("value")};
 
             using var schema = Column.CreateSchemaNode(columns);
+            using var valueNode = schema.Field(0);
+            using var listNode = ((GroupNode) valueNode).Field(0);
+            using var itemNode = ((GroupNode) listNode).Field(0);
+
             using var p0 = new ColumnPath(schema);
-            using var p1 = new ColumnPath(schema.Field(0));
-            using var p2 = new ColumnPath(((GroupNode) schema.Field(0)).Field(0));
-            using var p3 = new ColumnPath(((GroupNode) ((GroupNode) schema.Field(0)).Field(0)).Field(0));
+            using var p1 = new ColumnPath(valueNode);
+            using var p2 = new ColumnPath(listNode);
+            using var p3 = new ColumnPath(itemNode);
 
             Assert.AreEqual("", p0.ToDotString());
             Assert.AreEqual("value", p1.ToDotString());
             Assert.AreEqual("value.list", p2.ToDotString());
             Assert.AreEqual("value.list.item", p3.ToDotString());
 
-            Assert.AreEqual("", schema.Path.ToDotString());
-            Assert.AreEqual("value", schema.Field(0).Path.ToDotString());
-            Assert.AreEqual("value.list", ((GroupNode) schema.Field(0)).Field(0).Path.ToDotString());
-            Assert.AreEqual("value.list.item", ((GroupNode) ((GroupNode) schema.Field(0)).Field(0)).Field(0).Path.ToDotString());
+            using var schemaPath = schema.Path;
+            Assert.AreEqual("", schemaPath.ToDotString());
+            using var valuePath = valueNode.Path;
+            Assert.AreEqual("value", valuePath.ToDotString());
+            using var listPath = listNode.Path;
+            Assert.AreEqual("value.list", listPath.ToDotString());
+            using var itemPath = itemNode.Path;
+            Assert.AreEqual("value.list.item", itemPath.ToDotString());
         }
 
         [Test]
@@ -72,10 +80,13 @@ namespace ParquetSharp.Test
             var columns = new Column[] {new Column<int[]>(name)};
 
             using var schema = Column.CreateSchemaNode(columns);
+            using var colNode = schema.Field(0);
+            using var listNode = ((GroupNode) colNode).Field(0);
+            using var itemNode = ((GroupNode) listNode).Field(0);
             using var p0 = new ColumnPath(schema);
-            using var p1 = new ColumnPath(schema.Field(0));
-            using var p2 = new ColumnPath(((GroupNode) schema.Field(0)).Field(0));
-            using var p3 = new ColumnPath(((GroupNode) ((GroupNode) schema.Field(0)).Field(0)).Field(0));
+            using var p1 = new ColumnPath(colNode);
+            using var p2 = new ColumnPath(listNode);
+            using var p3 = new ColumnPath(itemNode);
 
             Assert.AreEqual("", p0.ToDotString());
             Assert.AreEqual(name, p1.ToDotString());
@@ -83,10 +94,14 @@ namespace ParquetSharp.Test
             Assert.AreEqual(name + ".list.item", p3.ToDotString());
             Assert.AreEqual(new[] {name, "list", "item"}, p3.ToDotVector());
 
-            Assert.AreEqual("", schema.Path.ToDotString());
-            Assert.AreEqual(name + "", schema.Field(0).Path.ToDotString());
-            Assert.AreEqual(name + ".list", ((GroupNode) schema.Field(0)).Field(0).Path.ToDotString());
-            Assert.AreEqual(name + ".list.item", ((GroupNode) ((GroupNode) schema.Field(0)).Field(0)).Field(0).Path.ToDotString());
+            using var schemaPath = schema.Path;
+            Assert.AreEqual("", schemaPath.ToDotString());
+            using var colPath = colNode.Path;
+            Assert.AreEqual(name + "", colPath.ToDotString());
+            using var listPath = listNode.Path;
+            Assert.AreEqual(name + ".list", listPath.ToDotString());
+            using var itemPath = itemNode.Path;
+            Assert.AreEqual(name + ".list.item", itemPath.ToDotString());
         }
     }
 }

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -63,7 +63,8 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestAgainstThirdParty()
         {
-            var columns = new Column[] {new Column<decimal>("Decimal", LogicalType.Decimal(precision: 29, scale: 3))};
+            using var decimalType = LogicalType.Decimal(precision: 29, scale: 3);
+            var columns = new Column[] {new Column<decimal>("Decimal", decimalType)};
             var values = Enumerable.Range(0, 10_000)
                 .Select(i => ((decimal) i * i * i) / 1000 - 10)
                 .Concat(new[] {decimal.MinValue / 1000, decimal.MaxValue / 1000})

--- a/csharp.test/TestEncryption.cs
+++ b/csharp.test/TestEncryption.cs
@@ -48,11 +48,13 @@ namespace ParquetSharp.Test
                 using var crypto0 = colMetadata0.CryptoMetadata;
                 using var crypto1 = colMetadata1.CryptoMetadata;
 
-                Assert.AreEqual("", crypto0?.ColumnPath.ToDotString());
+                using var crypto0Path = crypto0?.ColumnPath;
+                Assert.AreEqual("", crypto0Path?.ToDotString());
                 Assert.AreEqual(true, crypto0?.EncryptedWithFooterKey);
                 Assert.AreEqual("", crypto0?.KeyMetadata);
 
-                Assert.AreEqual("", crypto1?.ColumnPath.ToDotString());
+                using var crypto1Path = crypto1?.ColumnPath;
+                Assert.AreEqual("", crypto1Path?.ToDotString());
                 Assert.AreEqual(true, crypto1?.EncryptedWithFooterKey);
                 Assert.AreEqual("", crypto1?.KeyMetadata);
             });
@@ -69,11 +71,13 @@ namespace ParquetSharp.Test
                 using var crypto0 = colMetadata0.CryptoMetadata;
                 using var crypto1 = colMetadata1.CryptoMetadata;
 
-                Assert.AreEqual("Id", crypto0?.ColumnPath.ToDotString());
+                using var path0 = crypto0?.ColumnPath;
+                Assert.AreEqual("Id", path0?.ToDotString());
                 Assert.AreEqual(false, crypto0?.EncryptedWithFooterKey);
                 Assert.AreEqual("Key1", crypto0?.KeyMetadata);
 
-                Assert.AreEqual("Value", crypto1?.ColumnPath.ToDotString());
+                using var path1 = crypto1?.ColumnPath;
+                Assert.AreEqual("Value", path1?.ToDotString());
                 Assert.AreEqual(false, crypto1?.EncryptedWithFooterKey);
                 Assert.AreEqual("Key2", crypto1?.KeyMetadata);
             });
@@ -90,11 +94,13 @@ namespace ParquetSharp.Test
                 using var crypto0 = colMetadata0.CryptoMetadata;
                 using var crypto1 = colMetadata1.CryptoMetadata;
 
-                Assert.AreEqual("Id", crypto0?.ColumnPath.ToDotString());
+                using var path0 = crypto0?.ColumnPath;
+                Assert.AreEqual("Id", path0?.ToDotString());
                 Assert.AreEqual(false, crypto0?.EncryptedWithFooterKey);
                 Assert.AreEqual("Key1", crypto0?.KeyMetadata);
 
-                Assert.AreEqual("Value", crypto1?.ColumnPath.ToDotString());
+                using var path1 = crypto1?.ColumnPath;
+                Assert.AreEqual("Value", path1?.ToDotString());
                 Assert.AreEqual(false, crypto1?.EncryptedWithFooterKey);
                 Assert.AreEqual("Key2", crypto1?.KeyMetadata);
             });
@@ -125,7 +131,8 @@ namespace ParquetSharp.Test
 
                     Assert.AreEqual(null, crypto0);
 
-                    Assert.AreEqual("Value", crypto1?.ColumnPath.ToDotString());
+                    using var path1 = crypto1?.ColumnPath;
+                    Assert.AreEqual("Value", path1?.ToDotString());
                     Assert.AreEqual(false, crypto1?.EncryptedWithFooterKey);
                     Assert.AreEqual("Key2", crypto1?.KeyMetadata);
                 });
@@ -169,13 +176,15 @@ namespace ParquetSharp.Test
             using var builder = new FileEncryptionPropertiesBuilder(Key0);
             using var col0 = new ColumnEncryptionPropertiesBuilder("Id");
             using var col1 = new ColumnEncryptionPropertiesBuilder("Value");
+            using var col0Properties = col0.Key(Key1).KeyMetadata("Key1").Build();
+            using var col1Properties = col1.Key(Key2).KeyMetadata("Key2").Build();
 
             return builder
                 .FooterKeyMetadata("Key0")
                 .EncryptedColumns(new[]
                 {
-                    col0.Key(Key1).KeyMetadata("Key1").Build(),
-                    col1.Key(Key2).KeyMetadata("Key2").Build()
+                    col0Properties,
+                    col1Properties,
                 })
                 .Build();
         }
@@ -185,14 +194,16 @@ namespace ParquetSharp.Test
             using var builder = new FileEncryptionPropertiesBuilder(Key0);
             using var col1 = new ColumnEncryptionPropertiesBuilder("Value");
             using var col0 = new ColumnEncryptionPropertiesBuilder("Id");
+            using var col0Properties = col0.Key(Key1).KeyMetadata("Key1").Build();
+            using var col1Properties = col1.Key(Key2).KeyMetadata("Key2").Build();
 
             return builder
                 .FooterKeyMetadata("Key0")
                 .SetPlaintextFooter()
                 .EncryptedColumns(new[]
                 {
-                    col0.Key(Key1).KeyMetadata("Key1").Build(),
-                    col1.Key(Key2).KeyMetadata("Key2").Build()
+                    col0Properties,
+                    col1Properties,
                 })
                 .Build();
         }
@@ -201,13 +212,14 @@ namespace ParquetSharp.Test
         {
             using var builder = new FileEncryptionPropertiesBuilder(Key0);
             using var col1 = new ColumnEncryptionPropertiesBuilder("Value");
+            using var colProperties = col1.Key(Key2).KeyMetadata("Key2").Build();
 
             return builder
                 .FooterKeyMetadata("Key0")
                 .SetPlaintextFooter()
                 .EncryptedColumns(new[]
                 {
-                    col1.Key(Key2).KeyMetadata("Key2").Build()
+                    colProperties,
                 })
                 .Build();
         }

--- a/csharp.test/TestLogicalTypeFactory.cs
+++ b/csharp.test/TestLogicalTypeFactory.cs
@@ -50,7 +50,8 @@ namespace ParquetSharp.Test
             using var fileReader = new ParquetFileReader(input);
             using var groupReader = fileReader.RowGroup(0);
 
-            var exception = Assert.Throws<NotSupportedException>(() => groupReader.Column(0).LogicalReaderOverride<VolumeInDollars>());
+            using var colReader = groupReader.Column(0);
+            var exception = Assert.Throws<NotSupportedException>(() => colReader.LogicalReaderOverride<VolumeInDollars>());
             Assert.That(exception?.Message, Does.StartWith("unsupported logical system type"));
         }
 
@@ -401,7 +402,8 @@ namespace ParquetSharp.Test
             {
                 // We have to use the column name to know what type to expose.
                 Assert.IsNull(columnLogicalTypeOverride);
-                return base.GetSystemTypes(descriptor, descriptor.Path.ToDotVector().First() == "values" ? typeof(VolumeInDollars) : null);
+                using var descriptorPath = descriptor.Path;
+                return base.GetSystemTypes(descriptor, descriptorPath.ToDotVector().First() == "values" ? typeof(VolumeInDollars) : null);
             }
         }
 
@@ -453,7 +455,8 @@ namespace ParquetSharp.Test
             {
                 // We have to use the column name to know what type to expose.
                 Assert.IsNull(columnLogicalTypeOverride);
-                return base.GetSystemTypes(descriptor, descriptor.Path.ToDotVector().First() == "values" ? typeof(VolumeInDollars) : null);
+                using var descriptorPath = descriptor.Path;
+                return base.GetSystemTypes(descriptor, descriptorPath.ToDotVector().First() == "values" ? typeof(VolumeInDollars) : null);
             }
         }
 

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -20,34 +20,45 @@ namespace ParquetSharp.Test
         )
         {
             var expectedColumns = CreateExpectedColumns();
-            var schemaColumns = expectedColumns
-                .Select(c => new Column(c.Values.GetType().GetElementType() ?? throw new InvalidOperationException(), c.Name, c.LogicalTypeOverride))
-                .ToArray();
 
-            using var buffer = new ResizableBuffer();
-
-            // Write our expected columns to the parquet in-memory file.
-            using (var outStream = new BufferOutputStream(buffer))
+            try
             {
-                using var writerProperties = CreateWriterProperties(expectedColumns, useDictionaryEncoding);
-                using var fileWriter = new ParquetFileWriter(outStream, schemaColumns, writerProperties);
-                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                var schemaColumns = expectedColumns
+                    .Select(c => new Column(c.Values.GetType().GetElementType() ?? throw new InvalidOperationException(), c.Name, c.LogicalTypeOverride))
+                    .ToArray();
 
-                foreach (var column in expectedColumns)
+                using var buffer = new ResizableBuffer();
+
+                // Write our expected columns to the parquet in-memory file.
+                using (var outStream = new BufferOutputStream(buffer))
                 {
-                    Console.WriteLine("Writing '{0}' ({1})", column.Name, column.Values.GetType().GetElementType());
+                    using var writerProperties = CreateWriterProperties(expectedColumns, useDictionaryEncoding);
+                    using var fileWriter = new ParquetFileWriter(outStream, schemaColumns, writerProperties);
+                    using var rowGroupWriter = fileWriter.AppendRowGroup();
 
-                    using var columnWriter = rowGroupWriter.NextColumn().LogicalWriter(writeBufferLength);
-                    columnWriter.Apply(new LogicalValueSetter(column.Values, rowsPerBatch));
+                    foreach (var column in expectedColumns)
+                    {
+                        Console.WriteLine("Writing '{0}' ({1})", column.Name, column.Values.GetType().GetElementType());
+
+                        using var columnWriter = rowGroupWriter.NextColumn().LogicalWriter(writeBufferLength);
+                        columnWriter.Apply(new LogicalValueSetter(column.Values, rowsPerBatch));
+                    }
+
+                    fileWriter.Close();
                 }
 
-                fileWriter.Close();
+                Console.WriteLine();
+
+                // Read back the columns and make sure they match.
+                AssertReadRoundtrip(rowsPerBatch, readBufferLength, buffer, expectedColumns);
             }
-
-            Console.WriteLine();
-
-            // Read back the columns and make sure they match.
-            AssertReadRoundtrip(rowsPerBatch, readBufferLength, buffer, expectedColumns);
+            finally
+            {
+                foreach (var col in expectedColumns)
+                {
+                    col.Dispose();
+                }
+            }
         }
 
         [Test]
@@ -60,42 +71,52 @@ namespace ParquetSharp.Test
         )
         {
             var expectedColumns = CreateExpectedColumns();
-            var schemaColumns = expectedColumns
-                .Select(c => new Column(c.Values.GetType().GetElementType() ?? throw new InvalidOperationException(), c.Name, c.LogicalTypeOverride))
-                .ToArray();
-
-            using var buffer = new ResizableBuffer();
-
-            // Write our expected columns to the parquet in-memory file.
-            using (var outStream = new BufferOutputStream(buffer))
+            try
             {
-                using var writerProperties = CreateWriterProperties(expectedColumns, useDictionaryEncoding);
-                using var fileWriter = new ParquetFileWriter(outStream, schemaColumns, writerProperties);
-                using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+                var schemaColumns = expectedColumns
+                    .Select(c => new Column(c.Values.GetType().GetElementType() ?? throw new InvalidOperationException(), c.Name, c.LogicalTypeOverride))
+                    .ToArray();
 
-                const int rangeLength = 9;
+                using var buffer = new ResizableBuffer();
 
-                for (int r = 0; r < NumRows; r += rangeLength)
+                // Write our expected columns to the parquet in-memory file.
+                using (var outStream = new BufferOutputStream(buffer))
                 {
-                    for (var i = 0; i < expectedColumns.Length; i++)
+                    using var writerProperties = CreateWriterProperties(expectedColumns, useDictionaryEncoding);
+                    using var fileWriter = new ParquetFileWriter(outStream, schemaColumns, writerProperties);
+                    using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+
+                    const int rangeLength = 9;
+
+                    for (int r = 0; r < NumRows; r += rangeLength)
                     {
-                        var column = expectedColumns[i];
-                        var range = (r, Math.Min(r + rangeLength, NumRows));
+                        for (var i = 0; i < expectedColumns.Length; i++)
+                        {
+                            var column = expectedColumns[i];
+                            var range = (r, Math.Min(r + rangeLength, NumRows));
 
-                        Console.WriteLine("Writing '{0}' (element type: {1}) (range: {2})", column.Name, column.Values.GetType().GetElementType(), range);
+                            Console.WriteLine("Writing '{0}' (element type: {1}) (range: {2})", column.Name, column.Values.GetType().GetElementType(), range);
 
-                        using var columnWriter = rowGroupWriter.Column(i).LogicalWriter(writeBufferLength);
-                        columnWriter.Apply(new LogicalValueSetter(column.Values, rowsPerBatch, range));
+                            using var columnWriter = rowGroupWriter.Column(i).LogicalWriter(writeBufferLength);
+                            columnWriter.Apply(new LogicalValueSetter(column.Values, rowsPerBatch, range));
+                        }
                     }
+
+                    fileWriter.Close();
                 }
 
-                fileWriter.Close();
+                Console.WriteLine();
+
+                // Read back the columns and make sure they match.
+                AssertReadRoundtrip(rowsPerBatch, readBufferLength, buffer, expectedColumns);
             }
-
-            Console.WriteLine();
-
-            // Read back the columns and make sure they match.
-            AssertReadRoundtrip(rowsPerBatch, readBufferLength, buffer, expectedColumns);
+            finally
+            {
+                foreach (var col in expectedColumns)
+                {
+                    col.Dispose();
+                }
+            }
         }
 
         [TestCase(DateTimeKind.Utc, TimeUnit.Micros)]
@@ -107,9 +128,10 @@ namespace ParquetSharp.Test
             // ParquetSharp doesn't know the DateTime values upfront,
             // so we have to specify whether values are UTC in the logical type.
             var isAdjustedToUtc = kind == DateTimeKind.Utc;
+            using var timestampType = LogicalType.Timestamp(isAdjustedToUtc, timeUnit);
             var schemaColumns = new Column[]
             {
-                new Column<DateTime>("dateTime", LogicalType.Timestamp(isAdjustedToUtc, timeUnit)),
+                new Column<DateTime>("dateTime", timestampType),
             };
 
             const int numRows = 100;
@@ -145,7 +167,7 @@ namespace ParquetSharp.Test
 
         private static WriterProperties CreateWriterProperties(ExpectedColumn[] expectedColumns, bool useDictionaryEncoding)
         {
-            var builder = new WriterPropertiesBuilder();
+            using var builder = new WriterPropertiesBuilder();
 
             builder.Compression(Compression.Snappy);
 
@@ -180,16 +202,19 @@ namespace ParquetSharp.Test
                 using (var columnReader = rowGroupReader.Column(c).LogicalReader(readBufferLength))
                 {
                     var descr = columnReader.ColumnDescriptor;
-                    var chunkMetaData = rowGroupMetaData.GetColumnChunkMetaData(c);
-                    var statistics = chunkMetaData.Statistics;
+                    using var chunkMetaData = rowGroupMetaData.GetColumnChunkMetaData(c);
+                    using var statistics = chunkMetaData.Statistics;
 
                     Console.WriteLine("Reading '{0}'", expected.Name);
 
-                    Assert.AreEqual(expected.Name, fileMetaData.Schema.ColumnRoot(c).Name);
-                    Assert.AreEqual(expected.Name, descr.Path.ToDotVector().First());
-                    Assert.AreEqual(c, fileMetaData.Schema.ColumnIndex(descr.Path.ToDotString()));
+                    using var root = fileMetaData.Schema.ColumnRoot(c);
+                    Assert.AreEqual(expected.Name, root.Name);
+                    using var path = descr.Path;
+                    Assert.AreEqual(expected.Name, path.ToDotVector().First());
+                    Assert.AreEqual(c, fileMetaData.Schema.ColumnIndex(path.ToDotString()));
                     Assert.AreEqual(expected.PhysicalType, descr.PhysicalType);
-                    Assert.AreEqual(expected.LogicalType, descr.LogicalType);
+                    using var logicalType = descr.LogicalType;
+                    Assert.AreEqual(expected.LogicalType, logicalType);
                     Assert.AreEqual(expected.Values, columnReader.Apply(new LogicalValueGetter(checked((int) numRows), rowsPerBatch)));
                     Assert.AreEqual(expected.Length, descr.TypeLength);
                     Assert.AreEqual((expected.LogicalType as DecimalLogicalType)?.Precision ?? -1, descr.TypePrecision);
@@ -305,14 +330,17 @@ namespace ParquetSharp.Test
 
             using (var output = new BufferOutputStream(buffer))
             {
-                var element = new PrimitiveNode("element", Repetition.Required, LogicalType.None(), PhysicalType.Int32);
-                var list = new GroupNode("list", Repetition.Repeated, new[] {element});
-                var ids = new GroupNode("ids", Repetition.Optional, new[] {list}, LogicalType.List());
-                var outer = new GroupNode("struct", structRepetition, new[] {ids});
-                var schemaNode = new GroupNode("schema", Repetition.Required, new[] {outer});
+                using var noneType = LogicalType.None();
+                using var element = new PrimitiveNode("element", Repetition.Required, noneType, PhysicalType.Int32);
+                using var list = new GroupNode("list", Repetition.Repeated, new[] {element});
+                using var listType = LogicalType.List();
+                using var ids = new GroupNode("ids", Repetition.Optional, new[] {list}, listType);
+                using var outer = new GroupNode("struct", structRepetition, new[] {ids});
+                using var schemaNode = new GroupNode("schema", Repetition.Required, new[] {outer});
 
                 using var builder = new WriterPropertiesBuilder();
-                using var fileWriter = new ParquetFileWriter(output, schemaNode, builder.Build());
+                using var writerProperties = builder.Build();
+                using var fileWriter = new ParquetFileWriter(output, schemaNode, writerProperties);
                 using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
 
                 using var colWriter = rowGroupWriter.Column(0).LogicalWriter<int[]?>();
@@ -586,12 +614,15 @@ namespace ParquetSharp.Test
 
             using (var outStream = new BufferOutputStream(buffer))
             {
-                using var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<DateTime>("a", LogicalType.Timestamp(false, TimeUnit.Millis, forceSetConvertedType: true))});
+                using var timestampType = LogicalType.Timestamp(false, TimeUnit.Millis, forceSetConvertedType: true);
+                using var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<DateTime>("a", timestampType)});
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
                 using var colWriter = rowGroupWriter.NextColumn().LogicalWriter<DateTime>();
 
-                Assert.True((colWriter.ColumnDescriptor.LogicalType as TimestampLogicalType)?.ForceSetConvertedType);
-                Assert.AreEqual(ConvertedType.TimestampMillis, colWriter.ColumnDescriptor.SchemaNode.ConvertedType);
+                using var logicalType = colWriter.ColumnDescriptor.LogicalType;
+                Assert.True((logicalType as TimestampLogicalType)?.ForceSetConvertedType);
+                using var schemaNode = colWriter.ColumnDescriptor.SchemaNode;
+                Assert.AreEqual(ConvertedType.TimestampMillis, schemaNode.ConvertedType);
 
                 colWriter.WriteBatch(expected);
 
@@ -624,12 +655,15 @@ namespace ParquetSharp.Test
 
             using (var outStream = new BufferOutputStream(buffer))
             {
-                using var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<DateTime>("a", LogicalType.Timestamp(false, TimeUnit.Millis))});
+                using var timestampType = LogicalType.Timestamp(false, TimeUnit.Millis);
+                using var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<DateTime>("a", timestampType)});
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
                 using var colWriter = rowGroupWriter.NextColumn().LogicalWriter<DateTime>();
 
-                Assert.False((colWriter.ColumnDescriptor.LogicalType as TimestampLogicalType)?.ForceSetConvertedType);
-                Assert.AreEqual(ConvertedType.None, colWriter.ColumnDescriptor.SchemaNode.ConvertedType);
+                using var logicalType = colWriter.ColumnDescriptor.LogicalType;
+                Assert.False((logicalType as TimestampLogicalType)?.ForceSetConvertedType);
+                using var schemaNode = colWriter.ColumnDescriptor.SchemaNode;
+                Assert.AreEqual(ConvertedType.None, schemaNode.ConvertedType);
 
                 colWriter.WriteBatch(expected);
 
@@ -1255,13 +1289,11 @@ namespace ParquetSharp.Test
             };
         }
 
-        private sealed class ExpectedColumn
+        private sealed class ExpectedColumn : IDisposable
         {
             public string Name = ""; // TODO replace with init;
             public Array Values = new object[0]; // TODO replace with init;
             public PhysicalType PhysicalType;
-            public LogicalType LogicalType = LogicalType.None();
-            public LogicalType LogicalTypeOverride = LogicalType.None();
             public int Length;
 
             public bool HasStatistics = true;
@@ -1272,6 +1304,36 @@ namespace ParquetSharp.Test
             public long NumValues = NumRows;
 
             public Func<object, ColumnDescriptor, object> Converter = (v, _) => v;
+
+            private LogicalType _logicalType = LogicalType.None();
+
+            public LogicalType LogicalType
+            {
+                get => _logicalType;
+                set
+                {
+                    _logicalType.Dispose();
+                    _logicalType = value;
+                }
+            }
+
+            private LogicalType _logicalTypeOverride = LogicalType.None();
+
+            public LogicalType LogicalTypeOverride
+            {
+                get => _logicalTypeOverride;
+                set
+                {
+                    _logicalTypeOverride.Dispose();
+                    _logicalTypeOverride = value;
+                }
+            }
+
+            public void Dispose()
+            {
+                _logicalType.Dispose();
+                _logicalTypeOverride.Dispose();
+            }
         }
 
         private const int NumRows = 119;

--- a/csharp.test/TestMemoryLeaks.cs
+++ b/csharp.test/TestMemoryLeaks.cs
@@ -63,8 +63,9 @@ namespace ParquetSharp.Test
 
         private void CreateParquetFile(ResizableBuffer buffer)
         {
+            using var timestampType = LogicalType.Timestamp(true, TimeUnit.Millis);
             using (var output = new BufferOutputStream(buffer))
-            using (var fileWriter = new ParquetFileWriter(output, CreateFloatColumns(), keyValueMetadata: _keyValueProperties))
+            using (var fileWriter = new ParquetFileWriter(output, CreateFloatColumns(timestampType), keyValueMetadata: _keyValueProperties))
             {
                 using var rowGroupWriter = fileWriter.AppendRowGroup();
 
@@ -121,11 +122,11 @@ namespace ParquetSharp.Test
             }
         }
 
-        private static Column[] CreateFloatColumns()
+        private static Column[] CreateFloatColumns(LogicalType timestampType)
         {
             return new Column[]
             {
-                new Column<DateTime>("DateTime", LogicalType.Timestamp(true, TimeUnit.Millis)),
+                new Column<DateTime>("DateTime", timestampType),
                 new Column<int>("ObjectId"),
                 new Column<float>("Value")
             };

--- a/csharp.test/TestNestedReads.cs
+++ b/csharp.test/TestNestedReads.cs
@@ -18,40 +18,40 @@ namespace ParquetSharp.Test
             var path = Path.Combine(directory!, "TestFiles/nested.parquet");
 
             using var fileReader = new ParquetFileReader(path);
-            var rowGroupReader = fileReader.RowGroup(0);
+            using var rowGroupReader = fileReader.RowGroup(0);
 
             // first_level_long
-            var column0Reader = rowGroupReader.Column(0).LogicalReader<long?>();
+            using var column0Reader = rowGroupReader.Column(0).LogicalReader<long?>();
             var column0Actual = column0Reader.ReadAll(2);
             var column0Expected = new[] {1, 2};
             Assert.AreEqual(column0Expected, column0Actual);
 
             // first_level_nullable_string
-            var column1Reader = rowGroupReader.Column(1).LogicalReader<string?>();
+            using var column1Reader = rowGroupReader.Column(1).LogicalReader<string?>();
             var column1Actual = column1Reader.ReadAll(2);
             var column1Expected = new[] {null, "Not Null String"};
             Assert.AreEqual(column1Expected, column1Actual);
 
             // nullable_struct.nullable_struct_string
-            var column2Reader = rowGroupReader.Column(2).LogicalReader<string?>();
+            using var column2Reader = rowGroupReader.Column(2).LogicalReader<string?>();
             var column2Actual = column2Reader.ReadAll(2);
             var column2Expected = new[] {"Nullable Struct String", null};
             Assert.AreEqual(column2Expected, column2Actual);
 
             // struct.struct_string
-            var column3Reader = rowGroupReader.Column(3).LogicalReader<string>();
+            using var column3Reader = rowGroupReader.Column(3).LogicalReader<string>();
             var column3Actual = column3Reader.ReadAll(2);
             var column3Expected = new[] {"First Struct String", "Second Struct String"};
             Assert.AreEqual(column3Expected, column3Actual);
 
             // struct_array.array_in_struct_array
-            var column4Reader = rowGroupReader.Column(4).LogicalReader<long?[]?[]>();
+            using var column4Reader = rowGroupReader.Column(4).LogicalReader<long?[]?[]>();
             var column4Actual = column4Reader.ReadAll(2);
             var column4Expected = new[] {new[] {new[] {111, 112, 113}, new[] {121, 122, 123}}, new[] {new[] {211, 212, 213}}};
             Assert.AreEqual(column4Expected, column4Actual);
 
             // struct_array.string_in_struct_array
-            var column5Reader = rowGroupReader.Column(5).LogicalReader<string[]>();
+            using var column5Reader = rowGroupReader.Column(5).LogicalReader<string[]>();
             var column5Actual = column5Reader.ReadAll(2);
             var column5Expected = new[] {new[] {"First String", "Second String"}, new[] {"Third String"}};
             Assert.AreEqual(column5Expected, column5Actual);

--- a/csharp.test/TestParquetFileReader.cs
+++ b/csharp.test/TestParquetFileReader.cs
@@ -96,13 +96,14 @@ namespace ParquetSharp.Test
                     using (var columnReader = rowGroupReader.Column(c))
                     {
                         var descr = columnReader.ColumnDescriptor;
-                        var colChunkMetaData = rowGroupMetaData.GetColumnChunkMetaData(c);
+                        using var colChunkMetaData = rowGroupMetaData.GetColumnChunkMetaData(c);
 
                         Console.WriteLine("  - reader type: {0}", columnReader.Type);
                         Console.WriteLine("  - max definition level: {0}", descr.MaxDefinitionLevel);
                         Console.WriteLine("  - max repetition level: {0}", descr.MaxRepetitionLevel);
                         Console.WriteLine("  - physical type: {0}", descr.PhysicalType);
-                        Console.WriteLine("  - logical type: {0}", descr.LogicalType);
+                        using var logicalType = descr.LogicalType;
+                        Console.WriteLine("  - logical type: {0}", logicalType);
                         Console.WriteLine("  - column order: {0}", descr.ColumnOrder);
                         Console.WriteLine("  - sort order: {0}", descr.SortOrder);
                         Console.WriteLine("  - name: {0}", descr.Name);

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -140,7 +140,8 @@ namespace ParquetSharp
 
                 try
                 {
-                    return new GroupNode(name, Repetition.Optional, new[] {list}, LogicalType.List());
+                    using var listLogicalType = LogicalType.List();
+                    return new GroupNode(name, Repetition.Optional, new[] {list}, listLogicalType);
                 }
                 finally
                 {

--- a/csharp/ColumnDescriptor.cs
+++ b/csharp/ColumnDescriptor.cs
@@ -69,11 +69,22 @@ namespace ParquetSharp
             var (physicalType, logicalType) = typeFactory.GetSystemTypes(this, columnLogicalTypeOverride);
             var elementType = logicalType;
 
-            for (var node = SchemaNode; node != null; node = node.Parent)
+            var node = SchemaNode;
+            while (node != null)
             {
-                if (node.LogicalType.Type == LogicalTypeEnum.List)
+                try
                 {
-                    elementType = elementType.MakeArrayType();
+                    using var nodeLogicalType = node.LogicalType;
+                    if (nodeLogicalType.Type == LogicalTypeEnum.List)
+                    {
+                        elementType = elementType.MakeArrayType();
+                    }
+                }
+                finally
+                {
+                    var prevNode = node;
+                    node = prevNode.Parent;
+                    prevNode.Dispose();
                 }
             }
 

--- a/csharp/ColumnDescriptor.cs
+++ b/csharp/ColumnDescriptor.cs
@@ -72,20 +72,15 @@ namespace ParquetSharp
             var node = SchemaNode;
             while (node != null)
             {
-                try
+                using var nodeLogicalType = node.LogicalType;
+                if (nodeLogicalType.Type == LogicalTypeEnum.List)
                 {
-                    using var nodeLogicalType = node.LogicalType;
-                    if (nodeLogicalType.Type == LogicalTypeEnum.List)
-                    {
-                        elementType = elementType.MakeArrayType();
-                    }
+                    elementType = elementType.MakeArrayType();
                 }
-                finally
-                {
-                    var prevNode = node;
-                    node = prevNode.Parent;
-                    prevNode.Dispose();
-                }
+
+                var prevNode = node;
+                node = prevNode.Parent;
+                prevNode.Dispose();
             }
 
             return (physicalType, logicalType, elementType);

--- a/csharp/LogicalColumnReader.cs
+++ b/csharp/LogicalColumnReader.cs
@@ -161,8 +161,13 @@ namespace ParquetSharp
             short definitionLevel = 0;
             short schemaSlice = 0;
 
-            while (schemaNodes[schemaSlice] is GroupNode {LogicalType: NoneLogicalType})
+            while (schemaNodes[schemaSlice] is GroupNode groupNode)
             {
+                using var logicalType = groupNode.LogicalType;
+                if (logicalType is not NoneLogicalType)
+                {
+                    break;
+                }
                 if (schemaNodes[schemaSlice].Repetition == Repetition.Optional)
                 {
                     definitionLevel += 1;
@@ -220,8 +225,12 @@ namespace ParquetSharp
             {
                 if (schemaNodes.Length >= 2)
                 {
-                    if (schemaNodes[0] is GroupNode {LogicalType: ListLogicalType, Repetition: Repetition.Optional} &&
-                        schemaNodes[1] is GroupNode {LogicalType: NoneLogicalType, Repetition: Repetition.Repeated})
+                    using var node0LogicalType = schemaNodes[0].LogicalType;
+                    using var node1LogicalType = schemaNodes[1].LogicalType;
+                    if (schemaNodes[0] is GroupNode {Repetition: Repetition.Optional} &&
+                        node0LogicalType is ListLogicalType &&
+                        schemaNodes[1] is GroupNode {Repetition: Repetition.Repeated} &&
+                        node1LogicalType is NoneLogicalType)
                     {
                         return ReadArrayIntermediateLevel(
                             schemaNodes, valueReader, elementType, numArrayEntriesToRead, repetitionLevel, definitionLevel);

--- a/csharp/LogicalColumnStream.cs
+++ b/csharp/LogicalColumnStream.cs
@@ -42,6 +42,7 @@ namespace ParquetSharp
             {
                 schemaNodes.Add(n);
             }
+            schemaNodes[schemaNodes.Count - 1].Dispose();
             schemaNodes.RemoveAt(schemaNodes.Count - 1); // we don't need the schema root
             schemaNodes.Reverse(); // root to leaf
             return schemaNodes;

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -153,7 +153,7 @@ namespace ParquetSharp
                 return LogicalRead.GetNullableNativeConverter<Date, int>();
             }
 
-            var logicalType = columnDescriptor.LogicalType;
+            using var logicalType = columnDescriptor.LogicalType;
 
             if (typeof(TLogical) == typeof(DateTime))
             {

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -65,8 +65,9 @@ namespace ParquetSharp
         public virtual unsafe (Type physicalType, Type logicalType) GetSystemTypes(ColumnDescriptor descriptor)
         {
             var physicalType = descriptor.PhysicalType;
-            var logicalType = descriptor.LogicalType;
-            var repetition = descriptor.SchemaNode.Repetition;
+            using var logicalType = descriptor.LogicalType;
+            using var schemaNode = descriptor.SchemaNode;
+            var repetition = schemaNode.Repetition;
             var nullable = repetition == Repetition.Optional;
 
             // Check for an exact match in the default primitive mapping.

--- a/csharp/LogicalWrite.cs
+++ b/csharp/LogicalWrite.cs
@@ -131,7 +131,7 @@ namespace ParquetSharp
                 return LogicalWrite.GetNullableNativeConverter<Date, int>();
             }
 
-            var logicalType = columnDescriptor.LogicalType;
+            using var logicalType = columnDescriptor.LogicalType;
 
             if (typeof(TLogical) == typeof(DateTime))
             {

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -45,7 +45,7 @@ namespace ParquetSharp.Schema
                 return new GroupNode(
                     Name,
                     Repetition,
-                    fields,
+                    clonedFields,
                     logicalType is NoneLogicalType ? null : logicalType);
             }
             finally

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -37,11 +37,24 @@ namespace ParquetSharp.Schema
 
         public override Node DeepClone()
         {
-            return new GroupNode(
-                Name,
-                Repetition,
-                Fields.Select(f => f.DeepClone()).ToArray(),
-                LogicalType is NoneLogicalType ? null : LogicalType);
+            using var logicalType = LogicalType;
+            var fields = Fields;
+            var clonedFields = fields.Select(f => f.DeepClone()).ToArray();
+            try
+            {
+                return new GroupNode(
+                    Name,
+                    Repetition,
+                    fields,
+                    logicalType is NoneLogicalType ? null : logicalType);
+            }
+            finally
+            {
+                foreach (var field in fields.Concat(clonedFields))
+                {
+                    field.Dispose();
+                }
+            }
         }
 
         private static unsafe IntPtr Make(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType? logicalType)

--- a/csharp/Schema/PrimitiveNode.cs
+++ b/csharp/Schema/PrimitiveNode.cs
@@ -31,10 +31,11 @@ namespace ParquetSharp.Schema
 
         public override Node DeepClone()
         {
+            using var logicalType = LogicalType;
             return new PrimitiveNode(
                 Name,
                 Repetition,
-                LogicalType,
+                logicalType,
                 PhysicalType,
                 TypeLength);
         }


### PR DESCRIPTION
In this PR I've tried to dispose of most internal uses of LogicalType and Node to reduce the need to run finalizers.

There is still one main place where we create logical types and nodes that aren't disposed that I'm aware of. In LogicalColumnStream, the LogicalType and SchemaNodesPath properties are initialized in the constructor rather than being getters that create new instances, so these should probably be disposed when disposing the LogicalColumnStream instance. But there's a small chance that could be a breaking change if somebody is expecting to be able to continue using those after the LogicalColumnStream is disposed, so I've currently left that as-is.

There's also `RowOriented.ParquetFile.GetColumn` which creates logical types that aren't disposed, and I couldn't see a straightforward way to fix that.