### PR TITLE
Change version to 10.0.1 to match Arrow

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>10.0.0-beta1</Version>
+    <Version>10.0.1-beta1</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/docs/Reading.md
+++ b/docs/Reading.md
@@ -135,6 +135,6 @@ for example:
 ```
 
 Paths must also be specified in extended-length format,
-which is handled automatically by ParquetSharp when an absolute path is provided since version 10.0.0.
+which is handled automatically by ParquetSharp when an absolute path is provided since version 10.0.1.
 For more information, see the Microsoft documentation on the
 [maximum path length limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).


### PR DESCRIPTION
Use version 10.0.1 rather than 10.0.0 to match the Arrow version. I'd originally used 10.0.0 in #321, thinking only the major version needed to match Arrow and we would leave patch versions for any ParquetSharp changes. But Jonathan pointed out we previously released 6.0.1 to match the Arrow 6.0.1 version, and could always release a 10.0.1.1 version if we need a ParquetSharp specific bug fix release.