### PR TITLE
Upgrade to Arrow 10.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In the 5.0.X versions, reading nested structures was introduced. However, nestin
 
 Building ParquetSharp for Windows requires the following dependencies:
 - Visual Studio 2022 (17.0 or higher)
-- Apache Arrow (8.0.0)
+- Apache Arrow (10.0.1)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://github.com/Microsoft/vcpkg).
 The build scripts will use an existing vcpkg installation if either of the `VCPKG_INSTALLATION_ROOT` or `VCPKG_ROOT` environment variables are defined,

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -74,8 +74,8 @@ include_directories(
 	${PARQUET_INCLUDE_DIRS})
 
 target_link_libraries(ParquetSharpNative PRIVATE
-	${PARQUET_LIBRARIES}
-	${ARROW_LIBRARIES}
+	Parquet::parquet_static
+	Arrow::arrow_static
 	unofficial::brotli::brotlidec-static unofficial::brotli::brotlienc-static unofficial::brotli::brotlicommon-static
 	BZip2::BZip2
 	lz4::lz4
@@ -86,7 +86,7 @@ target_link_libraries(ParquetSharpNative PRIVATE
 	ZLIB::ZLIB
 	zstd::libzstd_static
 )
-	
+
 add_definitions(-DARROW_STATIC)
 add_definitions(-DARROW_NO_DEPRECATED_API)
 add_definitions(-DPARQUET_STATIC)

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Parquet.Net" Version="3.8.6" />
+    <PackageReference Include="Parquet.Net" Version="4.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Parquet.Net" Version="4.1.2" />
+    <PackageReference Include="Parquet.Net" Version="3.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -5,6 +5,7 @@ using Parquet;
 using ParquetSharp.IO;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ParquetSharp.Test
 {
@@ -61,7 +62,7 @@ namespace ParquetSharp.Test
         }
 
         [Test]
-        public static void TestAgainstThirdParty()
+        public static async Task TestAgainstThirdParty()
         {
             using var decimalType = LogicalType.Decimal(precision: 29, scale: 3);
             var columns = new Column[] {new Column<decimal>("Decimal", decimalType)};
@@ -86,10 +87,10 @@ namespace ParquetSharp.Test
 
             // Read using Parquet.NET
             using var memoryStream = new MemoryStream(buffer.ToArray());
-            using var fileReader = new ParquetReader(memoryStream);
+            using var fileReader = await ParquetReader.CreateAsync(memoryStream);
             using var rowGroupReader = fileReader.OpenRowGroupReader(0);
 
-            var read = (decimal[]) rowGroupReader.ReadColumn(fileReader.Schema.GetDataFields()[0]).Data;
+            var read = (decimal[]) (await rowGroupReader.ReadColumnAsync(fileReader.Schema.GetDataFields()[0])).Data;
             Assert.AreEqual(values, read);
         }
     }

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -162,14 +162,14 @@ namespace ParquetSharp.Test
 
             var numRows = expectedColumns.First().Values.Length;
 
-            Assert.AreEqual("parquet-cpp-arrow version 8.0.0", fileMetaData.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 10.0.1", fileMetaData.CreatedBy);
             Assert.AreEqual(new Dictionary<string, string> {{"case", "Test"}, {"Awesome", "true"}}, fileMetaData.KeyValueMetadata);
             Assert.AreEqual(expectedColumns.Length, fileMetaData.NumColumns);
             Assert.AreEqual(numRows, fileMetaData.NumRows);
             Assert.AreEqual(1, fileMetaData.NumRowGroups);
             Assert.AreEqual(1 + expectedColumns.Length, fileMetaData.NumSchemaElements);
             Assert.AreEqual(ParquetVersion.PARQUET_1_0, fileMetaData.Version);
-            Assert.AreEqual("parquet-cpp-arrow version 8.0.0", fileMetaData.WriterVersion.ToString());
+            Assert.AreEqual("parquet-cpp-arrow version 10.0.1", fileMetaData.WriterVersion.ToString());
 
             using var rowGroupReader = fileReader.RowGroup(0);
             var rowGroupMetaData = rowGroupReader.MetaData;

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -168,7 +168,11 @@ namespace ParquetSharp.Test
             Assert.AreEqual(numRows, fileMetaData.NumRows);
             Assert.AreEqual(1, fileMetaData.NumRowGroups);
             Assert.AreEqual(1 + expectedColumns.Length, fileMetaData.NumSchemaElements);
-            Assert.AreEqual(ParquetVersion.PARQUET_1_0, fileMetaData.Version);
+            // The default format version to write is 2.4, but this doesn't correspond exactly
+            // to the version read from the file metadata.
+            // The parquet format only stores an integer file version (1 or 2) and
+            // 2 gets mapped to the latest 2.x version.
+            Assert.AreEqual(ParquetVersion.PARQUET_2_6, fileMetaData.Version);
             Assert.AreEqual("parquet-cpp-arrow version 10.0.1", fileMetaData.WriterVersion.ToString());
 
             using var rowGroupReader = fileReader.RowGroup(0);
@@ -198,7 +202,7 @@ namespace ParquetSharp.Test
                 Assert.AreEqual(expected.TypeScale, descr.TypeScale);
 
                 Assert.AreEqual(
-                    expected.Encodings.Where(e => useDictionaryEncoding || e != Encoding.PlainDictionary).ToArray(),
+                    expected.Encodings.Where(e => useDictionaryEncoding || e != Encoding.RleDictionary).ToArray(),
                     chunkMetaData.Encodings.Distinct().ToArray());
 
                 Assert.AreEqual(expected.Compression, chunkMetaData.Compression);
@@ -314,7 +318,7 @@ namespace ParquetSharp.Test
                 }
             }
 
