### PR TITLE
Support of optional nested-nested types reading

### DIFF
--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -545,10 +545,10 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestNestedNestedOptionalListWithRequiredField()
         {
-            int rows = 5;
-            int nestedNestedElements = 111;
-            int maxNestedNestedIds = 200;
-            int randomSeed = 127;
+            const int rows = 5;
+            const int nestedNestedElements = 111;
+            const int maxNestedNestedIds = 200;
+            const int randomSeed = 127;
 
             var inputNestedNestedData = new Nested<Nested<string>[]?>[rows][];
 
@@ -559,9 +559,7 @@ namespace ParquetSharp.Test
 
                 for (int j = 0; j < nestedNestedElements; j++)
                 {
-                    Nested<string>[]? val = j % 2 == 0 ?
-                        Enumerable.Range(0, r.Next(maxNestedNestedIds)).Select(i => new Nested<string>(Guid.NewGuid().ToString())).ToArray() :
-                        null;
+                    Nested<string>[]? val = j % 2 == 0 ? Enumerable.Range(0, r.Next(maxNestedNestedIds)).Select(i => new Nested<string>(Guid.NewGuid().ToString())).ToArray() : null;
 
                     inputNestedNestedData[i][j] = new Nested<Nested<string>[]?>(val);
                 }
@@ -571,15 +569,15 @@ namespace ParquetSharp.Test
             using (var output = new BufferOutputStream(buffer))
             {
                 using var nestedNestedItem = new PrimitiveNode("nestedNestedIds", Repetition.Required, LogicalType.String(), PhysicalType.ByteArray);
-                using var nestedNestedElement = new GroupNode("element", Repetition.Required, new[] { nestedNestedItem } );
-                using var nestedNestedList = new GroupNode("list", Repetition.Repeated, new[] { nestedNestedElement });
-                using var nestedNestedStructure = new GroupNode("NestedNested", Repetition.Optional, new[] { nestedNestedList }, LogicalType.List());                
+                using var nestedNestedElement = new GroupNode("element", Repetition.Required, new[] {nestedNestedItem});
+                using var nestedNestedList = new GroupNode("list", Repetition.Repeated, new[] {nestedNestedElement});
+                using var nestedNestedStructure = new GroupNode("NestedNested", Repetition.Optional, new[] {nestedNestedList}, LogicalType.List());
 
-                using var nestedElement = new GroupNode("element", Repetition.Required, new[] { nestedNestedStructure });
-                using var nestedList = new GroupNode("list", Repetition.Repeated, new[] { nestedElement });
-                using var nestedStructure = new GroupNode("Nested", Repetition.Required, new[] { nestedList }, LogicalType.List());
+                using var nestedElement = new GroupNode("element", Repetition.Required, new[] {nestedNestedStructure});
+                using var nestedList = new GroupNode("list", Repetition.Repeated, new[] {nestedElement});
+                using var nestedStructure = new GroupNode("Nested", Repetition.Required, new[] {nestedList}, LogicalType.List());
 
-                using var schemaNode = new GroupNode("schema", Repetition.Required, new[] { nestedStructure });
+                using var schemaNode = new GroupNode("schema", Repetition.Required, new[] {nestedStructure});
 
                 using var builder = new WriterPropertiesBuilder();
                 using var writerProperties = builder.Build();
@@ -596,7 +594,7 @@ namespace ParquetSharp.Test
             using var rowGroupReader = fileReader.RowGroup(0);
 
             using var colReader = rowGroupReader.Column(0).LogicalReader<string[]?[]>();
-            var actual = colReader.ReadAll((int)rowGroupReader.MetaData.NumRows);
+            var actual = colReader.ReadAll((int) rowGroupReader.MetaData.NumRows);
             Assert.IsNotEmpty(actual);
             Assert.AreEqual(inputNestedNestedData.Length, actual.Length);
             for (var i = 0; i < inputNestedNestedData.Length; i++)
@@ -614,7 +612,7 @@ namespace ParquetSharp.Test
                     {
                         Assert.IsNull(inputNestedNestedData[i][j].Value);
                         Assert.AreEqual(inputNestedNestedData[i][j].Value, actual[i][j]);
-                    }                    
+                    }
                 }
             }
 

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -539,6 +539,89 @@ namespace ParquetSharp.Test
         }
 
         /// <summary>
