### PR TITLE
Document workarounds for using the dev container with podman and SELinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ If you want to work locally in [Visual Studio Code](https://code.visualstudio.co
 
 Simply open up your copy of ParquetSharp in VS Code and click "Reopen in container" when prompted. Once the project has been opened, you can follow the GitHub Codespaces instructions above.
 
+<details>
+<summary>Podman and SELinux workarounds</summary>
+Using the dev container on a Linux system with podman and SELinux requires some workarounds.
+
+You'll need to edit `.devcontainer/devcontainer.json` and add the following lines:
+
+```json
+  "remoteUser": "root",
+  "containerUser": "root",
+  "workspaceMount": "",
+  "runArgs": ["--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"],
+  "containerEnv": { "VCPKG_DEFAULT_BINARY_CACHE": "/home/vscode/.cache/vcpkg/archives" }
+```
+
+This configures the container to run as the root user,
+because when you run podman as a non-root user your user id is mapped
+to root in the container, and files in the workspace folder will be owned by root.
+
+The workspace mount command is also modified to add the `:Z` suffix,
+which tells podman to relabel the volume to allow access to it from within the container.
+
+Finally, setting the `VCPKG_DEFAULT_BINARY_CACHE` environment variable
+makes the root user in the container use the vcpkg cache of the vscode user.
+</details>
+
 #### CLI
 
 If the CLI is how you roll, then you can install the [Dev Container CLI](https://github.com/devcontainers/cli) tool and issue the following command in the your copy of ParquetSharp to get up and running:


### PR DESCRIPTION
This documents the workarounds I had to use to get the dev container working on Fedora 38 with SELinux and podman. I've put these in a collapsible section as they won't be relevant for most users, but it seems worth having them documented here in case anybody else has similar issues.