### PR TITLE
Support reading decimal data with int32 or int64 physical type

### DIFF
--- a/csharp.test/TestDecimal.cs
+++ b/csharp.test/TestDecimal.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using ParquetSharp.IO;
+using ParquetSharp.Schema;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestDecimal
+    {
+        [Test]
+        public static void TestReadInt32PhysicalType()
+        {
+            // ParquetSharp doesn't currently support writing decimal values
+            // with int32 physical type, so we need to define the schema manually.
+            using var decimalType = LogicalType.Decimal(precision: 9, scale: 4);
+            using var colNode = new PrimitiveNode("value", Repetition.Required, decimalType, PhysicalType.Int32);
+            using var schema = new GroupNode("schema", Repetition.Required, new Node[] {colNode});
+
+            var physicalValues = Enumerable.Range(0, 10_000)
+                .Select(i => i - 5_000)
+                .Concat(new[] {int.MinValue, int.MinValue + 1, int.MaxValue - 1, int.MaxValue})
+                .ToArray();
+            var scale = new decimal(10000);
+            var expectedValues = physicalValues.Select(v => new decimal(v) / scale).ToArray();
+
+            using var buffer = new ResizableBuffer();
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var propertiesBuilder = new WriterPropertiesBuilder();
+                using var writerProperties = propertiesBuilder.Build();
+                using var fileWriter = new ParquetFileWriter(outStream, schema, writerProperties);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                using var columnWriter = (ColumnWriter<int>) rowGroupWriter.NextColumn();
+
+                columnWriter.WriteBatch(physicalValues);
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            using var groupReader = fileReader.RowGroup(0);
+
+            using var columnReader = groupReader.Column(0).LogicalReader<decimal>();
+            var readValues = columnReader.ReadAll((int) groupReader.MetaData.NumRows);
+
+            Assert.That(readValues, Is.EqualTo(expectedValues));
+        }
+
+        [Test]
+        public static void TestReadNullableDataWithInt32PhysicalType()
+        {
+            using var decimalType = LogicalType.Decimal(precision: 9, scale: 4);
+            using var colNode = new PrimitiveNode("value", Repetition.Optional, decimalType, PhysicalType.Int32);
+            using var schema = new GroupNode("schema", Repetition.Required, new Node[] {colNode});
+
+            var physicalValues = new List<int>();
+            var defLevels = new List<short>();
+            var expectedValues = new List<decimal?>();
+
+            const int numValues = 10_000;
+            for (var i = 0; i < numValues; ++i)
+            {
+                if (i % 10 == 0)
+                {
+                    defLevels.Add(0);
+                    expectedValues.Add(null);
+                }
+                else
+                {
+                    var physicalValue = i - 5_000;
+                    physicalValues.Add(physicalValue);
+                    defLevels.Add(1);
+                    expectedValues.Add(new decimal(physicalValue) / 10_000);
+                }
+            }
+
+            using var buffer = new ResizableBuffer();
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var propertiesBuilder = new WriterPropertiesBuilder();
+                using var writerProperties = propertiesBuilder.Build();
+                using var fileWriter = new ParquetFileWriter(outStream, schema, writerProperties);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                using var columnWriter = (ColumnWriter<int>) rowGroupWriter.NextColumn();
+
+                columnWriter.WriteBatch(numValues, defLevels.ToArray(), null, physicalValues.ToArray());
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            using var groupReader = fileReader.RowGroup(0);
+
+            using var columnReader = groupReader.Column(0).LogicalReader<decimal?>();
+            var readValues = columnReader.ReadAll((int) groupReader.MetaData.NumRows);
+
+            Assert.That(readValues, Is.EqualTo(expectedValues.ToArray()));
+        }
+
+        [Test]
+        public static void TestReadInt64PhysicalType()
+        {
+            // ParquetSharp doesn't currently support writing decimal values
+            // with int64 physical type, so we need to define the schema manually.
+            using var decimalType = LogicalType.Decimal(precision: 10, scale: 4);
+            using var colNode = new PrimitiveNode("value", Repetition.Required, decimalType, PhysicalType.Int64);
+            using var schema = new GroupNode("schema", Repetition.Required, new Node[] {colNode});
+
+            var physicalValues = Enumerable.Range(0, 10_000)
+                .Select(i => (long) (i - 5_000))
+                .Concat(new[] {long.MinValue, long.MinValue + 1, long.MaxValue - 1, long.MaxValue})
+                .ToArray();
+            var scale = new decimal(10000);
+            var expectedValues = physicalValues.Select(v => new decimal(v) / scale).ToArray();
+
+            using var buffer = new ResizableBuffer();
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var propertiesBuilder = new WriterPropertiesBuilder();
+                using var writerProperties = propertiesBuilder.Build();
+                using var fileWriter = new ParquetFileWriter(outStream, schema, writerProperties);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                using var columnWriter = (ColumnWriter<long>) rowGroupWriter.NextColumn();
+
+                columnWriter.WriteBatch(physicalValues);
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            using var groupReader = fileReader.RowGroup(0);
+
+            using var columnReader = groupReader.Column(0).LogicalReader<decimal>();
+            var readValues = columnReader.ReadAll((int) groupReader.MetaData.NumRows);
+
+            Assert.That(readValues, Is.EqualTo(expectedValues));
+        }
+
+        [Test]
+        public static void TestReadNullableDataWithInt64PhysicalType()
+        {
+            using var decimalType = LogicalType.Decimal(precision: 10, scale: 4);
+            using var colNode = new PrimitiveNode("value", Repetition.Optional, decimalType, PhysicalType.Int64);
+            using var schema = new GroupNode("schema", Repetition.Required, new Node[] {colNode});
+
+            var physicalValues = new List<long>();
+            var defLevels = new List<short>();
+            var expectedValues = new List<decimal?>();
+
+            const int numValues = 10_000;
+            for (var i = 0; i < numValues; ++i)
+            {
+                if (i % 10 == 0)
+                {
+                    defLevels.Add(0);
+                    expectedValues.Add(null);
+                }
+                else
+                {
+                    var physicalValue = i - 5_000;
+                    physicalValues.Add(physicalValue);
+                    defLevels.Add(1);
+                    expectedValues.Add(new decimal(physicalValue) / 10_000);
+                }
+            }
+
+            using var buffer = new ResizableBuffer();
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var propertiesBuilder = new WriterPropertiesBuilder();
+                using var writerProperties = propertiesBuilder.Build();
+                using var fileWriter = new ParquetFileWriter(outStream, schema, writerProperties);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                using var columnWriter = (ColumnWriter<long>) rowGroupWriter.NextColumn();
+
+                columnWriter.WriteBatch(numValues, defLevels.ToArray(), null, physicalValues.ToArray());
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            using var groupReader = fileReader.RowGroup(0);
+
+            using var columnReader = groupReader.Column(0).LogicalReader<decimal?>();
+            var readValues = columnReader.ReadAll((int) groupReader.MetaData.NumRows);
+
+            Assert.That(readValues, Is.EqualTo(expectedValues.ToArray()));
+        }
+    }
+}

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -126,13 +126,35 @@ namespace ParquetSharp
             if (typeof(TLogical) == typeof(decimal))
             {
                 var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
-                return (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal128(s, d, multiplier));
+                if (typeof(TPhysical) == typeof(int))
+                {
+                    return (LogicalRead<decimal, int>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal32(s, d, multiplier));
+                }
+                if (typeof(TPhysical) == typeof(long))
+                {
+                    return (LogicalRead<decimal, long>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal64(s, d, multiplier));
+                }
+                if (typeof(TPhysical) == typeof(FixedLenByteArray))
+                {
+                    return (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal128(s, d, multiplier));
+                }
             }
 
             if (typeof(TLogical) == typeof(decimal?))
             {
                 var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
-                return (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal128(s, dl, d, multiplier, del));
+                if (typeof(TPhysical) == typeof(int))
+                {
+                    return (LogicalRead<decimal?, int>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal32(s, dl, d, multiplier, del));
+                }
+                if (typeof(TPhysical) == typeof(long))
+                {
+                    return (LogicalRead<decimal?, long>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal64(s, dl, d, multiplier, del));
+                }
+                if (typeof(TPhysical) == typeof(FixedLenByteArray))
+                {
+                    return (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal128(s, dl, d, multiplier, del));
+                }
             }
 
             if (typeof(TLogical) == typeof(Guid))
