### PR TITLE
Upgrade to Arrow 13.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ As only 64-bit runtimes are available, ParquetSharp cannot be referenced by a 32
 
 Building ParquetSharp for Windows requires the following dependencies:
 - Visual Studio 2022 (17.0 or higher)
-- Apache Arrow (12.0.1)
+- Apache Arrow (13.0.0)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://github.com/Microsoft/vcpkg).
 The build scripts will use an existing vcpkg installation if either of the `VCPKG_INSTALLATION_ROOT` or `VCPKG_ROOT` environment variables are defined,

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -64,9 +64,15 @@ extern "C"
 		TRYCATCH(*size = (*writer_properties)->write_batch_size();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Write_Page_Index(const std::shared_ptr<WriterProperties>* writer_properties, bool* enabled)
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Page_Index_Enabled(const std::shared_ptr<WriterProperties>* writer_properties, bool* enabled)
 	{
-		TRYCATCH(*enabled = (*writer_properties)->write_page_index();)
+		// Returns true if the page index is enabled by default or for any specific path
+		TRYCATCH(*enabled = (*writer_properties)->page_index_enabled();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Page_Index_Enabled_For_Path(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, bool* enabled)
+	{
+		TRYCATCH(*enabled = (*writer_properties)->page_index_enabled(*path);)
 	}
 
 	// ColumnPath taking methods.

--- a/cpp/WriterPropertiesBuilder.cpp
+++ b/cpp/WriterPropertiesBuilder.cpp
@@ -175,8 +175,28 @@ extern "C"
 		TRYCATCH(builder->enable_write_page_index();)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Enable_Write_Page_Index_By_Path(WriterProperties::Builder* builder, const char* path)
+	{
+		TRYCATCH(builder->enable_write_page_index(path);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Enable_Write_Page_Index_By_ColumnPath(WriterProperties::Builder* builder, const std::shared_ptr<schema::ColumnPath>* path)
+	{
+		TRYCATCH(builder->enable_write_page_index(*path);)
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Disable_Write_Page_Index(WriterProperties::Builder* builder)
 	{
 		TRYCATCH(builder->disable_write_page_index();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Disable_Write_Page_Index_By_Path(WriterProperties::Builder* builder, const char* path)
+	{
+		TRYCATCH(builder->disable_write_page_index(path);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Disable_Write_Page_Index_By_ColumnPath(WriterProperties::Builder* builder, const std::shared_ptr<schema::ColumnPath>* path)
+	{
+		TRYCATCH(builder->disable_write_page_index(*path);)
 	}
 }

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -201,9 +201,11 @@ namespace ParquetSharp.Test
                 Assert.AreEqual(expected.TypePrecision, descr.TypePrecision);
                 Assert.AreEqual(expected.TypeScale, descr.TypeScale);
 
-                Assert.AreEqual(
-                    expected.Encodings.Where(e => useDictionaryEncoding || e != Encoding.RleDictionary).ToArray(),
-                    chunkMetaData.Encodings.Distinct().ToArray());
+                var expectedEncodings = expected.Encodings
+                    .Where(e => useDictionaryEncoding || e != Encoding.RleDictionary).ToArray();
+                var actualEncodings = chunkMetaData.Encodings.Distinct().ToArray();
+                // Encoding ordering is not important
+                Assert.That(actualEncodings, Is.EquivalentTo(expectedEncodings));
 
                 Assert.AreEqual(expected.Compression, chunkMetaData.Compression);
                 Assert.AreEqual(expected.Values, columnReader.Apply(new PhysicalValueGetter(chunkMetaData.NumValues)).values);

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -162,7 +162,7 @@ namespace ParquetSharp.Test
 
             var numRows = expectedColumns.First().Values.Length;
 
-            Assert.AreEqual("parquet-cpp-arrow version 12.0.1", fileMetaData.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 13.0.0", fileMetaData.CreatedBy);
             Assert.AreEqual(new Dictionary<string, string> {{"case", "Test"}, {"Awesome", "true"}}, fileMetaData.KeyValueMetadata);
             Assert.AreEqual(expectedColumns.Length, fileMetaData.NumColumns);
             Assert.AreEqual(numRows, fileMetaData.NumRows);
@@ -173,7 +173,7 @@ namespace ParquetSharp.Test
             // The parquet format only stores an integer file version (1 or 2) and
             // 2 gets mapped to the latest 2.x version.
             Assert.AreEqual(ParquetVersion.PARQUET_2_6, fileMetaData.Version);
-            Assert.AreEqual("parquet-cpp-arrow version 12.0.1", fileMetaData.WriterVersion.ToString());
+            Assert.AreEqual("parquet-cpp-arrow version 13.0.0", fileMetaData.WriterVersion.ToString());
 
             using var rowGroupReader = fileReader.RowGroup(0);
             var rowGroupMetaData = rowGroupReader.MetaData;

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -14,7 +14,7 @@ namespace ParquetSharp.Test
         {
             var p = WriterProperties.GetDefaultWriterProperties();
 
-            Assert.AreEqual("parquet-cpp-arrow version 12.0.1", p.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 13.0.0", p.CreatedBy);
             Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
             Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024 * 1024, p.DataPageSize);

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -189,8 +189,8 @@ namespace ParquetSharp.Test
             using var metadataId = groupReader.MetaData.GetColumnChunkMetaData(0);
             using var metadataValue = groupReader.MetaData.GetColumnChunkMetaData(1);
 
-            Assert.AreEqual(new[] {Encoding.RleDictionary, Encoding.Plain, Encoding.Rle}, metadataId.Encodings);
-            Assert.AreEqual(new[] {Encoding.ByteStreamSplit, Encoding.Rle}, metadataValue.Encodings);
+            Assert.That(metadataId.Encodings, Is.EquivalentTo(new[] {Encoding.RleDictionary, Encoding.Plain, Encoding.Rle}));
+            Assert.That(metadataValue.Encodings, Is.EquivalentTo(new[] {Encoding.ByteStreamSplit, Encoding.Rle}));
 
             using var idReader = groupReader.Column(0).LogicalReader<int>();
             using var valueReader = groupReader.Column(1).LogicalReader<float>();
@@ -236,7 +236,7 @@ namespace ParquetSharp.Test
             using var groupReader = fileReader.RowGroup(0);
 
             using var columnMetadata = groupReader.MetaData.GetColumnChunkMetaData(0);
-            Assert.AreEqual(new[] {Encoding.ByteStreamSplit, Encoding.Rle}, columnMetadata.Encodings);
+            Assert.That(columnMetadata.Encodings, Is.EquivalentTo(new[] {Encoding.ByteStreamSplit, Encoding.Rle}));
 
             using var valueReader = groupReader.Column(0).LogicalReader<float?>();
             Assert.AreEqual(values, valueReader.ReadAll(numRows));

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -61,29 +61,29 @@ namespace ParquetSharp.Test
         public static void TestWritePageIndex()
         {
             using (var p = new WriterPropertiesBuilder()
-                       .DisableWritePageIndex()
-                       .Build())
+                .DisableWritePageIndex()
+                .Build())
             {
                 Assert.False(p.WritePageIndex);
             }
 
             using (var p = new WriterPropertiesBuilder()
-                       .DisableWritePageIndex()
-                       .EnableWritePageIndex("column_a")
-                       .EnableWritePageIndex(new ColumnPath(new [] {"column_b", "nested"}))
-                       .Build())
+                .DisableWritePageIndex()
+                .EnableWritePageIndex("column_a")
+                .EnableWritePageIndex(new ColumnPath(new[] {"column_b", "nested"}))
+                .Build())
             {
-                Assert.True(p.WritePageIndex);  // True if enabled for any path
+                Assert.True(p.WritePageIndex); // True if enabled for any path
                 Assert.False(p.WritePageIndexForPath(new ColumnPath("column_c")));
                 Assert.True(p.WritePageIndexForPath(new ColumnPath("column_a")));
                 Assert.True(p.WritePageIndexForPath(new ColumnPath("column_b.nested")));
             }
 
             using (var p = new WriterPropertiesBuilder()
-                       .EnableWritePageIndex()
-                       .DisableWritePageIndex("column_a")
-                       .DisableWritePageIndex(new ColumnPath(new [] {"column_b", "nested"}))
-                       .Build())
+                .EnableWritePageIndex()
+                .DisableWritePageIndex("column_a")
+                .DisableWritePageIndex(new ColumnPath(new[] {"column_b", "nested"}))
+                .Build())
             {
                 Assert.True(p.WritePageIndex);
                 Assert.True(p.WritePageIndexForPath(new ColumnPath("column_c")));

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -22,7 +22,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(Encoding.Plain, p.DictionaryPageEncoding);
             Assert.AreEqual(1024 * 1024, p.DictionaryPagesizeLimit);
             Assert.AreEqual(1024 * 1024, p.MaxRowGroupLength);
-            Assert.AreEqual(ParquetVersion.PARQUET_2_4, p.Version);
+            Assert.AreEqual(ParquetVersion.PARQUET_2_6, p.Version);
             Assert.AreEqual(1024, p.WriteBatchSize);
             Assert.False(p.WritePageIndex);
         }

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -58,6 +58,41 @@ namespace ParquetSharp.Test
         }
 
         [Test]
+        public static void TestWritePageIndex()
+        {
+            using (var p = new WriterPropertiesBuilder()
+                       .DisableWritePageIndex()
+                       .Build())
+            {
+                Assert.False(p.WritePageIndex);
+            }
+
+            using (var p = new WriterPropertiesBuilder()
+                       .DisableWritePageIndex()
+                       .EnableWritePageIndex("column_a")
+                       .EnableWritePageIndex(new ColumnPath(new [] {"column_b", "nested"}))
+                       .Build())
+            {
+                Assert.True(p.WritePageIndex);  // True if enabled for any path
+                Assert.False(p.WritePageIndexForPath(new ColumnPath("column_c")));
+                Assert.True(p.WritePageIndexForPath(new ColumnPath("column_a")));
+                Assert.True(p.WritePageIndexForPath(new ColumnPath("column_b.nested")));
+            }
+
+            using (var p = new WriterPropertiesBuilder()
+                       .EnableWritePageIndex()
+                       .DisableWritePageIndex("column_a")
+                       .DisableWritePageIndex(new ColumnPath(new [] {"column_b", "nested"}))
+                       .Build())
+            {
+                Assert.True(p.WritePageIndex);
+                Assert.True(p.WritePageIndexForPath(new ColumnPath("column_c")));
+                Assert.False(p.WritePageIndexForPath(new ColumnPath("column_a")));
+                Assert.False(p.WritePageIndexForPath(new ColumnPath("column_b.nested")));
+            }
+        }
+
+        [Test]
         [NonParallelizable]
         public static void TestOverrideDefaults()
         {

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>12.0.1</Version>
+    <Version>13.0.0-beta1</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -30,7 +30,19 @@ namespace ParquetSharp
         public long MaxRowGroupLength => ExceptionInfo.Return<long>(Handle, WriterProperties_Max_Row_Group_Length);
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(Handle, WriterProperties_Version);
         public long WriteBatchSize => ExceptionInfo.Return<long>(Handle, WriterProperties_Write_Batch_Size);
-        public bool WritePageIndex => ExceptionInfo.Return<bool>(Handle, WriterProperties_Write_Page_Index);
+
+        /// <summary>
+        /// Whether writing the page index is enabled for any columns
+        /// </summary>
+        public bool WritePageIndex => ExceptionInfo.Return<bool>(Handle, WriterProperties_Page_Index_Enabled);
+
+        /// <summary>
+        /// Whether writing the page index is enabled for the specified column
+        /// </summary>
+        public bool WritePageIndexForPath(ColumnPath path)
+        {
+            return ExceptionInfo.Return<bool>(Handle, path.Handle, WriterProperties_Page_Index_Enabled_For_Path);
+        }
 
         public Compression Compression(ColumnPath path)
         {
@@ -98,7 +110,10 @@ namespace ParquetSharp
         private static extern IntPtr WriterProperties_Write_Batch_Size(IntPtr writerProperties, out long size);
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr WriterProperties_Write_Page_Index(IntPtr writerProperties, out bool enabled);
+        private static extern IntPtr WriterProperties_Page_Index_Enabled(IntPtr writerProperties, out bool enabled);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterProperties_Page_Index_Enabled_For_Path(IntPtr writerProperties, IntPtr path, out bool enabled);
 
         //[DllImport(ParquetDll.Name)]
         //private static extern IntPtr WriterProperties_Column_Properties(IntPtr writerProperties, IntPtr path, out IntPtr columnProperties);

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -236,7 +236,7 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Enable writing the page index
+        /// Enable writing the page index by default
         ///
         /// The page index contains statistics for data pages and can be used to skip pages
         /// when scanning data in ordered and unordered columns.
@@ -251,11 +251,53 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Disable writing the page index
+        /// Enable writing the page index for a specific column
+        /// </summary>
+        public WriterPropertiesBuilder EnableWritePageIndex(ColumnPath path)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Write_Page_Index_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
+            return this;
+        }
+
+        /// <summary>
+        /// Enable writing the page index for a specific column
+        /// </summary>
+        public WriterPropertiesBuilder EnableWritePageIndex(string path)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Write_Page_Index_By_Path(_handle.IntPtr, path));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        /// <summary>
+        /// Disable writing the page index by default
         /// </summary>
         public WriterPropertiesBuilder DisableWritePageIndex()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Write_Page_Index(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        /// <summary>
+        /// Disable writing the page index for a specific column
+        /// </summary>
+        public WriterPropertiesBuilder DisableWritePageIndex(ColumnPath path)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Write_Page_Index_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
+            GC.KeepAlive(_handle);
+            GC.KeepAlive(path);
+            return this;
+        }
+
+        /// <summary>
+        /// Disable writing the page index for a specific column
+        /// </summary>
+        public WriterPropertiesBuilder DisableWritePageIndex(string path)
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Write_Page_Index_By_Path(_handle.IntPtr, path));
             GC.KeepAlive(_handle);
             return this;
         }
@@ -439,7 +481,19 @@ namespace ParquetSharp
         private static extern IntPtr WriterPropertiesBuilder_Enable_Write_Page_Index(IntPtr builder);
 
         [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Enable_Write_Page_Index_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Enable_Write_Page_Index_By_ColumnPath(IntPtr builder, IntPtr path);
+
+        [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Disable_Write_Page_Index(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Disable_Write_Page_Index_By_Path(IntPtr builder, [MarshalAs(UnmanagedType.LPUTF8Str)] string path);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Disable_Write_Page_Index_By_ColumnPath(IntPtr builder, IntPtr path);
 
         private readonly ParquetHandle _handle;
     }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,6 +2,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg.git",
-    "baseline": "80ecf32496c3806c5bb79bb80f029f83d058930e"
+    "baseline": "2cf957350da28ad032178a974607f59f961217d9"
   }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,7 @@
   "overrides": [
     {
       "name": "arrow",
-      "version": "12.0.1"
+      "version": "13.0.0"
     }
   ]
 }


### PR DESCRIPTION
This upgrades the version of the Arrow C++ library to 13.0.0.

The notable changes in this version are:
* Writing the page index can now be controlled per column
* The Parquet version written now defaults to 2.6. This version includes the nanosecond timestamp precision but we were already using this in ParquetSharp so this change doesn't seem to affect us besides the metadata being different
* Changes to how the column encodings are computed affected the order these are returned in, but the order shouldn't have been relied on

Comparing benchmark results between the current master and this branch, the timings are mostly the same, with some of the "chunked" writing tests slowing down a little (5 to 10%) indicating there might be a bit more per-row-group overhead. There is quite a large slowdown in the nested write test though, going from 47 ms to 85 ms per iteration on my machine. I looked into this and have made a PR to fix this in Arrow (https://github.com/apache/arrow/pull/37454), so hopefully the performance will be better again for the next version. I think this regression probably isn't bad enough to block upgrading to 13.0.0 though as it looks like it should only affect writing nested data, where we make lots of calls to WriteBatch with small batches of data. (And possibly this could be refactored to avoid needing to make so many WriteBatch calls if we buffered these first?)