### PR TITLE
Convert paths to extend length format on Windows and add documentation on long path support

### DIFF
--- a/csharp.test/TestParquetFileWriter.cs
+++ b/csharp.test/TestParquetFileWriter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ParquetSharp.IO;
@@ -104,12 +105,53 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestStringPathHandling([Values] bool absolutePath)
         {
+            using var testDir = new TempWorkingDirectory();
             var path = "test.parquet";
             if (absolutePath)
             {
-                path = Path.GetFullPath(path);
+                path = Path.Combine(testDir.DirectoryPath, path);
             }
+            WriteAndReadPath(path);
+        }
 
+        [Test]
+        [Platform("Win")]
+        public static void TestWindowsPathHandling()
+        {
+            using var testDir = new TempWorkingDirectory();
+            var path = Path.Combine(testDir.DirectoryPath, "test.parquet");
+
+            WriteAndReadPath(path.Replace('\\', '/'));
+            WriteAndReadPath("//?/" + path);
+            WriteAndReadPath(@"\\?\" + path);
+
+            var networkPath = @"\\localhost\" + path[0] + "$" + path.Substring(2);
+            WriteAndReadPath(networkPath);
+            WriteAndReadPath("//" + networkPath.Substring(2).Replace('\\', '/'));
+            WriteAndReadPath(@"\\?\UNC\" + networkPath.Substring(2));
+            WriteAndReadPath(@"//?/UNC/" + networkPath.Substring(2).Replace('\\', '/'));
+        }
+
+        [Test]
+        [Platform("Win")]
+        [Platform("NetCore")] // Can't easily create a long directory path in .Net Framework
+        public static void TestWindowsLongPathHandling()
+        {
+            using var testDir = new TempWorkingDirectory();
+
+            var longPathBuilder = new StringBuilder(testDir.DirectoryPath + "/");
+            for (var i = 0; i < 20; i++)
+            {
+                longPathBuilder.Append("long_path_component/");
+            }
+            var longDirectoryPath = longPathBuilder.ToString();
+            Directory.CreateDirectory(longDirectoryPath);
+            var longPath = Path.GetFullPath(longDirectoryPath + "test.parquet");
+            WriteAndReadPath(longPath);
+        }
+
+        private static void WriteAndReadPath(string path)
+        {
             var columns = new Column[]
             {
                 new Column<int>("x"),
@@ -341,6 +383,27 @@ namespace ParquetSharp.Test
 
             Task.WaitAll(running);
         }
+    }
 
+    internal sealed class TempWorkingDirectory : IDisposable
+    {
+        public TempWorkingDirectory()
+        {
+            _originalWorkingDirectory = Directory.GetCurrentDirectory();
+            _directoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_directoryPath);
+            Directory.SetCurrentDirectory(_directoryPath);
+        }
+
+        public void Dispose()
+        {
+            Directory.SetCurrentDirectory(_originalWorkingDirectory);
+            Directory.Delete(_directoryPath, recursive: true);
+        }
+
+        public string DirectoryPath => _directoryPath;
+
+        private readonly string _directoryPath;
+        private readonly string _originalWorkingDirectory;
     }
 }

--- a/csharp.test/TestParquetFileWriter.cs
+++ b/csharp.test/TestParquetFileWriter.cs
@@ -102,6 +102,36 @@ namespace ParquetSharp.Test
         }
 
         [Test]
