### PR TITLE
Upgrade to Arrow 12.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ As only 64-bit runtimes are available, ParquetSharp cannot be referenced by a 32
 
 Building ParquetSharp for Windows requires the following dependencies:
 - Visual Studio 2022 (17.0 or higher)
-- Apache Arrow (10.0.1)
+- Apache Arrow (12.0.1)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://github.com/Microsoft/vcpkg).
 The build scripts will use an existing vcpkg installation if either of the `VCPKG_INSTALLATION_ROOT` or `VCPKG_ROOT` environment variables are defined,

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -64,6 +64,11 @@ extern "C"
 		TRYCATCH(*size = (*writer_properties)->write_batch_size();)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Write_Page_Index(const std::shared_ptr<WriterProperties>* writer_properties, bool* enabled)
+	{
+		TRYCATCH(*enabled = (*writer_properties)->write_page_index();)
+	}
+
 	// ColumnPath taking methods.
 
 	//PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Column_Properties(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, const ColumnProperties** columnProperties)

--- a/cpp/WriterPropertiesBuilder.cpp
+++ b/cpp/WriterPropertiesBuilder.cpp
@@ -169,4 +169,14 @@ extern "C"
 	{
 		TRYCATCH(builder->write_batch_size(write_batch_size);)
 	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Enable_Write_Page_Index(WriterProperties::Builder* builder)
+	{
+		TRYCATCH(builder->enable_write_page_index();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Disable_Write_Page_Index(WriterProperties::Builder* builder)
+	{
+		TRYCATCH(builder->disable_write_page_index();)
+	}
 }

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -162,7 +162,7 @@ namespace ParquetSharp.Test
 
             var numRows = expectedColumns.First().Values.Length;
 
-            Assert.AreEqual("parquet-cpp-arrow version 10.0.1", fileMetaData.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 12.0.1", fileMetaData.CreatedBy);
             Assert.AreEqual(new Dictionary<string, string> {{"case", "Test"}, {"Awesome", "true"}}, fileMetaData.KeyValueMetadata);
             Assert.AreEqual(expectedColumns.Length, fileMetaData.NumColumns);
             Assert.AreEqual(numRows, fileMetaData.NumRows);
@@ -173,7 +173,7 @@ namespace ParquetSharp.Test
             // The parquet format only stores an integer file version (1 or 2) and
             // 2 gets mapped to the latest 2.x version.
             Assert.AreEqual(ParquetVersion.PARQUET_2_6, fileMetaData.Version);
-            Assert.AreEqual("parquet-cpp-arrow version 10.0.1", fileMetaData.WriterVersion.ToString());
+            Assert.AreEqual("parquet-cpp-arrow version 12.0.1", fileMetaData.WriterVersion.ToString());
 
             using var rowGroupReader = fileReader.RowGroup(0);
             var rowGroupMetaData = rowGroupReader.MetaData;

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -15,14 +15,14 @@ namespace ParquetSharp.Test
         {
             var p = WriterProperties.GetDefaultWriterProperties();
 
-            Assert.AreEqual("parquet-cpp-arrow version 10.0.1", p.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 12.0.1", p.CreatedBy);
             Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
             Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024 * 1024, p.DataPageSize);
             Assert.AreEqual(Encoding.RleDictionary, p.DictionaryIndexEncoding);
             Assert.AreEqual(Encoding.Plain, p.DictionaryPageEncoding);
             Assert.AreEqual(1024 * 1024, p.DictionaryPagesizeLimit);
-            Assert.AreEqual(64 * 1024 * 1024, p.MaxRowGroupLength);
+            Assert.AreEqual(1024 * 1024, p.MaxRowGroupLength);
             Assert.AreEqual(ParquetVersion.PARQUET_2_4, p.Version);
             Assert.AreEqual(1024, p.WriteBatchSize);
         }

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using NUnit.Framework;
 using ParquetSharp.IO;
 using ParquetSharp.Schema;
@@ -25,6 +24,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(1024 * 1024, p.MaxRowGroupLength);
             Assert.AreEqual(ParquetVersion.PARQUET_2_4, p.Version);
             Assert.AreEqual(1024, p.WriteBatchSize);
+            Assert.False(p.WritePageIndex);
         }
 
         [Test]
@@ -40,6 +40,8 @@ namespace ParquetSharp.Test
                 .MaxRowGroupLength(789)
                 .Version(ParquetVersion.PARQUET_1_0)
                 .WriteBatchSize(666)
+                .DisableWritePageIndex()
+                .EnableWritePageIndex()
                 .Build();
 
             Assert.AreEqual("Meeeee!!!", p.CreatedBy);
@@ -52,6 +54,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(789, p.MaxRowGroupLength);
             Assert.AreEqual(ParquetVersion.PARQUET_1_0, p.Version);
             Assert.AreEqual(666, p.WriteBatchSize);
+            Assert.True(p.WritePageIndex);
         }
 
         [Test]
@@ -71,6 +74,7 @@ namespace ParquetSharp.Test
                 DefaultWriterProperties.MaxRowGroupLength = 789;
                 DefaultWriterProperties.Version = ParquetVersion.PARQUET_1_0;
                 DefaultWriterProperties.WriteBatchSize = 666;
+                DefaultWriterProperties.WritePageIndex = true;
 
                 using var builder = new WriterPropertiesBuilder();
                 using var p = builder.Build();
@@ -87,6 +91,7 @@ namespace ParquetSharp.Test
                 Assert.AreEqual(789, p.MaxRowGroupLength);
                 Assert.AreEqual(ParquetVersion.PARQUET_1_0, p.Version);
                 Assert.AreEqual(666, p.WriteBatchSize);
+                Assert.True(p.WritePageIndex);
             }
             finally
             {
@@ -102,6 +107,7 @@ namespace ParquetSharp.Test
                 DefaultWriterProperties.MaxRowGroupLength = null;
                 DefaultWriterProperties.Version = null;
                 DefaultWriterProperties.WriteBatchSize = null;
+                DefaultWriterProperties.WritePageIndex = null;
             }
         }
 

