### PR TITLE
Upgrade the NUnit test adapter

### DIFF
--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Parquet.Net" Version="3.8.6" />
   </ItemGroup>
 

--- a/csharp.test/TestColumn.cs
+++ b/csharp.test/TestColumn.cs
@@ -16,29 +16,35 @@ namespace ParquetSharp.Test
             {
                 foreach (var expected in expectedPrimitives)
                 {
-                    Console.WriteLine("Testing primitive type {0}", expected.Type);
+                    try
+                    {
+                        Assert.True(LogicalTypeFactory.Default.IsSupported(expected.Type));
+                        var type = expected.Type;
+                        var column = new Column(type, expected.Name, expected.LogicalTypeOverride);
 
-                    Assert.True(LogicalTypeFactory.Default.IsSupported(expected.Type));
-                    var type = expected.Type;
-                    var column = new Column(type, expected.Name, expected.LogicalTypeOverride);
+                        using var node = column.CreateSchemaNode();
 
-                    using var node = column.CreateSchemaNode();
+                        using var nodeLogicalType = node.LogicalType;
+                        Assert.AreEqual(expected.LogicalType, nodeLogicalType);
+                        Assert.AreEqual(-1, node.FieldId);
+                        Assert.AreEqual(expected.Name, node.Name);
+                        Assert.AreEqual(NodeType.Primitive, node.NodeType);
+                        Assert.AreEqual(null, node.Parent);
+                        Assert.AreEqual(expected.Repetition, node.Repetition);
 
-                    using var nodeLogicalType = node.LogicalType;
-                    Assert.AreEqual(expected.LogicalType, nodeLogicalType);
-                    Assert.AreEqual(-1, node.FieldId);
-                    Assert.AreEqual(expected.Name, node.Name);
-                    Assert.AreEqual(NodeType.Primitive, node.NodeType);
-                    Assert.AreEqual(null, node.Parent);
-                    Assert.AreEqual(expected.Repetition, node.Repetition);
+                        var primitive = (PrimitiveNode) node;
 
-                    var primitive = (PrimitiveNode) node;
-
-                    Assert.AreEqual(expected.ColumnOrder, primitive.ColumnOrder);
-                    Assert.AreEqual(expected.PhysicalType, primitive.PhysicalType);
-                    Assert.AreEqual(expected.Length, primitive.TypeLength);
-                    using var logicalType = primitive.LogicalType;
-                    Assert.AreEqual(expected.LogicalType, logicalType);
+                        Assert.AreEqual(expected.ColumnOrder, primitive.ColumnOrder);
+                        Assert.AreEqual(expected.PhysicalType, primitive.PhysicalType);
+                        Assert.AreEqual(expected.Length, primitive.TypeLength);
+                        using var logicalType = primitive.LogicalType;
+                        Assert.AreEqual(expected.LogicalType, logicalType);
+                    }
+                    catch (Exception)
+                    {
+                        TestContext.Out.WriteLine("Failure testing primitive type {0}", expected.Type);
+                        throw;
+                    }
                 }
             }
             finally

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -30,11 +30,9 @@ namespace ParquetSharp.Test
 
             foreach (var value in decimals)
             {
-                Console.WriteLine($"{value:E}");
-                Assert.AreEqual(value, new Decimal128(value, multiplier).ToDecimal(multiplier));
+                Assert.That(value, Is.EqualTo(new Decimal128(value, multiplier).ToDecimal(multiplier)));
 
-                Console.WriteLine($"{-value:E}");
-                Assert.AreEqual(-value, new Decimal128(-value, multiplier).ToDecimal(multiplier));
+                Assert.That(-value, Is.EqualTo(new Decimal128(-value, multiplier).ToDecimal(multiplier)));
             }
         }
 

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -94,8 +94,6 @@ namespace ParquetSharp.Test
                             var column = expectedColumns[i];
                             var range = (r, Math.Min(r + rangeLength, NumRows));
 
-                            Console.WriteLine("Writing '{0}' (element type: {1}) (range: {2})", column.Name, column.Values.GetType().GetElementType(), range);
-
                             using var columnWriter = rowGroupWriter.Column(i).LogicalWriter(writeBufferLength);
                             columnWriter.Apply(new LogicalValueSetter(column.Values, rowsPerBatch, range));
                         }

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -137,11 +137,6 @@ namespace ParquetSharp.Test
                         var column = expectedColumns[i];
                         var range = (r, Math.Min(r + rangeLength, numRows));
 
-                        if (range.Item1 == 0 || range.Item2 == numRows)
-                        {
-                            Console.WriteLine("Writing '{0}' (range: {1})", column.Name, range);
-                        }
-
                         using var columnWriter = rowGroupWriter.Column(i);
                         columnWriter.Apply(new ValueSetter(column.Values, range));
                     }

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -98,10 +98,16 @@ namespace ParquetSharp.Test
 
                 foreach (var column in expectedColumns)
                 {
-                    Console.WriteLine("Writing '{0}'", column.Name);
-
-                    using var columnWriter = rowGroupWriter.NextColumn();
-                    columnWriter.Apply(new ValueSetter(column.Values));
+                    try
+                    {
+                        using var columnWriter = rowGroupWriter.NextColumn();
+                        columnWriter.Apply(new ValueSetter(column.Values));
+                    }
+                    catch (Exception)
+                    {
+                        TestContext.WriteLine("Failure writing '{0}'", column.Name);
+                        throw;
+                    }
                 }
 
                 fileWriter.Close();
