### PR TITLE
Allow NullLogicalType given a PhysicalType

### DIFF
--- a/csharp.test/TestCaseGenericAttribute.cs
+++ b/csharp.test/TestCaseGenericAttribute.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
+
+namespace ParquetSharp.Test
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    internal sealed class TestCaseGenericAttribute : TestCaseAttribute, ITestBuilder
+    {
+        public TestCaseGenericAttribute(params object[] arguments)
+            : base(arguments)
+        {
+        }
+
+        public Type[] TypeArguments { get; set; } = null!;
+
+        IEnumerable<TestMethod> ITestBuilder.BuildFrom(IMethodInfo method, NUnit.Framework.Internal.Test? suite)
+        {
+            if (!method.IsGenericMethodDefinition)
+                return base.BuildFrom(method, suite);
+
+            if (TypeArguments == null || TypeArguments.Length != method.GetGenericArguments().Length)
+            {
+                var parms = new TestCaseParameters {RunState = RunState.NotRunnable};
+                parms.Properties.Set("_SKIPREASON", $"{nameof(TypeArguments)} should have {method.GetGenericArguments().Length} elements");
+                return new[] {new NUnitTestCaseBuilder().BuildTestMethod(method, suite, parms)};
+            }
+
+            var genMethod = method.MakeGenericMethod(TypeArguments);
+            return base.BuildFrom(genMethod, suite);
+        }
+    }
+}

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -82,7 +82,7 @@ namespace ParquetSharp
                 return (DefaultPhysicalTypeMapping[physicalType], match.Key);
             }
 
-            if (logicalType is NoneLogicalType)
+            if (logicalType is NoneLogicalType or NullLogicalType)
             {
                 switch (physicalType)
                 {
@@ -90,6 +90,14 @@ namespace ParquetSharp
                         return (typeof(int), nullable ? typeof(int?) : typeof(int));
                     case PhysicalType.Int64:
                         return (typeof(long), nullable ? typeof(long?) : typeof(long));
+                    case PhysicalType.Int96:
+                        return (typeof(Int96), nullable ? typeof(Int96?) : typeof(Int96));
+                    case PhysicalType.Boolean:
+                        return (typeof(bool), nullable ? typeof(bool?) : typeof(bool));
+                    case PhysicalType.Float:
+                        return (typeof(float), nullable ? typeof(float?) : typeof(float));
+                    case PhysicalType.Double:
+                        return (typeof(double), nullable ? typeof(double?) : typeof(double));
                 }
             }
 

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -84,6 +84,10 @@ namespace ParquetSharp
 
             if (logicalType is NoneLogicalType or NullLogicalType)
             {
+                if (!nullable && logicalType is NullLogicalType)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(logicalType), "The null logical type may only be used with optional columns");
+                }
                 switch (physicalType)
                 {
                     case PhysicalType.Int32:


### PR DESCRIPTION
_This PR is on behalf of @msumner91._

The goal is to fix the following exception:
```
System.ArgumentOutOfRangeException: unsupported logical type Null with physical type Int32
Parameter name: logicalType
at ParquetSharp.LogicalTypeFactory.GetSystemTypes(ColumnDescriptor descriptor)
at ParquetSharp.LogicalTypeFactory.GetSystemTypes(ColumnDescriptor descriptor, Type columnLogicalTypeOverride)
at ParquetSharp.ColumnDescriptor.GetSystemTypes(LogicalTypeFactory typeFactory, Type columnLogicalTypeOverride)
```