### PR TITLE
README Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Supported platforms:
 
 ## Why use Parquet?
 
-**Apache Parquet** is an [open source][2], column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Relative to CSV files, <u>Parquet executes queries **34x faster** while taking up **87% less space**</u>. [Source][7]
+**Apache Parquet** is an [open source][6], column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Relative to CSV files, Parquet executes queries **34x faster** while taking up **87% less space**. [Source][7]
 
 [1]: https://parquet.apache.org/
-[2]: https://github.com/apache/parquet-format
-[3]: https://docs.microsoft.com/en-us/cpp/dotnet/how-to-call-native-dlls-from-managed-code-using-pinvoke
-[4]: https://github.com/apache/arrow
-[5]: https://github.com/G-Research/ParquetSharp.DataFrame
-[6]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.analysis.dataframe
+[2]: https://docs.microsoft.com/en-us/cpp/dotnet/how-to-call-native-dlls-from-managed-code-using-pinvoke
+[3]: https://github.com/apache/arrow
+[4]: https://github.com/G-Research/ParquetSharp.DataFrame
+[5]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.analysis.dataframe
+[6]: https://github.com/apache/parquet-format
 [7]: https://towardsdatascience.com/demystifying-the-parquet-file-format-13adb0206705
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ## Introduction
 
-ParquetSharp is a cross-platform .NET library for reading and writing Apache [Parquet][1] files.
+**ParquetSharp** is a cross-platform .NET library for reading and writing Apache [Parquet][1] files.
 
-It is implemented in C# as a [PInvoke][2] wrapper around [Apache Parquet C++][3] to provide high performance and compatibility. Check out [ParquetSharp.DataFrame][4] if you need a convenient integration with the .NET [DataFrames][5].
+**Apache Parquet** is an [open source][2], column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Relative to CSV files, <u>Parquet executes queries **34x faster** while taking up **87% less space**</u>.
+
+ParquetSharp is implemented in C# as a [PInvoke][2] wrapper around [Apache Parquet C++][3] to provide high performance and compatibility. Check out [ParquetSharp.DataFrame][4] if you need a convenient integration with the .NET [DataFrames][5].
 
 Supported platforms:
 
@@ -13,11 +15,12 @@ Supported platforms:
 | x64   | &#x2714; | &#x2714; | &#x2714; |
 | arm64 | &#x2714; |          | &#x2714; |
 
