### PR TITLE
test: update Microsoft.NET.Test.Sdk

### DIFF
--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Parquet.Net" Version="3.8.6" />


### PR DESCRIPTION
Fix test not runnable from VS UI, even though they are found. Error:

```
The following test container was not found: 'ParquetSharp\csharp.test\bin\Debug\net7.0\ParquetSharp.Test.dll'. This can be resolved by one or more of the following steps:
1. The test container does not exist on disk and the corresponding project might need to be built successfully.
2. For .NET Core based test projects, please ensure that a nuget package reference to "Microsoft.NET.Test.SDK" exists and that it uses the latest stable version.
3. For .NET based test projects, the project might be marked as a non-test project through an msbuild property, "IsTestProject". Please consider clearing it or set "<IsTestProject>true</IsTestProject>" in a "<PropertyGroup>" in the test project.
```