@@ -389,6 +411,38 @@ namespace ParquetSharp
             for (int i = 0, src = 0; i < destination.Length; ++i)
             {
                 destination[i] = defLevels[i] != definedLevel ? default(ushort?) : (ushort) source[src++];
+            }
+        }
+
+        public static void ConvertDecimal32(ReadOnlySpan<int> source, Span<decimal> destination, decimal multiplier)
+        {
+            for (int i = 0; i < destination.Length; ++i)
+            {
+                destination[i] = source[i] / multiplier;
+            }
+        }
+
+        public static void ConvertDecimal32(ReadOnlySpan<int> source, ReadOnlySpan<short> defLevels, Span<decimal?> destination, decimal multiplier, short definedLevel)
+        {
+            for (int i = 0, src = 0; i < destination.Length; ++i)
+            {
+                destination[i] = defLevels[i] != definedLevel ? default(decimal?) : source[src++] / multiplier;
+            }
+        }
+
+        public static void ConvertDecimal64(ReadOnlySpan<long> source, Span<decimal> destination, decimal multiplier)
+        {
+            for (int i = 0; i < destination.Length; ++i)
+            {
+                destination[i] = source[i] / multiplier;
+            }
+        }
+
+        public static void ConvertDecimal64(ReadOnlySpan<long> source, ReadOnlySpan<short> defLevels, Span<decimal?> destination, decimal multiplier, short definedLevel)
+        {
+            for (int i = 0, src = 0; i < destination.Length; ++i)
+            {
+                destination[i] = defLevels[i] != definedLevel ? default(decimal?) : source[src++] / multiplier;
             }
         }
 

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -107,9 +107,25 @@ namespace ParquetSharp
 
             if (logicalType is DecimalLogicalType)
             {
-                if (descriptor.TypeLength != sizeof(Decimal128)) throw new NotSupportedException($"only {sizeof(Decimal128)} bytes of decimal length is supported");
-                if (descriptor.TypePrecision > 29) throw new NotSupportedException("only max 29 digits of decimal precision is supported");
-                return (typeof(FixedLenByteArray), nullable ? typeof(decimal?) : typeof(decimal));
+                switch (physicalType)
+                {
+                    case PhysicalType.Int32:
+                        return (typeof(int), nullable ? typeof(decimal?) : typeof(decimal));
+                    case PhysicalType.Int64:
+                        return (typeof(long), nullable ? typeof(decimal?) : typeof(decimal));
+                    case PhysicalType.FixedLenByteArray:
+                    {
+                        if (descriptor.TypeLength != sizeof(Decimal128))
+                        {
+                            throw new NotSupportedException($"only {sizeof(Decimal128)} bytes of decimal length is supported with fixed-length byte array data");
+                        }
+                        if (descriptor.TypePrecision > 29)
+                        {
+                            throw new NotSupportedException("only max 29 digits of decimal precision is supported with fixed-length byte array data");
+                        }
+                        return (typeof(FixedLenByteArray), nullable ? typeof(decimal?) : typeof(decimal));
+                    }
+                }
             }
 
             if (logicalType is TimeLogicalType timeLogicalType)

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -110,9 +110,21 @@ namespace ParquetSharp
                 switch (physicalType)
                 {
                     case PhysicalType.Int32:
+                    {
+                        if (descriptor.TypePrecision > 9)
+                        {
+                            throw new NotSupportedException("A maximum of 9 digits of decimal precision is supported with int32 data");
+                        }
                         return (typeof(int), nullable ? typeof(decimal?) : typeof(decimal));
+                    }
                     case PhysicalType.Int64:
+                    {
+                        if (descriptor.TypePrecision > 18)
+                        {
+                            throw new NotSupportedException("A maximum of 18 digits of decimal precision is supported with int64 data");
+                        }
                         return (typeof(long), nullable ? typeof(decimal?) : typeof(decimal));
+                    }
                     case PhysicalType.FixedLenByteArray:
                     {
                         if (descriptor.TypeLength != sizeof(Decimal128))

--- a/csharp/LogicalWrite.cs
+++ b/csharp/LogicalWrite.cs
@@ -97,6 +97,10 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(decimal))
             {
+                if (typeof(TPhysical) != typeof(FixedLenByteArray))
+                {
+                    throw new NotSupportedException("Writing decimal data is only supported with a fixed-length byte array physical type");
+                }
                 if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
                 return (LogicalWrite<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalWrite.ConvertDecimal128(s, d, multiplier, byteBuffer));
@@ -104,6 +108,10 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(decimal?))
             {
+                if (typeof(TPhysical) != typeof(FixedLenByteArray))
+                {
+                    throw new NotSupportedException("Writing decimal data is only supported with a fixed-length byte array physical type");
+                }
                 if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
                 return (LogicalWrite<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, nl) => LogicalWrite.ConvertDecimal128(s, dl, d, multiplier, nl, byteBuffer));


### PR DESCRIPTION
Fixes #314, based on code by @fan130 in https://github.com/fan130/ParquetSharp/commit/7b7a5d4968a6ac35cde96d4b2343cfd5a5b26f36 but also supporting reading int32 data.