### PR TITLE
Documentation Enhancements

### DIFF
--- a/docs/Arrow.md
+++ b/docs/Arrow.md
@@ -18,6 +18,8 @@ In this example, we'll open a file using a path:
 using var fileReader = new FileReader("data.parquet");
 ```
 
+### Inspecting the schema
+
 We can then inspect the Arrow schema that will be used when reading the file:
 
 ```csharp
@@ -27,6 +29,8 @@ foreach (var field in schema.FieldsList)
     Console.WriteLine($"field '{field.Name}' data type = '{field.DataType}'");
 }
 ```
+
+### Reading data
 
 To read data from the file, we use the `GetRecordBatchReader` method,
 which returns an `Apache.Arrow.IArrowArrayStream`.
@@ -138,7 +142,9 @@ using var writer = new FileWriter("data.parquet", schema);
 ```
 
 Rather than specifying a file path, we could also write to a .NET `System.IO.Stream`
-or a subclass of `ParquetShap.IO.OutputStream`.
+or a subclass of `ParquetSharp.IO.OutputStream`.
+
+### Writing data in batches
 
 Now we're ready to write batches of data:
 
@@ -158,6 +164,8 @@ if it contains more rows than the chunk size, which can be specified when writin
 writer.WriteRecordBatch(recordBatch, chunkSize: 1024);
 ```
 
+### Writing data one column at a time
+
 Rather than writing record batches, you may also explicitly start Parquet row groups
 and write data one column at a time, for more control over how data is written:
 
@@ -171,6 +179,8 @@ for (var batchNumber = 0; batchNumber < 10; ++batchNumber)
     writer.WriteColumnChunk(recordBatch.Column(2));
 }
 ```
+
+### Closing the file
 
 Finally, we should call the `Close` method when we have finished writing data,
 which will write the Parquet file footer and close the file.

--- a/docs/Reading.md
+++ b/docs/Reading.md
@@ -16,6 +16,7 @@ using var fileReader = new ParquetFileReader(input);
 ### Obtaining file metadata
 
 The `FileMetaData` property of a `ParquetFileReader` exposes information about the Parquet file and its schema:
+
 ```csharp
 int numColumns = fileReader.FileMetaData.NumColumns;
 long numRows = fileReader.FileMetaData.NumRows;
@@ -30,6 +31,7 @@ for (int columnIndex = 0; columnIndex < schema.NumColumns; ++columnIndex) {
 ```
 
 ### Reading row groups
+
 Parquet files store data in separate row groups, which all share the same schema,
 so if you wish to read all data in a file, you generally want to loop over all of the row groups
 and create a `RowGroupReader` for each one:
@@ -86,6 +88,7 @@ and reading physical values in a type-safe way, but most users will want to work
 
 
 ### Reading data in batches
+
 The `LogicalColumnReader<TElement>` class provides multiple ways to read data.
 It implements `IEnumerable<TElement>` which internally buffers batches of data and iterates over them,
 but for more fine-grained control over reading behaviour, you can read into your own buffer. For example:
@@ -146,7 +149,7 @@ has the `Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem
 registry key enabled, and the application must have a manifest that specifies it is long path aware,
 for example:
 
-```
+```xml
 <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
         <ws2:longPathAware>true</ws2:longPathAware>

--- a/docs/Reading.md
+++ b/docs/Reading.md
@@ -14,6 +14,7 @@ using var fileReader = new ParquetFileReader(input);
 ```
 
 ### Obtaining file metadata
+
 The `FileMetaData` property of a `ParquetFileReader` exposes information about the Parquet file and its schema:
 ```csharp
 int numColumns = fileReader.FileMetaData.NumColumns;
@@ -41,6 +42,7 @@ for (int rowGroup = 0; rowGroup < fileReader.FileMetaData.NumRowGroups; ++rowGro
 ```
 
 ### Reading columns directly
+
 The `Column` method of `RowGroupReader` takes an integer column index and returns a `ColumnReader` object,
 which can read primitive values from the column, as well as raw definition level and repetition level data.
 Usually you will not want to use a `ColumnReader` directly, but instead call its `LogicalReader` method to