-            public Encoding[] Encodings = {Encoding.PlainDictionary, Encoding.Plain, Encoding.Rle};
+            public Encoding[] Encodings = {Encoding.RleDictionary, Encoding.Plain, Encoding.Rle};
             public Compression Compression = Compression.Snappy;
 
             public void Dispose()

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -15,7 +15,7 @@ namespace ParquetSharp.Test
         {
             var p = WriterProperties.GetDefaultWriterProperties();
 
-            Assert.AreEqual("parquet-cpp-arrow version 8.0.0", p.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 10.0.1", p.CreatedBy);
             Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
             Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024 * 1024, p.DataPageSize);

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -19,11 +19,11 @@ namespace ParquetSharp.Test
             Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
             Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024 * 1024, p.DataPageSize);
-            Assert.AreEqual(Encoding.PlainDictionary, p.DictionaryIndexEncoding);
-            Assert.AreEqual(Encoding.PlainDictionary, p.DictionaryPageEncoding);
+            Assert.AreEqual(Encoding.RleDictionary, p.DictionaryIndexEncoding);
+            Assert.AreEqual(Encoding.Plain, p.DictionaryPageEncoding);
             Assert.AreEqual(1024 * 1024, p.DictionaryPagesizeLimit);
             Assert.AreEqual(64 * 1024 * 1024, p.MaxRowGroupLength);
-            Assert.AreEqual(ParquetVersion.PARQUET_1_0, p.Version);
+            Assert.AreEqual(ParquetVersion.PARQUET_2_4, p.Version);
             Assert.AreEqual(1024, p.WriteBatchSize);
         }
 
@@ -97,7 +97,7 @@ namespace ParquetSharp.Test
             using var metadataId = groupReader.MetaData.GetColumnChunkMetaData(0);
             using var metadataValue = groupReader.MetaData.GetColumnChunkMetaData(1);
 
-            Assert.AreEqual(new[] {Encoding.PlainDictionary, Encoding.Plain, Encoding.Rle}, metadataId.Encodings);
+            Assert.AreEqual(new[] {Encoding.RleDictionary, Encoding.Plain, Encoding.Rle}, metadataId.Encodings);
             Assert.AreEqual(new[] {Encoding.ByteStreamSplit, Encoding.Rle}, metadataValue.Encodings);
 
             using var idReader = groupReader.Column(0).LogicalReader<int>();

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>8.0.0</Version>
+    <Version>10.0.0-beta1</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/docs/Reading.md
+++ b/docs/Reading.md
@@ -135,6 +135,6 @@ for example:
 ```
 
 Paths must also be specified in extended-length format,
-which is handled automatically by ParquetSharp when an absolute path is provided since version 9.0.0.
+which is handled automatically by ParquetSharp when an absolute path is provided since version 10.0.0.
 For more information, see the Microsoft documentation on the
 [maximum path length limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,6 +2,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg.git",
-    "baseline": "d8a31a97c5feded71e61b149d7e676a52e5a1c29"
+    "baseline": "163fe7bd3d67c41200617caaa245b5ba2ba854e6"
   }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,7 @@
   "overrides": [
     {
       "name": "arrow",
-      "version": "8.0.0"
+      "version": "10.0.1"
     }
   ]
 }


### PR DESCRIPTION
This upgrades the version of Arrow used to 10.0.1 and bumps the ParquetSharp version to 10.0.0-beta1.

The main user-visible change with this is that the default version of the Parquet format to write is now 2.4. The Arrow Jira issue that explains the motivation for this is https://issues.apache.org/jira/browse/ARROW-12203.

I believe the points about supported time and integer types are not relevant to us as these only affect type mappings when converting from Arrow data, and we already used these new types when writing 1.0 versioned files with the corresponding .NET types. One change that could cause issues is that dictionary encoded data now uses the `RleDictionary` encoding by default rather than `PlainDictionary`, which could cause compatibility issues with old versions of some libraries. Eg. Parquet.Net only supports `RleDictionary` since 4.0.2, which also dropped .NET framework support. I believe this isn't actually a different encoding implementation to `PlainDictionary` but just a naming tidy up.

It's worth pointing out that we could upgrade to Arrow 10.0.1 but override the default version to write to keep it as 1.0 if we wanted, but it seems sensible to follow the lead of the Arrow project here.