### PR TITLE
Finalize net7.0 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,15 +244,15 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.x
-    - name: Setup .NET SDK v7.0.x
-      if: matrix.dotnet == 'net7.0'
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
     - name: Setup .NET SDK v6.0.x
+      if: matrix.dotnet == 'net6.0'
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+    - name: Setup .NET SDK v7.0.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
     - name: Add local NuGet feed
       run: |
         dotnet new nugetconfig

--- a/csharp.benchmark/ParquetSharp.Benchmark.csproj
+++ b/csharp.benchmark/ParquetSharp.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp.Benchmark</AssemblyName>

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
     <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0</TargetFrameworks>

--- a/fsharp.test/ParquetSharp.Test.FSharp.fsproj
+++ b/fsharp.test/ParquetSharp.Test.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
     <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0</TargetFrameworks>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.100",
+      "version": "7.0.100",
       "rollForward": "latestMinor"
     }
   }


### PR DESCRIPTION
#363 started the migration to `net7.0` but stopped short of running actual tests and building with the `net7.0` SDK — this PR aims at fixing that.