### PR TITLE
Missing dispose of RowGroupMetaData in RowGroupReader?

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cquery.cacheDirectory": "${workspaceFolder}/.vscode/cquery_cached_index/"
+}

--- a/cpp/ColumnChunkMetaData.cpp
+++ b/cpp/ColumnChunkMetaData.cpp
@@ -20,7 +20,7 @@ extern "C"
 
 	PARQUETSHARP_EXPORT void ColumnChunkMetaData_Free(const ColumnChunkMetaData* column_chunk_meta_data)
 	{
-		delete column_chunk_meta_data;
+		delete column_chunk_meta_data
 	}
 
 	PARQUETSHARP_EXPORT ExceptionInfo* ColumnChunkMetaData_Compression(const ColumnChunkMetaData* column_chunk_meta_data, Compression::type* compression)

--- a/cpp/ColumnChunkMetaData.cpp
+++ b/cpp/ColumnChunkMetaData.cpp
@@ -20,7 +20,7 @@ extern "C"
 
 	PARQUETSHARP_EXPORT void ColumnChunkMetaData_Free(const ColumnChunkMetaData* column_chunk_meta_data)
 	{
-		delete column_chunk_meta_data
+		delete column_chunk_meta_data;
 	}
 
 	PARQUETSHARP_EXPORT ExceptionInfo* ColumnChunkMetaData_Compression(const ColumnChunkMetaData* column_chunk_meta_data, Compression::type* compression)

--- a/cpp/RowGroupMetaData.cpp
+++ b/cpp/RowGroupMetaData.cpp
@@ -8,6 +8,11 @@ using namespace parquet;
 
 extern "C"
 {
+	PARQUETSHARP_EXPORT void RowGroupMetaData_Free(const RowGroupMetaData* row_group_meta_data)
+	{
+		delete row_group_meta_data;
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* RowGroupMetaData_Get_Column_Chunk_Meta_Data(const RowGroupMetaData* row_group_meta_data, int i, ColumnChunkMetaData** column_chunk_meta_data)
 	{
 		TRYCATCH(*column_chunk_meta_data = row_group_meta_data->ColumnChunk(i).release();)

--- a/cpp/SchemaDescriptor.cpp
+++ b/cpp/SchemaDescriptor.cpp
@@ -8,6 +8,11 @@ using namespace parquet;
 
 extern "C"
 {
+	PARQUETSHARP_EXPORT ExceptionInfo* SchemaDescriptor_Free(const SchemaDescriptor* descriptor)
+	{
+		delete descriptor;
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* SchemaDescriptor_Column(const SchemaDescriptor* descriptor, int i, const ColumnDescriptor** column_descriptor)
 	{
 		TRYCATCH(*column_descriptor = descriptor->Column(i);)

--- a/cpp/SchemaDescriptor.cpp
+++ b/cpp/SchemaDescriptor.cpp
@@ -8,7 +8,7 @@ using namespace parquet;
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* SchemaDescriptor_Free(const SchemaDescriptor* descriptor)
+	PARQUETSHARP_EXPORT void SchemaDescriptor_Free(const SchemaDescriptor* descriptor)
 	{
 		delete descriptor;
 	}

--- a/csharp/RowGroupMetaData.cs
+++ b/csharp/RowGroupMetaData.cs
@@ -3,11 +3,16 @@ using System.Runtime.InteropServices;
 
 namespace ParquetSharp
 {
-    public sealed class RowGroupMetaData
+    public sealed class RowGroupMetaData : IDisposable
     {
         internal RowGroupMetaData(IntPtr handle)
         {
             _handle = handle;
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
         }
 
         public int NumColumns => ExceptionInfo.Return<int>(_handle, RowGroupMetaData_Num_Columns);

--- a/csharp/RowGroupMetaData.cs
+++ b/csharp/RowGroupMetaData.cs
@@ -42,7 +42,7 @@ namespace ParquetSharp
         private static extern IntPtr RowGroupMetaData_Total_Byte_Size(IntPtr rowGroupMetaData, out long totalByteSize);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr RowGroupMetaData_Free(IntPtr rowGroupMetaData);
+        private static extern void RowGroupMetaData_Free(IntPtr rowGroupMetaData);
 
         private readonly ParquetHandle _handle;
         private SchemaDescriptor? _schema;

--- a/csharp/RowGroupMetaData.cs
+++ b/csharp/RowGroupMetaData.cs
@@ -7,11 +7,12 @@ namespace ParquetSharp
     {
         internal RowGroupMetaData(IntPtr handle)
         {
-            _handle = handle;
+            _handle = new ParquetHandle(handle, RowGroupMetaData_Free);
         }
 
         public void Dispose()
         {
+            _schema?.Dispose();
             _handle.Dispose();
         }
 
@@ -40,7 +41,10 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr RowGroupMetaData_Total_Byte_Size(IntPtr rowGroupMetaData, out long totalByteSize);
 
-        private readonly IntPtr _handle;
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr RowGroupMetaData_Free(IntPtr rowGroupMetaData);
+
+        private readonly ParquetHandle _handle;
         private SchemaDescriptor? _schema;
     }
 }

--- a/csharp/RowGroupReader.cs
+++ b/csharp/RowGroupReader.cs
@@ -13,6 +13,7 @@ namespace ParquetSharp
 
         public void Dispose()
         {
+            _metaData?.Dispose();
             _handle.Dispose();
         }
 

--- a/csharp/SchemaDescriptor.cs
+++ b/csharp/SchemaDescriptor.cs
@@ -44,7 +44,7 @@ namespace ParquetSharp
         }
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr SchemaDescriptor_Free(IntPtr descriptor);
+        private static extern void SchemaDescriptor_Free(IntPtr descriptor);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr SchemaDescriptor_Column(IntPtr descriptor, int i, out IntPtr columnDescriptor);

--- a/csharp/SchemaDescriptor.cs
+++ b/csharp/SchemaDescriptor.cs
@@ -4,11 +4,16 @@ using ParquetSharp.Schema;
 
 namespace ParquetSharp
 {
-    public sealed class SchemaDescriptor
+    public sealed class SchemaDescriptor : IDisposable
     {
         internal SchemaDescriptor(IntPtr schemaDescriptorHandle)
         {
-            _handle = schemaDescriptorHandle;
+            _handle = new ParquetHandle(schemaDescriptorHandle, SchemaDescriptor_Free);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
         }
 
         public GroupNode GroupNode => (GroupNode) (Node.Create(ExceptionInfo.Return<IntPtr>(_handle, SchemaDescriptor_Group_Node)) ?? throw new InvalidOperationException());
@@ -39,6 +44,9 @@ namespace ParquetSharp
         }
 
         [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaDescriptor_Free(IntPtr descriptor);
+
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr SchemaDescriptor_Column(IntPtr descriptor, int i, out IntPtr columnDescriptor);
 
         [DllImport(ParquetDll.Name)]
@@ -62,6 +70,6 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr SchemaDescriptor_Schema_Root(IntPtr descriptor, out IntPtr schemaRoot);
 
-        private readonly IntPtr _handle;
+        private readonly ParquetHandle _handle;
     }
 }


### PR DESCRIPTION
- Added missing `_metaData?.Dispose()` in RowGroupReader
- Implemented `IDisposable` for RowGroupMetaData (to dispose _handle)