### PR TITLE
Fix using internal F# types with the row oriented API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
       run: |
         dotnet build csharp.benchmark --configuration=Release -p:OSArchitecture=${{ matrix.arch }}
         dotnet build csharp.test --configuration=Release -p:OSArchitecture=${{ matrix.arch }}
+        dotnet build fsharp.test --configuration=Release -p:OSArchitecture=${{ matrix.arch }}
     - name: Upload native ParquetSharp library
       uses: actions/upload-artifact@v3
       with:
@@ -262,17 +263,25 @@ jobs:
       run: |
         dotnet remove csharp.test reference csharp/ParquetSharp.csproj
         dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
+        dotnet remove fsharp.test reference csharp/ParquetSharp.csproj
+        dotnet add fsharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
     - name: Setup QEMU for arm64
       if: matrix.arch == 'arm64'
       uses: docker/setup-qemu-action@v2
       with:
         platforms: arm64
-    - name: Build & Run .NET unit tests (x64)
+    - name: Build & Run C# unit tests (x64)
       if: matrix.arch == 'x64'
       run: dotnet test csharp.test --configuration=Release --framework ${{ matrix.dotnet }}
-    - name: Build & Run .NET unit tests (arm64)
+    - name: Build & Run F# unit tests (x64)
+      if: matrix.arch == 'x64'
+      run: dotnet test fsharp.test --configuration=Release --framework ${{ matrix.dotnet }}
+    - name: Build & Run C# unit tests (arm64)
       if: matrix.arch == 'arm64'
       run: docker run --rm --platform linux/arm64/v8 -v $PWD:$PWD -w $PWD mcr.microsoft.com/dotnet/sdk:6.0 dotnet test csharp.test --configuration=Release --framework ${{ matrix.dotnet }}
+    - name: Build & Run F# unit tests (arm64)
+      if: matrix.arch == 'arm64'
+      run: docker run --rm --platform linux/arm64/v8 -v $PWD:$PWD -w $PWD mcr.microsoft.com/dotnet/sdk:6.0 dotnet test fsharp.test --configuration=Release --framework ${{ matrix.dotnet }}
 
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ if (MSVC)
 
 	include_external_msproject(ParquetSharp.Test ${CMAKE_SOURCE_DIR}/csharp.test/ParquetSharp.Test.csproj TYPE 9A19103F-16F7-4668-BE54-9A1E7A4F7556 PLATFORM x64)
 	add_dependencies(ParquetSharp.Test ParquetSharp)
+
+	include_external_msproject(ParquetSharp.Test.FSharp ${CMAKE_SOURCE_DIR}/fsharp.test/ParquetSharp.Test.Fsharp.fsproj TYPE 6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705 PLATFORM x64)
+	add_dependencies(ParquetSharp.Test.FSharp ParquetSharp)
 endif ()
 
 add_subdirectory(cpp)

