### PR TITLE
Integrate Slack Github Action

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -1,0 +1,17 @@
+name: Nudge
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [master]
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    environment: protected
+    steps:
+      - name: Send notification
+        uses: pavlovic-ivan/octo-nudge@v1
+        with:
+          webhooks: ${{ secrets.WEBHOOKS }}

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -15,4 +15,3 @@ jobs:
         uses: pavlovic-ivan/octo-nudge@v1
         with:
           webhooks: ${{ secrets.WEBHOOKS }}
-          conclusions: 'failure,success'

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -15,3 +15,4 @@ jobs:
         uses: pavlovic-ivan/octo-nudge@v1
         with:
           webhooks: ${{ secrets.WEBHOOKS }}
+          conclusions: 'failure,success'


### PR DESCRIPTION
This PR introduces a workflow that will be triggered when the main CI workflow is completed. By default, you will receive a notification in Slack only if the CI workflow has failed.

[Here](https://github.com/pavlovic-ivan/ParquetSharp/actions/runs/3237654834) is the workflow that failed. And [here](https://github.com/pavlovic-ivan/ParquetSharp/actions/runs/3237686068/jobs/5305039372) is the workflow that got triggered, that had sent the notification to Slack.

In this PR, when the Github Action Octo Nudge is callled, it is using default values. In short:

- notify if workflow conclusion is `failure`
- notify if the CI workflow is triggered by a `push` or `schedule` to the master branch

You can check the rest [here](https://github.com/pavlovic-ivan/octo-nudge#action-input-arguments).

I've tested using my fork, my incoming webhook created withing Slack, and a channel i've created. Which means that you will need to create the incoming webhook and the channel, or connect the incoming webhook to an existing channel. If you need help, please let me know, i will be available for setting it up.

Lastly, this is how the notification looks like in Slack.
<img width="615" alt="Screenshot 2022-10-12 at 22 29 22" src="https://user-images.githubusercontent.com/23194814/195694782-f94da7e3-46e8-425e-9559-2a086d95c672.png">
