### PR TITLE
Defer checking decimal precision and type length until creating converter

### DIFF
--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -98,5 +98,35 @@ namespace ParquetSharp.Test
             var read = (decimal[]) rowGroupReader.ReadColumn(fileReader.Schema.GetDataFields()[0]).Data;
             Assert.AreEqual(values, read);
         }
+
+        [Test]
+        public static void TestThrowsWithUnsupportedPrecision()
+        {
+            using var decimalType = LogicalType.Decimal(precision: 28, scale: 3);
+            var columns = new Column[] {new Column<decimal>("Decimal", decimalType)};
+
+            using var buffer = new ResizableBuffer();
+            using var outStream = new BufferOutputStream(buffer);
+            using var fileWriter = new ParquetFileWriter(outStream, columns);
+            using var rowGroupWriter = fileWriter.AppendRowGroup();
+            var exception = Assert.Throws<NotSupportedException>(() => { rowGroupWriter.NextColumn().LogicalWriter<decimal>(); });
+            Assert.That(exception!.Message, Does.Contain("29 digits of precision"));
+            fileWriter.Close();
+        }
+
+        [Test]
+        public static void TestThrowsWithUnsupportedLength()
+        {
+            using var decimalType = LogicalType.Decimal(precision: 29, scale: 3);
+            var columns = new Column[] {new Column(typeof(decimal), "Decimal", decimalType, 13)};
+
+            using var buffer = new ResizableBuffer();
+            using var outStream = new BufferOutputStream(buffer);
+            using var fileWriter = new ParquetFileWriter(outStream, columns);
+            using var rowGroupWriter = fileWriter.AppendRowGroup();
+            var exception = Assert.Throws<NotSupportedException>(() => { rowGroupWriter.NextColumn().LogicalWriter<decimal>(); });
+            Assert.That(exception!.Message, Does.Contain("16 bytes of decimal length"));
+            fileWriter.Close();
+        }
     }
 }

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -17,7 +17,7 @@ namespace ParquetSharp
             Name = name ?? throw new ArgumentNullException(nameof(name));
         }
 
-        public unsafe Column(Type logicalSystemType, string name, LogicalType? logicalTypeOverride, int length)
+        public Column(Type logicalSystemType, string name, LogicalType? logicalTypeOverride, int length)
         {
             var isDecimal = logicalSystemType == typeof(decimal) || logicalSystemType == typeof(decimal?);
             var isUuid = logicalSystemType == typeof(Guid) || logicalSystemType == typeof(Guid?);
@@ -35,22 +35,6 @@ namespace ParquetSharp
             if (isUuid && !(logicalTypeOverride is UuidLogicalType))
             {
                 throw new ArgumentException("Guid type requires a UuidLogicalType override");
-            }
-
-            if (logicalTypeOverride is DecimalLogicalType decimalLogicalType)
-            {
-                // For the moment we only support serializing decimal to Decimal128.
-                // This reflects the C# decimal structure with 28-29 digits precision.
-                // Will implement 32-bits, 64-bits and other precision later.
-                if (decimalLogicalType.Precision != 29)
-                {
-                    throw new NotSupportedException("only 29 digits of precision is currently supported for decimal type");
-                }
-
-                if (length != sizeof(Decimal128))
-                {
-                    throw new NotSupportedException("only 16 bytes of length is currently supported for decimal type ");
-                }
             }
 
             LogicalSystemType = logicalSystemType ?? throw new ArgumentNullException(nameof(logicalSystemType));

--- a/csharp/LogicalWrite.cs
+++ b/csharp/LogicalWrite.cs
@@ -97,10 +97,7 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(decimal))
             {
-                if (typeof(TPhysical) != typeof(FixedLenByteArray))
-                {
-                    throw new NotSupportedException("Writing decimal data is only supported with a fixed-length byte array physical type");
-                }
+                ValidateDecimalColumn(columnDescriptor);
                 if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
                 return (LogicalWrite<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalWrite.ConvertDecimal128(s, d, multiplier, byteBuffer));
@@ -108,10 +105,7 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(decimal?))
             {
-                if (typeof(TPhysical) != typeof(FixedLenByteArray))
-                {
-                    throw new NotSupportedException("Writing decimal data is only supported with a fixed-length byte array physical type");
-                }
+                ValidateDecimalColumn(columnDescriptor);
                 if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
                 var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
                 return (LogicalWrite<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, nl) => LogicalWrite.ConvertDecimal128(s, dl, d, multiplier, nl, byteBuffer));
@@ -218,6 +212,25 @@ namespace ParquetSharp
             }
 
             throw new NotSupportedException($"unsupported logical system type {typeof(TLogical)} with logical type {logicalType}");
+        }
+
+        private static unsafe void ValidateDecimalColumn(ColumnDescriptor columnDescriptor)
+        {
+            // For the moment we only support serializing decimal to Decimal128.
+            // This reflects the C# decimal structure with 28-29 digits precision.
+            // Will implement 32-bits, 64-bits and other precision later.
+            if (typeof(TPhysical) != typeof(FixedLenByteArray))
+            {
+                throw new NotSupportedException("Writing decimal data is only supported with a fixed-length byte array physical type");
+            }
+            if (columnDescriptor.TypePrecision != 29)
+            {
+                throw new NotSupportedException("only 29 digits of precision is currently supported for decimal type");
+            }
+            if (columnDescriptor.TypeLength != sizeof(Decimal128))
+            {
+                throw new NotSupportedException("only 16 bytes of length is currently supported for decimal type ");
+            }
         }
     }
 


### PR DESCRIPTION
This allows use of custom converters that support different precision and type lengths.

Fixes #347 