### PR TITLE
remove deprecated ubuntu-18.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   check-format:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Check format
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-11, windows-2022]
+        os: [ubuntu-20.04, macos-11, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
@@ -215,7 +215,7 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12, windows-2022]
+        os: [ubuntu-20.04, macos-11, macos-12, windows-2022]
         dotnet: [netcoreapp3.1, net5.0, net6.0]
         arch: [x64]
         include:


### PR DESCRIPTION
as `ubuntu-18.04` runners are deprecated, we should remove them and use `ubuntu-20.04` for now