### PR TITLE
Don't retry writing in Dispose after encountering an error in ParquetRowWriter

### DIFF
--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -133,8 +133,9 @@ namespace ParquetSharp.RowOriented
                 // Always set the RowGroupWriter to null to ensure we don't try to re-write again when
                 // this ParquetRowWriter is disposed after encountering an error,
                 // which could lead to writing invalid data (eg. mismatching numbers of rows between columns).
-                _rowGroupWriter.Dispose();
+                var rowGroupWriter = _rowGroupWriter;
                 _rowGroupWriter = null;
+                rowGroupWriter.Dispose();
             }
         }
 

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -83,10 +83,7 @@ namespace ParquetSharp.RowOriented
         {
             if (_rowGroupWriter == null) throw new InvalidOperationException("writer has been closed or disposed");
 
-            _writeAction(this, _rows, _pos);
-            _pos = 0;
-
-            _rowGroupWriter.Dispose();
+            FlushAndDisposeRowGroup();
             _rowGroupWriter = _parquetFileWriter.AppendRowGroup();
         }
 
@@ -121,14 +118,24 @@ namespace ParquetSharp.RowOriented
 
         private void FlushAndDisposeRowGroup()
         {
-            if (_rowGroupWriter != null)
+            if (_rowGroupWriter == null)
+            {
+                return;
+            }
+
+            try
             {
                 _writeAction(this, _rows, _pos);
                 _pos = 0;
             }
-
-            _rowGroupWriter?.Dispose();
-            _rowGroupWriter = null;
+            finally
+            {
+                // Always set the RowGroupWriter to null to ensure we don't try to re-write again when
+                // this ParquetRowWriter is disposed after encountering an error,
+                // which could lead to writing invalid data (eg. mismatching numbers of rows between columns).
+                _rowGroupWriter.Dispose();
+                _rowGroupWriter = null;
+            }
         }
 
         private readonly ParquetFileWriter _parquetFileWriter;


### PR DESCRIPTION
When an error is encountered flushing row-oriented data to Parquet, eg. an out-of-memory error, make sure we don't later retry writing when the `ParquetRowWriter` is disposed as this can lead to unhandled native exceptions for mismatching row counts if data has been partially written.