--- a/docs/RowOriented.md
+++ b/docs/RowOriented.md
@@ -67,3 +67,14 @@ using (var rowReader = ParquetFile.CreateRowReader<MyRow>("example.parquet"))
     }
 }
 ```
+
+## Using the row-oriented API from F#
+
+The row-oriented API works with F# types,
+but one important issue to note is that if you are mapping an internal type,
+all fields must have the `MapToColumn` attribute applied to be mapped to Parquet columns.
+
+This is because ParquetSharp will only map public fields and properties of a type by default,
+and all fields of an internal F# type are private.
+However, the `MapToColumn` attribute can be applied to private properties to
+opt-in to including them in the column mapping.

--- a/fsharp.test/ParquetSharp.Test.FSharp.fsproj
+++ b/fsharp.test/ParquetSharp.Test.FSharp.fsproj
@@ -1,26 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
     <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <AssemblyName>ParquetSharp.Test</AssemblyName>
-    <RootNamespace>ParquetSharp.Test</RootNamespace>
+    <AssemblyName>ParquetSharp.Test.FSharp</AssemblyName>
+    <RootNamespace>ParquetSharp.Test.FSharp</RootNamespace>
     <PlatformTarget Condition="'$(TargetFramework)'=='net472'">x64</PlatformTarget>
-    <GenerateProgramFile>false</GenerateProgramFile>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsUnit" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Parquet.Net" Version="3.8.6" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,10 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="TestFiles\*.parquet">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <Compile Include="TestRowOrientedApi.fs" />
   </ItemGroup>
-
 
 </Project>

--- a/fsharp.test/ParquetSharp.Test.FSharp.fsproj
+++ b/fsharp.test/ParquetSharp.Test.FSharp.fsproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
     <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
-    <AssemblyName>ParquetSharp.Test.FSharp</AssemblyName>
-    <RootNamespace>ParquetSharp.Test.FSharp</RootNamespace>
     <PlatformTarget Condition="'$(TargetFramework)'=='net472'">x64</PlatformTarget>
-    <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/fsharp.test/TestRowOrientedApi.fs
+++ b/fsharp.test/TestRowOrientedApi.fs
@@ -8,24 +8,45 @@ open ParquetSharp.RowOriented
 
 module TestRowOrientedApi =
 
-    [<Struct>]
-    type internal Record =
+    type PublicRecord =
         {
             Field : int
         }
 
-    [<Test>]
-    let TestWritingInternalRecord () =
+    type PublicRecordWithMappedField =
+        {
+            [<MapToColumn("field")>]
+            Field : int
+        }
+
+    type internal InternalRecord =
+        {
+            Field : int
+        }
+
+    type internal InternalRecordWithMappedField =
+        {
+            [<MapToColumn("field")>]
+            Field : int
+        }
+
+    [<Struct>]
+    type internal InternalStructRecordWithMappedField =
+        {
+            [<MapToColumn("field")>]
+            Field : int
+        }
+
+    let TestWritingRecord<'T> record verify =
         let dir = Path.Combine(Path.GetTempPath (), Guid.NewGuid().ToString ()) |> Directory.CreateDirectory
         try
-            let path = Path.Combine (dir.FullName, "f.parquet")
+            let path = Path.Combine (dir.FullName, "test.parquet")
 
-            using (ParquetFile.CreateRowWriter<Record> path) ( fun writer ->
-                let r = { Field = 1 }
-                writer.WriteRow r
+            using (ParquetFile.CreateRowWriter<'T> path) ( fun writer ->
+                writer.WriteRow record
             )
 
-            use reader = ParquetFile.CreateRowReader<Record> path
+            use reader = ParquetFile.CreateRowReader<'T> path
             let got =
                 seq {
                     for i in 0 .. reader.FileMetaData.NumRowGroups-1 do
@@ -34,5 +55,35 @@ module TestRowOrientedApi =
                 } |> Seq.toList
 
             got |> Seq.length |> should equal 1
+            got |> Seq.head |> verify
         finally
             dir.Delete true
+
+    [<Test>]
+    let TestErrorWritingInternalRecord () =
+        let dir = Path.Combine(Path.GetTempPath (), Guid.NewGuid().ToString ()) |> Directory.CreateDirectory
+        try
+            let path = Path.Combine (dir.FullName, "test.parquet")
+            let expectedMessage = ("Type 'ParquetSharp.Test.FSharp.TestRowOrientedApi+InternalRecord' does not have " +
+                "any public fields or properties to map to Parquet columns, or any private fields or properties " +
+                "annotated with 'MapToColumnAttribute' (Parameter 'type')")
+            (fun () -> ParquetFile.CreateRowWriter<InternalRecord> path |> ignore)
+                |> should (throwWithMessage expectedMessage) typeof<System.ArgumentException>
+        finally
+            dir.Delete true
+
+    [<Test>]
+    let TestWritingPublicRecord () =
+        TestWritingRecord<PublicRecord> { Field = 1 } ( fun readField -> readField.Field |> should equal 1)
+
+    [<Test>]
+    let TestWritingPublicRecordWithMappedField () =
+        TestWritingRecord<PublicRecordWithMappedField> { Field = 1 } ( fun readField -> readField.Field |> should equal 1)
+
+    [<Test>]
+    let TestWritingInternalRecordWithMappedField () =
+        TestWritingRecord<InternalRecordWithMappedField> { Field = 1 } ( fun readField -> readField.Field |> should equal 1)
+
+    [<Test>]
+    let TestWritingInternalStructRecordWithMappedField () =
+        TestWritingRecord<InternalStructRecordWithMappedField> { Field = 1 } ( fun readField -> readField.Field |> should equal 1)

--- a/fsharp.test/TestRowOrientedApi.fs
+++ b/fsharp.test/TestRowOrientedApi.fs
@@ -1,0 +1,38 @@
+﻿namespace ParquetSharp.Test.FSharp
+
+open System
+open System.IO
+open NUnit.Framework
+open FsUnit
+open ParquetSharp.RowOriented
+
+module TestRowOrientedApi =
+
+    [<Struct>]
+    type internal Record =
+        {
+            Field : int
+        }
+
+    [<Test>]
+    let TestWritingInternalRecord () =
+        let dir = Path.Combine(Path.GetTempPath (), Guid.NewGuid().ToString ()) |> Directory.CreateDirectory
+        try
+            let path = Path.Combine (dir.FullName, "f.parquet")
+
+            using (ParquetFile.CreateRowWriter<Record> path) ( fun writer ->
+                let r = { Field = 1 }
+                writer.WriteRow r
+            )
+
+            use reader = ParquetFile.CreateRowReader<Record> path
+            let got =
+                seq {
+                    for i in 0 .. reader.FileMetaData.NumRowGroups-1 do
+                        for r in reader.ReadRows i do
+                            yield r
+                } |> Seq.toList
+
+            got |> Seq.length |> should equal 1
+        finally
+            dir.Delete true

--- a/fsharp.test/TestRowOrientedApi.fs
+++ b/fsharp.test/TestRowOrientedApi.fs
@@ -64,11 +64,8 @@ module TestRowOrientedApi =
         let dir = Path.Combine(Path.GetTempPath (), Guid.NewGuid().ToString ()) |> Directory.CreateDirectory
         try
             let path = Path.Combine (dir.FullName, "test.parquet")
-            let expectedMessage = ("Type 'ParquetSharp.Test.FSharp.TestRowOrientedApi+InternalRecord' does not have " +
-                "any public fields or properties to map to Parquet columns, or any private fields or properties " +
-                "annotated with 'MapToColumnAttribute' (Parameter 'type')")
             (fun () -> ParquetFile.CreateRowWriter<InternalRecord> path |> ignore)
-                |> should (throwWithMessage expectedMessage) typeof<System.ArgumentException>
+                |> should throw typeof<System.ArgumentException>
         finally
             dir.Delete true
 


### PR DESCRIPTION
Fixes #329 by allowing the `MapToColumn` attribute to be used on private properties, and throwing an exception if a type has no public fields or properties, and no private fields or properties annotated with `MapToColumn`.