### PR TITLE
Run tests on Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,11 +225,14 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, macos-12, windows-2022, ubuntu-20.04-arm64]
+        os: [ubuntu-20.04, macos-11, macos-12, macos-13-xlarge, windows-2022, ubuntu-20.04-arm64]
         dotnet: [netcoreapp3.1, net6.0, net7.0]
         include:
         - os: windows-2022
           dotnet: net472
+        exclude:
+        - os: macos-13-xlarge
+          dotnet: netcoreapp3.1
       fail-fast: false
     name: Test NuGet package (${{ matrix.dotnet }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub has _finally_ [announced](https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/) support for Apple Silicon in GitHub Actions. This PR enables them according to the [documentation](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners) by adding a `macos-13-xlarge` label.

Closes #233.