### PR TITLE
Avoid use of ManagedOutputStream and RandomAccessFile after GC

### DIFF
--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -38,6 +38,7 @@ namespace ParquetSharp
             var properties = readerProperties ?? defaultProperties!;
 
             _handle = new ParquetHandle(ExceptionInfo.Return<IntPtr, IntPtr>(randomAccessFile.Handle, properties.Handle.IntPtr, ParquetFileReader_Open), ParquetFileReader_Free);
+            _randomAccessFile = randomAccessFile;
 
             GC.KeepAlive(readerProperties);
         }
@@ -83,5 +84,6 @@ namespace ParquetSharp
 
         private readonly ParquetHandle _handle;
         private FileMetaData? _fileMetaData;
+        private readonly RandomAccessFile? _randomAccessFile; // Keep a handle to the input file to prevent GC
     }
 }

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -55,6 +55,7 @@ namespace ParquetSharp
                 _parquetKeyValueMetadata = new KeyValueMetadata();
             }
             _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
+            _outputStream = outputStream;
             Columns = columns;
         }
 
@@ -109,6 +110,7 @@ namespace ParquetSharp
                 _parquetKeyValueMetadata = new KeyValueMetadata();
             }
             _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
+            _outputStream = outputStream;
             Columns = columns;
         }
 
@@ -157,6 +159,7 @@ namespace ParquetSharp
                 _parquetKeyValueMetadata = new KeyValueMetadata();
             }
             _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
+            _outputStream = outputStream;
             Columns = columns;
         }
 
@@ -209,6 +212,7 @@ namespace ParquetSharp
                 _parquetKeyValueMetadata = new KeyValueMetadata();
             }
             _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
+            _outputStream = outputStream;
             Columns = columns;
         }
 
@@ -255,6 +259,7 @@ namespace ParquetSharp
                 _parquetKeyValueMetadata = new KeyValueMetadata();
             }
             _handle = CreateParquetFileWriter(outputStream, schema, writerProperties, _parquetKeyValueMetadata);
+            _outputStream = outputStream;
             Columns = null;
         }
 
@@ -453,5 +458,6 @@ namespace ParquetSharp
         private FileMetaData? _fileMetaData;
         private WriterProperties? _writerProperties;
         private bool _keyValueMetadataSet;
+        private readonly OutputStream? _outputStream; // Keep a handle to the output stream to prevent GC
     }
 }


### PR DESCRIPTION
This fixes crashes when users don't keep a reference to a `ManagedOutputStream` or `ManagedRandomAccessFile` while they are in use. They should still be used with a using statement so that the handle is freed immediately when no longer needed though.

A reference to the managed objects is captured in the handle free functions so that they are kept alive until after the handle is freed. `ParquetFileReader` and `ParquetFileWriter` now also keep references to the `RandomAccessFile` and `OutputStream` instances if used to ensure they aren't GC'd until after they are no longer needed.

Fixes #312
