### PR TITLE
Fix "All required checks done" CI job to never be skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,12 +271,21 @@ jobs:
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:
     name: All required checks done
+    if: ${{ always() }}
     needs:
       - check-format
       - test-nuget
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All required checks done"
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const results = ${{ toJSON(needs.*.result) }};
+            if (results.every(res => res === 'success')) {
+              core.info('All required checks succeeded');
+            } else {
+              core.setFailed('Some required checks failed');
+            }
 
   # Create a GitHub release and publish the NuGet packages to nuget.org when a tag is pushed.
   publish-release:


### PR DESCRIPTION
The "All required checks done" CI job has been designed to be a required check, but GitHub considers it successful when it's skipped, and it gets skipped when some of the jobs it depends on fail.

This PR fixes that by always running the job and checking the results of all the jobs it depends on.

Example runs:
- [all jobs successful](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5835414192)
- [some jobs failed](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5835422840)