### PR TITLE
Update nested data documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ Typically this can arise when attempting to access an instance whose owner has b
 
 As only 64-bit runtimes are available, ParquetSharp cannot be referenced by a 32-bit project.  For example, using the library from F# Interactive requires running `fsiAnyCpu.exe` rather than `fsi.exe`.
 
-In the 5.0.X versions, reading nested structures was introduced. However, nesting information about nulls is lost when reading columns with Repetition Level optional inside structs with Repetition Level optional. ParquetSharp does not yet provide information about whether the column or the enclosing struct is null.
-
 ## Building
 
 Building ParquetSharp for Windows requires the following dependencies:


### PR DESCRIPTION
Fixes #339 by explaining that we want to write one object per row in the Parquet file, and explains why we don't just use a `message` and `ids` column.

I also removed the outdated paragraph in the README under `Known Limitations` about not being able to fully interpret nested data.