@@ -176,34 +182,39 @@ namespace ParquetSharp.Test
             for (int c = 0; c != fileMetaData.NumColumns; ++c)
             {
                 using var columnReader = rowGroupReader.Column(c);
-
                 var expected = expectedColumns[c];
+                try
+                {
+                    var descr = columnReader.ColumnDescriptor;
+                    using var chunkMetaData = rowGroupMetaData.GetColumnChunkMetaData(c);
 
-                Console.WriteLine("Reading '{0}'", expected.Name);
+                    Assert.AreEqual(expected.MaxDefinitionlevel, descr.MaxDefinitionLevel);
+                    Assert.AreEqual(expected.MaxRepetitionLevel, descr.MaxRepetitionLevel);
+                    Assert.AreEqual(expected.PhysicalType, descr.PhysicalType);
+                    using var logicalType = descr.LogicalType;
+                    Assert.AreEqual(expected.LogicalType, logicalType);
+                    Assert.AreEqual(expected.ColumnOrder, descr.ColumnOrder);
+                    Assert.AreEqual(expected.SortOrder, descr.SortOrder);
+                    Assert.AreEqual(expected.Name, descr.Name);
+                    Assert.AreEqual(expected.TypeLength, descr.TypeLength);
+                    Assert.AreEqual(expected.TypePrecision, descr.TypePrecision);
+                    Assert.AreEqual(expected.TypeScale, descr.TypeScale);
 
-                var descr = columnReader.ColumnDescriptor;
-                using var chunkMetaData = rowGroupMetaData.GetColumnChunkMetaData(c);
+                    var expectedEncodings = expected.Encodings
+                        .Where(e => useDictionaryEncoding || e != Encoding.RleDictionary).ToArray();
+                    var actualEncodings = chunkMetaData.Encodings.Distinct().ToArray();
+                    // Encoding ordering is not important
+                    Assert.That(actualEncodings, Is.EquivalentTo(expectedEncodings));
 
-                Assert.AreEqual(expected.MaxDefinitionlevel, descr.MaxDefinitionLevel);
-                Assert.AreEqual(expected.MaxRepetitionLevel, descr.MaxRepetitionLevel);
-                Assert.AreEqual(expected.PhysicalType, descr.PhysicalType);
-                using var logicalType = descr.LogicalType;
-                Assert.AreEqual(expected.LogicalType, logicalType);
-                Assert.AreEqual(expected.ColumnOrder, descr.ColumnOrder);
-                Assert.AreEqual(expected.SortOrder, descr.SortOrder);
-                Assert.AreEqual(expected.Name, descr.Name);
-                Assert.AreEqual(expected.TypeLength, descr.TypeLength);
-                Assert.AreEqual(expected.TypePrecision, descr.TypePrecision);
-                Assert.AreEqual(expected.TypeScale, descr.TypeScale);
-
-                var expectedEncodings = expected.Encodings
-                    .Where(e => useDictionaryEncoding || e != Encoding.RleDictionary).ToArray();
-                var actualEncodings = chunkMetaData.Encodings.Distinct().ToArray();
-                // Encoding ordering is not important
-                Assert.That(actualEncodings, Is.EquivalentTo(expectedEncodings));
-
-                Assert.AreEqual(expected.Compression, chunkMetaData.Compression);
-                Assert.AreEqual(expected.Values, columnReader.Apply(new PhysicalValueGetter(chunkMetaData.NumValues)).values);
+                    Assert.AreEqual(expected.Compression, chunkMetaData.Compression);
+                    Assert.AreEqual(expected.Values,
+                        columnReader.Apply(new PhysicalValueGetter(chunkMetaData.NumValues)).values);
+                }
+                catch (Exception)
+                {
+                    TestContext.Out.WriteLine("Failure reading '{0}'", expected.Name);
+                    throw;
+                }
             }
         }
 

--- a/fsharp.test/ParquetSharp.Test.FSharp.fsproj
+++ b/fsharp.test/ParquetSharp.Test.FSharp.fsproj
@@ -14,7 +14,7 @@
     <PackageReference Include="FsUnit" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Running the tests under Visual Studio Code with the C# Dev Kit extension would include tests marked explicit, leading to surprises like the `StressTestProcessMemory` test running for a long time. This is fixed by upgrading the version of the `NUnit3TestAdapter` package, but this also seems to have changed behaviour so that now any console logging from tests is output by default when running `dotnet test`. The tests were doing a lot of logging, over 80k lines, so I've also removed some logging I thought was unnecessary and changed some logs to only be shown in the case of an error where they add some useful context.