### PR TITLE
Update benchmark code and results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 build
 obj
 nuget
+BenchmarkDotNet.Artifacts

--- a/README.md
+++ b/README.md
@@ -104,12 +104,14 @@ Not finding an existing solution meeting these requirements, we decided to imple
 
 ## Performance
 
-The following benchmarks can be reproduced by running `ParquetSharp.Benchmark.csproj`. The relative performance of ParquetSharp 2.4.0-beta1 is compared to [Parquet.NET](https://github.com/aloneguid/parquet-dotnet) 3.8.6, an alternative open-source .NET library that is fully managed. The Decimal tests focus purely on handling the C# `decimal` type, while the TimeSeries tests benchmark three columns respectively of the types `{int, DateTime, float}`. Results are from a Ryzen 5950X on Windows 10.
+The following benchmarks can be reproduced by running `ParquetSharp.Benchmark.csproj`. The relative performance of ParquetSharp 10.0.1 is compared to [Parquet.NET](https://github.com/aloneguid/parquet-dotnet) 4.6.2, an alternative open-source .NET library that is fully managed. The Decimal tests focus purely on handling the C# `decimal` type, while the TimeSeries tests benchmark three columns of the types `{int, DateTime, float}`. Results are from a Ryzen 5900X on Linux 6.2.7 using the dotnet 6.0.14 runtime.
+
+If performance is a concern for you, we recommend benchmarking your own workloads and testing different encodings and compression methods. For example, disabling dictionary encoding for floating point columns can often significantly improve performance.
 
 |              | Decimal (Read) | Decimal (Write) | TimeSeries (Read) | TimeSeries (Write) |
 | -----------: | :------------: | :-------------: | :---------------: | :----------------: |
 | Parquet.NET  | 1.0x           | 1.0x            | 1.0x              | 1.0x               |
-| ParquetSharp | 4.7x Faster    | 3.7x Faster     | 2.9x Faster       | 8.5x Faster        |
+| ParquetSharp | 4.0x Faster    | 3.0x Faster     | 2.8x Faster       | 1.5x Faster        |
 
 ## Known Limitations
 

--- a/csharp.benchmark/DecimalRead.cs
+++ b/csharp.benchmark/DecimalRead.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Parquet;
 using Parquet.Data;
@@ -53,11 +54,10 @@ namespace ParquetSharp.Benchmark
         }
 
         [Benchmark]
-        public DataColumn[] ParquetDotNet()
+        public async Task<DataColumn[]> ParquetDotNet()
         {
-            using var stream = File.OpenRead(Filename);
-            using var parquetReader = new ParquetReader(stream);
-            var results = parquetReader.ReadEntireRowGroup();
+            using var parquetReader = await ParquetReader.CreateAsync(Filename);
+            var results = await parquetReader.ReadEntireRowGroupAsync();
 
             if (Check.Enabled)
             {

--- a/csharp.benchmark/FloatArrayTimeSeriesRead.cs
+++ b/csharp.benchmark/FloatArrayTimeSeriesRead.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Parquet;
 using Parquet.Data;
@@ -98,11 +99,10 @@ namespace ParquetSharp.Benchmark
         }
 
         [Benchmark]
-        public DataColumn[] ParquetDotNet()
+        public async Task<DataColumn[]> ParquetDotNet()
         {
-            using var stream = File.OpenRead(Filename);
-            using var parquetReader = new ParquetReader(stream);
-            var results = parquetReader.ReadEntireRowGroup();
+            using var parquetReader = await ParquetReader.CreateAsync(Filename);
+            var results = await parquetReader.ReadEntireRowGroupAsync();
 
             if (Check.Enabled)
             {

--- a/csharp.benchmark/FloatTimeSeriesRead.cs
+++ b/csharp.benchmark/FloatTimeSeriesRead.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Parquet;
 using Parquet.Data;
@@ -98,11 +99,10 @@ namespace ParquetSharp.Benchmark
         }
 
         [Benchmark]
-        public DataColumn[] ParquetDotNet()
+        public async Task<DataColumn[]> ParquetDotNet()
         {
-            using var stream = File.OpenRead(Filename);
-            using var parquetReader = new ParquetReader(stream);
-            var results = parquetReader.ReadEntireRowGroup();
+            using var parquetReader = await ParquetReader.CreateAsync(Filename);
+            var results = await parquetReader.ReadEntireRowGroupAsync();
 
             if (Check.Enabled)
             {

--- a/csharp.benchmark/ParquetSharp.Benchmark.csproj
+++ b/csharp.benchmark/ParquetSharp.Benchmark.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Parquet.Net" Version="3.9.1" />
+    <PackageReference Include="Parquet.Net" Version="4.6.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates the benchmark code to work with the latest version of Parquet.Net and updates the results in the README.

I also took a look at reproducing the benchmark results that were published by the author of Parquet.Net in https://www.aloneguid.uk/posts/2023/01/parquet-dotnet-vs-parquet-sharp/ and https://github.com/aloneguid/parquet-dotnet/releases/tag/4.2.0

I get similar results to them when running on my machine, with much slower times to write 1,000,000 random integers or floats with ParquetSharp compared to Parquet.Net. It looks like this is due to our (or really Apache Arrow's) default behaviour of using dictionary encoding for all columns. If I disable dictionary encoding for these columns it makes us about 10x faster than we were, or 2x faster than Parquet.Net. Parquet.Net only supports writing with dictionary encoding for string columns.

We don't disable dictionary encoding for our time series write benchmark. Out of interest, I tested doing that for the float column and it improved performance by about 25%, but it probably makes sense to keep the benchmark code using close to default options. We might want to consider disabling dictionary encoding for float columns by default though, or asking about changing this in Arrow?