@@ -58,6 +60,7 @@ DateTime[] timestamps = rowGroupReader.Column(0).LogicalReader<DateTime>().ReadA
 ```
 
 ### Reading columns with unknown types
+
 However, if you don't know ahead of time the types for each column, you can implement the
 `ILogicalColumnReaderVisitor<TReturn>` interface to handle column data in a type-safe way, for example:
 
@@ -106,6 +109,7 @@ The .NET type used to represent read values can optionally be overridden by usin
 For more details, see the [type factories documentation](TypeFactories.md).
 
 ## DateTimeKind when reading Timestamps
+
 When reading Timestamp to a DateTime, ParquetSharp sets the DateTimeKind based on the value of `IsAdjustedToUtc`.
 
 If `IsAdjustedToUtc` is `true` the DateTimeKind will be set to `DateTimeKind.Utc` otherwise it will be set to `DateTimeKind.Unspecified`.

--- a/docs/TypeFactories.md
+++ b/docs/TypeFactories.md
@@ -10,17 +10,16 @@ This means that:
 
 The API at the core of this is encompassed by `LogicalTypeFactory`, `LogicalReadConverterFactory` and `LogicalWriteConverterFactory`.
 
-Whenever the user uses a custom type to read or write values to a Parquet file, a `LogicalRead/WriteConverterFactory` needs to be provided. This converter factory tells to the `LogicalColumnReader/Writer` how to convert the user custom type into a physical type that is understood by Parquet.
+Whenever the user uses a custom type to read or write values to a Parquet file, a `LogicalReadConverterFactory` or `LogicalWriteConverterFactory` needs to be provided. This converter factory tells to the `LogicalColumnReader` or `LogicalColumnWriter` how to convert the user custom type into a physical type that is understood by Parquet.
 
-On top of that, if the custom type is used for creating the schema (when writing), or if accessing a `LogicalColumnReader/Writer` without explicitly overriding the element type (e.g. `columnWriter.LogicalReaderOverride<CustomType>()`), then a `LogicalTypeFactory` is needed in order to establish the proper logical type mapping.
+On top of that, if the custom type is used for creating the schema (when writing), or if accessing a `LogicalColumnReader` or `LogicalColumnWriter` without explicitly overriding the element type (e.g. `columnWriter.LogicalReaderOverride<CustomType>()`), then a `LogicalTypeFactory` is needed in order to establish the proper logical type mapping.
 
-In other words, the `LogicalTypeFactory` is required if the user provides a `Column` class with a custom type (writer only, the factory is needed to know the physical parquet type) or gets the `LogicalColumnReader/Writer` via the non type-overriding methods (in which case the factory is needed to know the full type of the logical column reader/writer). The corresponding converter factory is always needed.
+In other words, the `LogicalTypeFactory` is required if the user provides a `Column` class with a custom type (writer only, the factory is needed to know the physical Parquet type) or gets the `LogicalColumnReader/Writer` via the non type-overriding methods (in which case the factory is needed to know the full type of the logical column reader/writer). The corresponding converter factory is always needed.
 
 ## Examples
 
-One of the approaches for reading custom values can be described by the following code.
-
-```C#
+One of the approaches for reading custom values can be described by the following code:
+```csharp
     using var fileReader = new ParquetFileReader(filename) { LogicalReadConverterFactory = new ReadConverterFactory() };
     using var groupReader = fileReader.RowGroup(0);
     using var columnReader = groupReader.Column(0).LogicalReaderOverride<VolumeInDollars>();
@@ -46,4 +45,6 @@ One of the approaches for reading custom values can be described by the followin
     }
 ```
 
-But do check [TestLogicalTypeFactory.cs](../csharp.test/TestLogicalTypeFactory.cs) for a more comprehensive set of examples, as there are many places that can be customized and optimized by the user.
+### Learn More
+
+Check [TestLogicalTypeFactory.cs](../csharp.test/TestLogicalTypeFactory.cs) for a more comprehensive set of examples, as there are many places that can be customized and optimized by the user.

--- a/docs/TypeFactories.md
+++ b/docs/TypeFactories.md
@@ -14,11 +14,12 @@ Whenever the user uses a custom type to read or write values to a Parquet file, 
 
 On top of that, if the custom type is used for creating the schema (when writing), or if accessing a `LogicalColumnReader` or `LogicalColumnWriter` without explicitly overriding the element type (e.g. `columnWriter.LogicalReaderOverride<CustomType>()`), then a `LogicalTypeFactory` is needed in order to establish the proper logical type mapping.
 
-In other words, the `LogicalTypeFactory` is required if the user provides a `Column` class with a custom type (writer only, the factory is needed to know the physical Parquet type) or gets the `LogicalColumnReader/Writer` via the non type-overriding methods (in which case the factory is needed to know the full type of the logical column reader/writer). The corresponding converter factory is always needed.
+In other words, the `LogicalTypeFactory` is required if the user provides a `Column` class with a custom type (writer only, the factory is needed to know the physical Parquet type) or gets the `LogicalColumnReader` or `LogicalColumnWriter` via the non type-overriding methods (in which case the factory is needed to know the full type of the logical column reader/writer). The corresponding converter factory is always needed.
 
 ## Examples
 
 One of the approaches for reading custom values can be described by the following code:
