### PR TITLE
Handle reading and writing string values without definition levels

### DIFF
--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -656,11 +656,9 @@ namespace ParquetSharp.Test
             var stringValues = Enumerable.Range(0, 100).Select(i => i.ToString()).ToArray();
 
             using var stringType = LogicalType.String();
-            var typeMapping = new Dictionary<Type, (LogicalType? logicalType, Repetition repetition, PhysicalType physicalType)>(
-                LogicalTypeFactory.DefaultPrimitiveMapping)
-            {
-                [typeof(string)] = (stringType, Repetition.Required, PhysicalType.ByteArray)
-            };
+            var typeMapping = LogicalTypeFactory.DefaultPrimitiveMapping.ToDictionary(
+                entry => entry.Key, entry => entry.Value);
+            typeMapping[typeof(string)] = (stringType, Repetition.Required, PhysicalType.ByteArray);
             var logicalTypeFactory = new LogicalTypeFactory(typeMapping);
 
             using var stringColumn = new PrimitiveNode("strings", Repetition.Required, stringType, PhysicalType.ByteArray);

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -470,7 +470,7 @@ namespace ParquetSharp
         {
             for (int i = 0, src = 0; i < destination.Length; ++i)
             {
-                destination[i] = defLevels[i] != definedLevel ? null : ToString(source[src++], byteArrayCache);
+                destination[i] = defLevels.IsEmpty || defLevels[i] == definedLevel ? ToString(source[src++], byteArrayCache) : null;
             }
         }
 

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -124,6 +124,11 @@ namespace ParquetSharp
                 }
             }
 
+            if (logicalType.Type == LogicalTypeEnum.String)
+            {
+                return (typeof(ByteArray), typeof(string));
+            }
+
             if (logicalType.Type == LogicalTypeEnum.Json)
             {
                 return (typeof(ByteArray), typeof(string));

--- a/csharp/LogicalWrite.cs
+++ b/csharp/LogicalWrite.cs
@@ -522,7 +522,10 @@ namespace ParquetSharp
                 else
                 {
                     destination[dst++] = FromString(value, byteBuffer);
-                    defLevels[i] = (short) (nullLevel + 1);
+                    if (!defLevels.IsEmpty)
+                    {
+                        defLevels[i] = (short) (nullLevel + 1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes #292 by updating the `LogicalTypeFactory` to handle string columns where repetition is set to required, and fixing the definition level handling when reading and writing required string data.