+        /// This checks that values written to nested-nested required field of 
+        /// a nested-nested optional list can be read back.
+        /// </summary>
+        [Test]
+        public static void TestNestedNestedOptinalListWithRequiredField()
+        {
+            int rows = 5;
+            int nestedNestedElements = 111;
+            int maxNestedNestedIds = 200;
+            int randomSeed = 127;
+
+            var inputNestedNestedData = new Nested<Nested<string>[]?>[rows][];
+
+            Random r = new Random(randomSeed);
+            for (int i = 0; i < rows; i++)
+            {
+                inputNestedNestedData[i] = new Nested<Nested<string>[]?>[nestedNestedElements];
+
+                for (int j = 0; j < nestedNestedElements; j++)
+                {
+                    Nested<string>[]? val = j % 2 == 0 ?
+                        Enumerable.Range(0, r.Next(maxNestedNestedIds)).Select(i => new Nested<string>(Guid.NewGuid().ToString())).ToArray() :
+                        null;
+
+                    inputNestedNestedData[i][j] = new Nested<Nested<string>[]?>(val);
+                }
+            }
+
+            using var buffer = new ResizableBuffer();
+            using (var output = new BufferOutputStream(buffer))
+            {
+                using var nestedNestedItem = new PrimitiveNode("nestedNestedIds", Repetition.Required, LogicalType.String(), PhysicalType.ByteArray);
+                using var nestedNestedElement = new GroupNode("element", Repetition.Required, new[] { nestedNestedItem } );
+                using var nestedNestedList = new GroupNode("list", Repetition.Repeated, new[] { nestedNestedElement });
+                using var nestedNestedStructure = new GroupNode("NestedNested", Repetition.Optional, new[] { nestedNestedList }, LogicalType.List());                
+
+                using var nestedElement = new GroupNode("element", Repetition.Required, new[] { nestedNestedStructure });
+                using var nestedList = new GroupNode("list", Repetition.Repeated, new[] { nestedElement });
+                using var nestedStructure = new GroupNode("Nested", Repetition.Required, new[] { nestedList }, LogicalType.List());
+
+                using var schemaNode = new GroupNode("schema", Repetition.Required, new[] { nestedStructure });
+
+                using var builder = new WriterPropertiesBuilder();
+                using var writerProperties = builder.Build();
+                using var fileWriter = new ParquetFileWriter(output, schemaNode, writerProperties);
+                using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+
+                using var colWriter = rowGroupWriter.Column(0).LogicalWriter<Nested<Nested<string>[]?>[]>();
+                colWriter.WriteBatch(inputNestedNestedData);
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            using var rowGroupReader = fileReader.RowGroup(0);
+
+            using var colReader = rowGroupReader.Column(0).LogicalReader<string[]?[]>();
+            var actual = colReader.ReadAll((int)rowGroupReader.MetaData.NumRows);
+            Assert.IsNotEmpty(actual);
+            Assert.AreEqual(inputNestedNestedData.Length, actual.Length);
+            for (var i = 0; i < inputNestedNestedData.Length; i++)
+            {
+                for (int j = 0; j < inputNestedNestedData[i].Length; j++)
+                {
+                    if (j % 2 == 0)
+                    {
+                        for (int k = 0; k < inputNestedNestedData[i][j].Value!.Length; k++)
+                        {
+                            Assert.AreEqual(inputNestedNestedData[i][j].Value![k].Value, actual[i][j]![k]);
+                        }
+                    }
+                    else
+                    {
+                        Assert.IsNull(inputNestedNestedData[i][j].Value);
+                        Assert.AreEqual(inputNestedNestedData[i][j].Value, actual[i][j]);
+                    }                    
+                }
+            }
+
+            fileReader.Close();
+        }
+
+        /// <summary>
         /// This checks that LogicalColumnReader's GetEnumerator() works correctly
         /// when the column is longer than the buffer length but not an exact multiple
         /// (see https://github.com/G-Research/ParquetSharp/issues/242).

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -543,7 +543,7 @@ namespace ParquetSharp.Test
         /// a nested-nested optional list can be read back.
         /// </summary>
         [Test]
-        public static void TestNestedNestedOptinalListWithRequiredField()
+        public static void TestNestedNestedOptionalListWithRequiredField()
         {
             int rows = 5;
             int nestedNestedElements = 111;

--- a/csharp.test/TestMaps.cs
+++ b/csharp.test/TestMaps.cs
@@ -56,10 +56,10 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestNestedNestedOptionalMapWithRequiredKey()
         {
-            int rows = 5;
-            int nestedNestedElements = 111;
-            int maxNestedNestedIds = 200;
-            int randomSeed = 127;
+            const int rows = 5;
+            const int nestedNestedElements = 111;
+            const int maxNestedNestedIds = 200;
+            const int randomSeed = 127;
 
             var inputNestedNestedKeys = new Nested<string[]?>[rows][];
             var inputNestedNestedValues = new Nested<string[]?>[rows][];
@@ -72,13 +72,9 @@ namespace ParquetSharp.Test
 
                 for (int j = 0; j < nestedNestedElements; j++)
                 {
-                    string[]? vals = j % 2 == 0 ?
-                        Enumerable.Range(0, r.Next(maxNestedNestedIds)).Select(i => Guid.NewGuid().ToString()).ToArray() :
-                        null;
+                    string[]? vals = j % 2 == 0 ? Enumerable.Range(0, r.Next(maxNestedNestedIds)).Select(i => Guid.NewGuid().ToString()).ToArray() : null;
 
-                    string[]? keys = j % 2 == 0 ?
-                        Enumerable.Range(0, vals!.Length).Select(i => Guid.NewGuid().ToString()).ToArray() :
-                        null;
+                    string[]? keys = j % 2 == 0 ? Enumerable.Range(0, vals!.Length).Select(i => Guid.NewGuid().ToString()).ToArray() : null;
 
                     inputNestedNestedKeys[i][j] = new Nested<string[]?>(keys);
                     inputNestedNestedValues[i][j] = new Nested<string[]?>(vals);
@@ -90,14 +86,14 @@ namespace ParquetSharp.Test
             {
                 using var nestedNestedKey = new PrimitiveNode("key", Repetition.Required, LogicalType.String(), PhysicalType.ByteArray);
                 using var nestedNestedValue = new PrimitiveNode("value", Repetition.Required, LogicalType.String(), PhysicalType.ByteArray);
-                using var nestedNestedMap = new GroupNode("key_value", Repetition.Repeated, new[] { nestedNestedKey, nestedNestedValue });
-                using var nestedNestedStructure = new GroupNode("NestedNested", Repetition.Optional, new[] { nestedNestedMap }, LogicalType.Map());
+                using var nestedNestedMap = new GroupNode("key_value", Repetition.Repeated, new[] {nestedNestedKey, nestedNestedValue});
+                using var nestedNestedStructure = new GroupNode("NestedNested", Repetition.Optional, new[] {nestedNestedMap}, LogicalType.Map());
 
-                using var nestedElement = new GroupNode("element", Repetition.Required, new[] { nestedNestedStructure });
-                using var nestedList = new GroupNode("list", Repetition.Repeated, new[] { nestedElement });
-                using var nestedStructure = new GroupNode("Nested", Repetition.Required, new[] { nestedList }, LogicalType.List());
+                using var nestedElement = new GroupNode("element", Repetition.Required, new[] {nestedNestedStructure});
+                using var nestedList = new GroupNode("list", Repetition.Repeated, new[] {nestedElement});
+                using var nestedStructure = new GroupNode("Nested", Repetition.Required, new[] {nestedList}, LogicalType.List());
 
-                using var schemaNode = new GroupNode("schema", Repetition.Required, new[] { nestedStructure });
+                using var schemaNode = new GroupNode("schema", Repetition.Required, new[] {nestedStructure});
 
                 using var builder = new WriterPropertiesBuilder();
                 using var writerProperties = builder.Build();
@@ -118,10 +114,10 @@ namespace ParquetSharp.Test
             using var rowGroupReader = fileReader.RowGroup(0);
 
             using var colReader = rowGroupReader.Column(0).LogicalReader<string[]?[]>();
-            var actualKeys = colReader.ReadAll((int)rowGroupReader.MetaData.NumRows);
+            var actualKeys = colReader.ReadAll((int) rowGroupReader.MetaData.NumRows);
 
             using var colReader2 = rowGroupReader.Column(1).LogicalReader<string[]?[]>();
-            var actualValues = colReader2.ReadAll((int)rowGroupReader.MetaData.NumRows);
+            var actualValues = colReader2.ReadAll((int) rowGroupReader.MetaData.NumRows);
 
             Assert.IsNotEmpty(actualKeys);
             Assert.AreEqual(inputNestedNestedKeys.Length, actualKeys.Length);

--- a/csharp.test/TestMaps.cs
+++ b/csharp.test/TestMaps.cs
@@ -54,7 +54,7 @@ namespace ParquetSharp.Test
         /// a nested-nested optional map can be read back.
         /// </summary>
         [Test]
-        public static void TestNestedNestedOptinalMapWithRequiredKey()
+        public static void TestNestedNestedOptionalMapWithRequiredKey()
         {
             int rows = 5;
             int nestedNestedElements = 111;

--- a/csharp.test/TestMaps.cs
+++ b/csharp.test/TestMaps.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 using ParquetSharp.IO;
 using ParquetSharp.Schema;
@@ -46,6 +47,110 @@ namespace ParquetSharp.Test
             var values = new[] {new[] {"v1", "v2"}, new[] {"v3", "v4"}, Array.Empty<string>()};
 
             DoRoundtripTest(false, keys, values);
+        }
+
+        /// <summary>
+        /// This checks that values written to nested-nested required key field of 
+        /// a nested-nested optional map can be read back.
+        /// </summary>
+        [Test]
+        public static void TestNestedNestedOptinalMapWithRequiredKey()
+        {
+            int rows = 5;
+            int nestedNestedElements = 111;
+            int maxNestedNestedIds = 200;
+            int randomSeed = 127;
+
+            var inputNestedNestedKeys = new Nested<string[]?>[rows][];
+            var inputNestedNestedValues = new Nested<string[]?>[rows][];
+
+            Random r = new Random(randomSeed);
+            for (int i = 0; i < rows; i++)
+            {
+                inputNestedNestedKeys[i] = new Nested<string[]?>[nestedNestedElements];
+                inputNestedNestedValues[i] = new Nested<string[]?>[nestedNestedElements];
+
+                for (int j = 0; j < nestedNestedElements; j++)
+                {
+                    string[]? vals = j % 2 == 0 ?
+                        Enumerable.Range(0, r.Next(maxNestedNestedIds)).Select(i => Guid.NewGuid().ToString()).ToArray() :
+                        null;
+
+                    string[]? keys = j % 2 == 0 ?
+                        Enumerable.Range(0, vals!.Length).Select(i => Guid.NewGuid().ToString()).ToArray() :
+                        null;
+
+                    inputNestedNestedKeys[i][j] = new Nested<string[]?>(keys);
+                    inputNestedNestedValues[i][j] = new Nested<string[]?>(vals);
+                }
+            }
+
+            using var buffer = new ResizableBuffer();
+            using (var output = new BufferOutputStream(buffer))
+            {
+                using var nestedNestedKey = new PrimitiveNode("key", Repetition.Required, LogicalType.String(), PhysicalType.ByteArray);
+                using var nestedNestedValue = new PrimitiveNode("value", Repetition.Required, LogicalType.String(), PhysicalType.ByteArray);
+                using var nestedNestedMap = new GroupNode("key_value", Repetition.Repeated, new[] { nestedNestedKey, nestedNestedValue });
+                using var nestedNestedStructure = new GroupNode("NestedNested", Repetition.Optional, new[] { nestedNestedMap }, LogicalType.Map());
+
+                using var nestedElement = new GroupNode("element", Repetition.Required, new[] { nestedNestedStructure });
+                using var nestedList = new GroupNode("list", Repetition.Repeated, new[] { nestedElement });
+                using var nestedStructure = new GroupNode("Nested", Repetition.Required, new[] { nestedList }, LogicalType.List());
+
+                using var schemaNode = new GroupNode("schema", Repetition.Required, new[] { nestedStructure });
+
+                using var builder = new WriterPropertiesBuilder();
+                using var writerProperties = builder.Build();
+                using var fileWriter = new ParquetFileWriter(output, schemaNode, writerProperties);
+                using var rowGroupWriter = fileWriter.AppendBufferedRowGroup();
+
+                using var colWriter = rowGroupWriter.Column(0).LogicalWriter<Nested<string[]?>[]>();
+                colWriter.WriteBatch(inputNestedNestedKeys);
+
+                using var colWriter2 = rowGroupWriter.Column(1).LogicalWriter<Nested<string[]?>[]>();
+                colWriter2.WriteBatch(inputNestedNestedValues);
+
+                fileWriter.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            using var rowGroupReader = fileReader.RowGroup(0);
+
+            using var colReader = rowGroupReader.Column(0).LogicalReader<string[]?[]>();
+            var actualKeys = colReader.ReadAll((int)rowGroupReader.MetaData.NumRows);
+
+            using var colReader2 = rowGroupReader.Column(1).LogicalReader<string[]?[]>();
+            var actualValues = colReader2.ReadAll((int)rowGroupReader.MetaData.NumRows);
+
+            Assert.IsNotEmpty(actualKeys);
+            Assert.AreEqual(inputNestedNestedKeys.Length, actualKeys.Length);
+            Assert.AreEqual(actualValues.Length, actualKeys.Length);
+
+            for (var i = 0; i < inputNestedNestedKeys.Length; i++)
+            {
+                for (int j = 0; j < inputNestedNestedKeys[i].Length; j++)
+                {
+                    if (j % 2 == 0)
+                    {
+                        for (int k = 0; k < inputNestedNestedKeys[i][j].Value!.Length; k++)
+                        {
+                            Assert.AreEqual(inputNestedNestedKeys[i][j].Value![k], actualKeys[i][j]![k]);
+                            Assert.AreEqual(inputNestedNestedValues[i][j].Value![k], actualValues[i][j]![k]);
+                        }
+                    }
+                    else
+                    {
+                        Assert.IsNull(inputNestedNestedKeys[i][j].Value);
+                        Assert.AreEqual(inputNestedNestedKeys[i][j].Value, actualKeys[i][j]);
+
+                        Assert.IsNull(inputNestedNestedValues[i][j].Value);
+                        Assert.AreEqual(inputNestedNestedValues[i][j].Value, actualValues[i][j]);
+                    }
+                }
+            }
+
+            fileReader.Close();
         }
 
         [Test]

--- a/csharp/BufferedReader.cs
+++ b/csharp/BufferedReader.cs
@@ -126,7 +126,7 @@ namespace ParquetSharp
                 _numValues = _nullableLeafValues ? _numLevels : numValues;
                 // Required field is defined then all its parents are defined too so there is no sense to consider definition levels for 
                 // the non-nullable leaf values
-                var defLevels = _nullableLeafValues ? (_defLevels == null ? null : _defLevels.AsSpan(0, (int)_numLevels)) : Array.Empty<short>();
+                var defLevels = _nullableLeafValues ? (_defLevels == null ? null : _defLevels.AsSpan(0, (int) _numLevels)) : Array.Empty<short>();
                 // It's important that we immediately convert the read values. In the case of ByteArray physical values,
                 // these are pointers to internal Arrow memory that may be invalidated if we perform any other operation
                 // on the column reader, for example calling HasNext will trigger a new page load if the Arrow column

--- a/csharp/BufferedReader.cs
+++ b/csharp/BufferedReader.cs
@@ -124,13 +124,16 @@ namespace ParquetSharp
                 // For non-nullable leaf values, converters will ignore definition levels and produce compacted
                 // values, otherwise definition levels are used and the number of values will match the number of levels.
                 _numValues = _nullableLeafValues ? _numLevels : numValues;
+                // Required field is defined then all its parents are defined too so there is no sense to consider definition levels for 
+                // the non-nullable leaf values
+                var defLevels = _nullableLeafValues ? (_defLevels == null ? null : _defLevels.AsSpan(0, (int)_numLevels)) : Array.Empty<short>();
                 // It's important that we immediately convert the read values. In the case of ByteArray physical values,
                 // these are pointers to internal Arrow memory that may be invalidated if we perform any other operation
                 // on the column reader, for example calling HasNext will trigger a new page load if the Arrow column
                 // reader is at the end of a data page.
                 _converter(
                     _values.AsSpan(0, (int) _numValues),
-                    _defLevels == null ? null : _defLevels.AsSpan(0, (int) _numLevels),
+                    defLevels,
                     _logicalValues.AsSpan(0, (int) _numValues),
                     _leafDefinitionLevel);
             }


### PR DESCRIPTION
Fixed a bug and added unit tests to cover nested-nested types writing/reading when nested is list and nested-nested is either optional parquet list or parquet map with a required leaf field.