+
 ```csharp
     using var fileReader = new ParquetFileReader(filename) { LogicalReadConverterFactory = new ReadConverterFactory() };
     using var groupReader = fileReader.RowGroup(0);

--- a/docs/Writing.md
+++ b/docs/Writing.md
@@ -6,9 +6,8 @@ The low-level ParquetSharp API provides the `ParquetFileWriter` class for writin
 
 When writing a Parquet file, you must define the schema up-front, which specifies all of the columns
 in the file along with their names and types.
-This schema can be defined using a graph of `ParquetSharp.Schema.Node` instances,
-starting from a root `GroupNode`,
-but ParquetSharp also provides a convenient higher level API for defining the schema as an array
+
+ParquetSharp provides a convenient higher level API for defining the schema as an array
 of `Column` objects.
 A `Column` can be constructed using only a name and a type parameter that is used to
 determine the logical Parquet type to write:
@@ -23,6 +22,9 @@ var columns = new Column[]
 
 using var file = new ParquetFileWriter("float_timeseries.parquet", columns);
 ```
+
+The schema can also be defined using a graph of `ParquetSharp.Schema.Node` instances,
+starting from a root `GroupNode`. For concrete examples, see [How to write a file with nested columns](Nested.md).
 
 ### Overriding logical types
 

--- a/docs/Writing.md
+++ b/docs/Writing.md
@@ -32,6 +32,7 @@ For more control over how values are represented in the Parquet file,
 you can pass a `LogicalType` instance as the `logicalTypeOverride` parameter of the `Column` constructor.
 
 For example, you may wish to write times or timestamps with millisecond resolution rather than the default microsecond resolution:
+
 ```csharp
 var timestampColumn = new Column<DateTime>(
         "Timestamp", LogicalType.Timestamp(isAdjustedToUtc: true, timeUnit: TimeUnit.Millis));
@@ -41,6 +42,7 @@ var timeColumn = new Column<TimeSpan>(
 
 When writing decimal values, you must provide a `logicalTypeOverride` to define the precision and scale type parameters.
 Currently the precision must be 29.
+
 ```csharp
 var decimalColumn = new Column<decimal>("Values", LogicalType.Decimal(precision: 29, scale: 3);
 ```
@@ -79,6 +81,7 @@ using (var stream = new FileStream("float_timeseries.parquet", FileMode.Create))
 
 Parquet data is written in batches of column data named row groups.
 To begin writing data, you first create a new row group:
+
 ```csharp
 using RowGroupWriter rowGroup = file.AppendRowGroup();
 ```

--- a/docs/Writing.md
+++ b/docs/Writing.md
@@ -24,6 +24,8 @@ var columns = new Column[]
 using var file = new ParquetFileWriter("float_timeseries.parquet", columns);
 ```
 
+### Overriding logical types
+
 For more control over how values are represented in the Parquet file,
 you can pass a `LogicalType` instance as the `logicalTypeOverride` parameter of the `Column` constructor.
 
@@ -40,6 +42,8 @@ Currently the precision must be 29.
 ```csharp
 var decimalColumn = new Column<decimal>("Values", LogicalType.Decimal(precision: 29, scale: 3);
 ```
+
+### Metadata
 
 As well as defining the file schema, you may optionally provide key-value metadata that is stored in the file when creating
 a `ParquetFileWriter`:
@@ -100,6 +104,8 @@ you may append another row group to the file and repeat the row group writing pr
 The `NextColumn` method of `RowGroupWriter` returns a `ColumnWriter`, which writes physical values to the file,
 and can write definition level and repetition level data to support nullable and array values.
 
+### Using LogicalColumnWriter
+
 Rather than working with a `ColumnWriter` directly, it's usually more convenient to create a `LogicalColumnWriter`
 with the `ColumnWriter.LogicalWriter<TElement>` method.
 This allows writing an array or `ReadOnlySpan` of `TElement` to the column data,
@@ -131,6 +137,8 @@ for (int columnIndex = 0; columnIndex < file.NumColumns; ++columnIndex)
     var returnVal = logicalWriter.Apply(new ExampleWriter());
 }
 ```
+
+### Closing the ParquetFileWriter
 
 Note that it's important to explicitly call `Close` on the `ParquetFileWriter` when writing is complete,
 as otherwise any errors encountered when writing may be silently ignored:


### PR DESCRIPTION
Hi, I'd like to make a few minor changes to the documentation files to make them more readable.

## Changes:
- Added headers to separate content into bite-sized pieces
  - Makes the documentation easier to browse
  - Improves SEO by adding context to each document
- Standardized whitespaces and punctuation
   - Slightly improves readability (especially for anybody editing docs)
- Reordered `Writing.md` schema creation section to have high-level API shown first, and added an internal link to an example of the graph API
  - This improves developer experience by emphasizing the easier way of doing things while also giving an example for the lower-level API
- Fixed various typos and improved wording
  - Fixed minor typo in code snippet
  - Fixed references to `LogicalColumnWriter` and `LogicalColumnReader` to aid SEO

Feel free to recommend any changes you see fit, particularly regarding the header names if you feel they aren't relevant enough.

Thank you!