-[1]: https://github.com/apache/parquet-format
-[2]: https://docs.microsoft.com/en-us/cpp/dotnet/how-to-call-native-dlls-from-managed-code-using-pinvoke
-[3]: https://github.com/apache/arrow
-[4]: https://github.com/G-Research/ParquetSharp.DataFrame
-[5]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.analysis.dataframe
+[1]: https://parquet.apache.org/
+[2]: https://github.com/apache/parquet-format
+[3]: https://docs.microsoft.com/en-us/cpp/dotnet/how-to-call-native-dlls-from-managed-code-using-pinvoke
+[4]: https://github.com/apache/arrow
+[5]: https://github.com/G-Research/ParquetSharp.DataFrame
+[6]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.analysis.dataframe
 
 |                       | Status                                                                                                                                                                                                                         |
 | --------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following examples show how to write and then read a Parquet file with three
 These use the low-level API, which is the recommended API for working with native .NET types and closely maps to the API of Apache Parquet C++.
 For reading and writing data in the [Apache Arrow](https://arrow.apache.org/) format, an [Arrow based API](docs/Arrow.md) is also provided.
 
-Writing a Parquet File:
+### How to write a Parquet File:
 
 ```csharp
 var timestamps = new DateTime[] { /* ... */ };
@@ -68,7 +68,7 @@ using (var valueWriter = rowGroup.NextColumn().LogicalWriter<float>())
 file.Close();
 ```
 
-Reading the file back:
+### How to read a Parquet file:
 
 ```csharp
 using var file = new ParquetFileReader("float_timeseries.parquet");
@@ -89,8 +89,8 @@ file.Close();
 
 For more detailed information on how to use ParquetSharp, see the following documentation:
 
-* [Writing parquet files](docs/Writing.md)
-* [Reading parquet files](docs/Reading.md)
+* [Writing Parquet files](docs/Writing.md)
+* [Reading Parquet files](docs/Reading.md)
 * [Working with nested data](docs/Nested.md)
 * [Reading and writing Arrow data](docs/Arrow.md) &mdash; how to read and write data using the [Apache Arrow format](https://arrow.apache.org/)
 * [Row-oriented API](docs/RowOriented.md) &mdash; a higher level API that abstracts away the column-oriented nature of Parquet files

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **ParquetSharp** is a cross-platform .NET library for reading and writing Apache [Parquet][1] files.
 
-**Apache Parquet** is an [open source][2], column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Relative to CSV files, <u>Parquet executes queries **34x faster** while taking up **87% less space**</u>.
+**Apache Parquet** is an [open source][2], column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Relative to CSV files, <u>Parquet executes queries **34x faster** while taking up **87% less space**</u>. [Source][7]
 
 ParquetSharp is implemented in C# as a [PInvoke][2] wrapper around [Apache Parquet C++][3] to provide high performance and compatibility. Check out [ParquetSharp.DataFrame][4] if you need a convenient integration with the .NET [DataFrames][5].
 
@@ -21,6 +21,7 @@ Supported platforms:
 [4]: https://github.com/apache/arrow
 [5]: https://github.com/G-Research/ParquetSharp.DataFrame
 [6]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.analysis.dataframe
+[7]: https://towardsdatascience.com/demystifying-the-parquet-file-format-13adb0206705
 
 |                       | Status                                                                                                                                                                                                                         |
 | --------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 **ParquetSharp** is a cross-platform .NET library for reading and writing Apache [Parquet][1] files.
 
-**Apache Parquet** is an [open source][2], column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Relative to CSV files, <u>Parquet executes queries **34x faster** while taking up **87% less space**</u>. [Source][7]
-
 ParquetSharp is implemented in C# as a [PInvoke][2] wrapper around [Apache Parquet C++][3] to provide high performance and compatibility. Check out [ParquetSharp.DataFrame][4] if you need a convenient integration with the .NET [DataFrames][5].
 
 Supported platforms:
@@ -15,6 +13,16 @@ Supported platforms:
 | x64   | &#x2714; | &#x2714; | &#x2714; |
 | arm64 | &#x2714; |          | &#x2714; |
 
+|                       | Status                                                                                                                                                                                                                         |
+| --------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Release Nuget**     | [![NuGet latest release](https://img.shields.io/nuget/v/ParquetSharp.svg)](https://www.nuget.org/packages/ParquetSharp)                                                                                                        |
+| **Pre-Release Nuget** | [![NuGet latest pre-release](https://img.shields.io/nuget/vpre/ParquetSharp.svg)](https://www.nuget.org/packages/ParquetSharp/absoluteLatest)                                                                                  |
+| **CI Build**          | [![CI Status](https://github.com/G-Research/ParquetSharp/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/G-Research/ParquetSharp/actions/workflows/ci.yml?query=branch%3Amaster+event%3Apush) |
+
+## Why use Parquet?
+
+**Apache Parquet** is an [open source][2], column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. Relative to CSV files, <u>Parquet executes queries **34x faster** while taking up **87% less space**</u>. [Source][7]
+
 [1]: https://parquet.apache.org/
 [2]: https://github.com/apache/parquet-format
 [3]: https://docs.microsoft.com/en-us/cpp/dotnet/how-to-call-native-dlls-from-managed-code-using-pinvoke
@@ -22,12 +30,6 @@ Supported platforms:
 [5]: https://github.com/G-Research/ParquetSharp.DataFrame
 [6]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.analysis.dataframe
 [7]: https://towardsdatascience.com/demystifying-the-parquet-file-format-13adb0206705
-
-|                       | Status                                                                                                                                                                                                                         |
-| --------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Release Nuget**     | [![NuGet latest release](https://img.shields.io/nuget/v/ParquetSharp.svg)](https://www.nuget.org/packages/ParquetSharp)                                                                                                        |
-| **Pre-Release Nuget** | [![NuGet latest pre-release](https://img.shields.io/nuget/vpre/ParquetSharp.svg)](https://www.nuget.org/packages/ParquetSharp/absoluteLatest)                                                                                  |
-| **CI Build**          | [![CI Status](https://github.com/G-Research/ParquetSharp/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/G-Research/ParquetSharp/actions/workflows/ci.yml?query=branch%3Amaster+event%3Apush) |
 
 ## Quickstart
 


### PR DESCRIPTION
I'm Juan, an MLH Fellow, and my goal is to improve G-Research projects by making them more accessible to new users and contributors by reducing friction while browsing and learning how to use each project.

I hope these changes to the README make sense:

## Changelog: 
- Added details about Parquet to the README
  - New users that stumble upon the repo may not be completely aware of **what Parquet is** and **why we should use it**.
  - Added supporting fact and source (source links improve SEO by increasing credibility)
  - New section was added to make the extra info unobtrusive and improve SEO by hitting the "why use parquet" query keywords
- Changed wording for quickstart sections and made them more visible
  - This is one of the most important parts of the README, so visual cues help users find what they want
  - The new wording helps SEO, as users are more likely to search "how to read a parquet file" or "read parquet file" (old wording is still included in the Documentation section to hit queries for "reading/writing parquet file" as well)
- Standardized capitalization for Parquet
  - This might seem trivial, but consistent capitalization can be helpful for SEO. This will allow people who search for "parquet" to find it more quickly as it is marked as a proper noun