+        public static void TestStringPathHandling([Values] bool absolutePath)
+        {
+            var path = "test.parquet";
+            if (absolutePath)
+            {
+                path = Path.GetFullPath(path);
+            }
+
+            var columns = new Column[]
+            {
+                new Column<int>("x"),
+            };
+            using (var writer = new ParquetFileWriter(path, columns))
+            {
+                writer.Close();
+            }
+
+            try
+            {
+                using var reader = new ParquetFileReader(path);
+                Assert.That(reader.FileMetaData.NumRowGroups, Is.EqualTo(0));
+                Assert.That(reader.FileMetaData.NumColumns, Is.EqualTo(1));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
         public static void TestDisposedAccess()
         {
             using var buffer = new ResizableBuffer();

--- a/csharp/LongPath.cs
+++ b/csharp/LongPath.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp
+{
+    internal static class LongPath
+    {
+        /// <summary>
+        /// Perform OS-dependent pre-processing of the specified path so that the win32 apis used by Arrow to open
+        /// files will handle long paths.
+        /// The host must also be configured to enable long paths, and the application manifest must specify that
+        /// the application is long path aware.
+        /// See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation for more details.
+        /// </summary>
+        public static string EnsureLongPathSafe(string path)
+        {
+            if (!Path.IsPathRooted(path) || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return path;
+            }
+            if (path.StartsWith("//?/") || path.StartsWith(@"\\?\"))
+            {
+                return path;
+            }
+            if (path.StartsWith("//") || path.StartsWith(@"\\"))
+            {
+                return @"\\?\UNC\" + path.Substring(2);
+            }
+            return @"\\?\" + path;
+        }
+    }
+}

--- a/csharp/LongPath.cs
+++ b/csharp/LongPath.cs
@@ -7,7 +7,7 @@ namespace ParquetSharp
     {
         /// <summary>
         /// Perform OS-dependent pre-processing of the specified path so that the win32 apis used by Arrow to open
-        /// files will handle long paths.
+        /// files will handle long paths. Note that this only handles absolute paths.
         /// The host must also be configured to enable long paths, and the application manifest must specify that
         /// the application is long path aware.
         /// See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation for more details.

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -19,6 +19,7 @@ namespace ParquetSharp
         public ParquetFileReader(string path, ReaderProperties? readerProperties)
         {
             if (path == null) throw new ArgumentNullException(nameof(path));
+            path = LongPath.EnsureLongPathSafe(path);
 
             using var defaultProperties = readerProperties == null ? ReaderProperties.GetDefaultReaderProperties() : null;
             var properties = readerProperties ?? defaultProperties!;

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -374,6 +374,8 @@ namespace ParquetSharp
             if (schema == null) throw new ArgumentNullException(nameof(schema));
             if (writerProperties == null) throw new ArgumentNullException(nameof(writerProperties));
 
+            path = LongPath.EnsureLongPathSafe(path);
+
             ExceptionInfo.Check(ParquetFileWriter_OpenFile(
                 path, schema.Handle.IntPtr, writerProperties.Handle.IntPtr, keyValueMetadata?.Handle.IntPtr ?? IntPtr.Zero, out var writer));
 

--- a/docs/Reading.md
+++ b/docs/Reading.md
@@ -135,4 +135,4 @@ for example:
 ```
 
 For more information, see the Microsoft documentation on the
-`maximum path length limitation`(https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).
+[maximum path length limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).

--- a/docs/Reading.md
+++ b/docs/Reading.md
@@ -134,5 +134,7 @@ for example:
 </application>
 ```
 
+Paths must also be specified in extended-length format,
+which is handled automatically by ParquetSharp when an absolute path is provided since version 9.0.0.
 For more information, see the Microsoft documentation on the
 [maximum path length limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).

--- a/docs/Reading.md
+++ b/docs/Reading.md
@@ -117,3 +117,22 @@ or
     <RuntimeHostConfigurationOption Include="ParquetSharp.ReadDateTimeKindAsUnspecified" Value="true" />
   </ItemGroup>
 ```
+
+## Long path handling
+
+When running on Windows, the Arrow library used internally by ParquetSharp uses Win32 APIs that can support
+long paths (paths greater than 260 characters), but handling long paths additionally requires that the host
+has the `Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled`
+registry key enabled, and the application must have a manifest that specifies it is long path aware,
+for example:
+
+```
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+</application>
+```
+
+For more information, see the Microsoft documentation on the
+`maximum path length limitation`(https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).


### PR DESCRIPTION
Although Arrow was updated to use long-path aware win32 APIs (#114), there are additional configuration requirements needed to handle long paths, so I've added documentation on this.

In addition, paths need to be provided in extended-length format, even in dotnet core, so I've added code to do this conversion automatically for absolute paths.