--- a/csharp/DefaultWriterProperties.cs
+++ b/csharp/DefaultWriterProperties.cs
@@ -65,5 +65,10 @@ namespace ParquetSharp
         /// Default write batch size
         /// </summary>
         public static long? WriteBatchSize { get; set; }
+
+        /// <summary>
+        /// Write the page index
+        /// </summary>
+        public static bool? WritePageIndex { get; set; }
     }
 }

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>10.0.1</Version>
+    <Version>12.0.1-beta1</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -30,6 +30,7 @@ namespace ParquetSharp
         public long MaxRowGroupLength => ExceptionInfo.Return<long>(Handle, WriterProperties_Max_Row_Group_Length);
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(Handle, WriterProperties_Version);
         public long WriteBatchSize => ExceptionInfo.Return<long>(Handle, WriterProperties_Write_Batch_Size);
+        public bool WritePageIndex => ExceptionInfo.Return<bool>(Handle, WriterProperties_Write_Page_Index);
 
         public Compression Compression(ColumnPath path)
         {
@@ -95,6 +96,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterProperties_Write_Batch_Size(IntPtr writerProperties, out long size);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterProperties_Write_Page_Index(IntPtr writerProperties, out bool enabled);
 
         //[DllImport(ParquetDll.Name)]
         //private static extern IntPtr WriterProperties_Column_Properties(IntPtr writerProperties, IntPtr path, out IntPtr columnProperties);

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -235,6 +235,31 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Enable writing the page index
+        ///
+        /// The page index contains statistics for data pages and can be used to skip pages
+        /// when scanning data in ordered and unordered columns.
+        ///
+        /// For more details, see https://github.com/apache/parquet-format/blob/master/PageIndex.md
+        /// </summary>
+        public WriterPropertiesBuilder EnableWritePageIndex()
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Write_Page_Index(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        /// <summary>
+        /// Disable writing the page index
+        /// </summary>
+        public WriterPropertiesBuilder DisableWritePageIndex()
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Write_Page_Index(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
         private void ApplyDefaults()
         {
             OnDefaultProperty(DefaultWriterProperties.EnableDictionary, enabled =>
@@ -278,6 +303,18 @@ namespace ParquetSharp
             OnDefaultProperty(DefaultWriterProperties.Version, version => { Version(version); });
 
             OnDefaultProperty(DefaultWriterProperties.WriteBatchSize, writeBatchSize => { WriteBatchSize(writeBatchSize); });
+
+            OnDefaultProperty(DefaultWriterProperties.WritePageIndex, writePageIndex =>
+            {
+                if (writePageIndex)
+                {
+                    EnableWritePageIndex();
+                }
+                else
+                {
+                    DisableWritePageIndex();
+                }
+            });
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -397,6 +434,12 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Write_Batch_Size(IntPtr builder, long writeBatchSize);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Enable_Write_Page_Index(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Disable_Write_Page_Index(IntPtr builder);
 
         private readonly ParquetHandle _handle;
     }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,6 +2,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg.git",
-    "baseline": "163fe7bd3d67c41200617caaa245b5ba2ba854e6"
+    "baseline": "80ecf32496c3806c5bb79bb80f029f83d058930e"
   }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,7 @@
   "overrides": [
     {
       "name": "arrow",
-      "version": "10.0.1"
+      "version": "12.0.1"
     }
   ]
 }


### PR DESCRIPTION
Upgrades the version of the Arrow C++ library used to 12.0.1. Fixes #355 and fixes reading nullable byte-stream-split encoded data (#237) as this was fixed in Arrow.

This PR also exposes the new `write_page_index` option in the writer properties, which was added in Arrow 12.

~~The main change that might affect users is that the default row group size has been reduced from 64 Mi to 1 Mi (see https://github.com/apache/arrow/pull/34281).~~ Actually this is only used when writing Arrow tables or record batches, when using ParquetSharp users control batching into row groups, even with the row-oriented API, so this change should have no effect.

I've run the benchmarks and didn't find any significant performance differences.