### PR TITLE
Add support for custom conversion logic with Row-oriented API

### DIFF
--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Parquet.Net" Version="3.8.6" />

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -451,7 +451,7 @@ namespace ParquetSharp.Test
             var logicalReadConverterFactory = new ReadConverterFactory();
             var logicalWriteConverterFactory = new WriteConverterFactory();
             var logicalWriteTypeFactory = new WriteTypeFactory();
-            var logicalReadTypeFactory = new ReadTypeFactoryNoOverride();
+            var logicalReadTypeFactory = new ReadTypeFactory();
 
             using (var outputStream = new BufferOutputStream(buffer))
             {
@@ -518,14 +518,14 @@ namespace ParquetSharp.Test
         /// <summary>
         /// A logical type factory that supports our user custom type (for the read tests only). Ignore overrides (used by unit tests that cannot provide a columnLogicalTypeOverride).
         /// </summary>
-        private sealed class ReadTypeFactoryNoOverride : LogicalTypeFactory
+        private sealed class ReadTypeFactory : LogicalTypeFactory
         {
             public override (Type physicalType, Type logicalType) GetSystemTypes(ColumnDescriptor descriptor, Type? columnLogicalTypeOverride)
             {
                 // We have to use the column name to know what type to expose.
                 Assert.IsNull(columnLogicalTypeOverride);
                 using var descriptorPath = descriptor.Path;
-                return base.GetSystemTypes(descriptor, descriptorPath.ToDotVector().First() == "values" ? typeof(VolumeInDollars) : null);
+                return base.GetSystemTypes(descriptor, descriptorPath.ToDotVector().First() == "B" ? typeof(VolumeInDollars) : null);
             }
         }
 

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -461,7 +461,7 @@ namespace ParquetSharp.Test
             }
 
             using var inputStream = new BufferReader(buffer);
-            using var reader = ParquetFile.CreateRowReader<TTupleRead>(inputStream, logicalReadConverterFactory);
+            using var reader = ParquetFile.CreateRowReader<TTupleRead>(inputStream, logicalTypeFactory: logicalTypeFactory, logicalReadConverterFactory: logicalReadConverterFactory);
 
             var values = reader.ReadRows(rowGroup: 0);
             Assert.AreEqual(expectedRows, values);

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -6,6 +6,7 @@ using ParquetSharp.IO;
 using ParquetSharp.RowOriented;
 using NUnit.Framework;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 #if DUMP_EXPRESSION_TREES
 using System.Linq.Expressions;
@@ -454,6 +455,25 @@ namespace ParquetSharp.Test
 
             [ParquetDecimalScale(3)]
             public decimal D { get; set; }
+        }
+
+        private sealed class Row3 : IEquatable<Row3>
+        {
+            public int A;
+            public VolumeInDollars B;
+            public bool Equals(Row3? other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return A == other.A && B.Equals(other.B);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct VolumeInDollars
+        {
+            public VolumeInDollars(float value) { Value = value; }
+            public readonly float Value;
         }
 
         private struct MappedRow1

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -449,9 +449,9 @@ namespace ParquetSharp.Test
         private static void CustomTypeRoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows)
         {
             using var buffer = new ResizableBuffer();
-            var logicalReadConverterFactory = new ReadConverterFactory();
             var logicalWriteConverterFactory = new WriteConverterFactory();
             var logicalWriteTypeFactory = new WriteTypeFactory();
+            var logicalReadConverterFactory = new ReadConverterFactory();
             var logicalReadTypeFactory = new ReadTypeFactory();
 
             using (var outputStream = new BufferOutputStream(buffer))

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -446,7 +446,8 @@ namespace ParquetSharp.Test
             Assert.AreEqual(expectedRows, values);
         }
 
-        private static void CustomTypeRoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[]? columnNames) {
+        private static void CustomTypeRoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[]? columnNames)
+        {
             using var buffer = new ResizableBuffer();
             var logicalReadConverterFactory = new ReadConverterFactory();
             var logicalWriteConverterFactory = new WriteConverterFactory();
@@ -455,7 +456,7 @@ namespace ParquetSharp.Test
 
             using (var outputStream = new BufferOutputStream(buffer))
             {
-                using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream, columnNames, logicalTypeFactory: logicalWriteTypeFactory, logicalWriteConverterFactory: logicalWriteConverterFactory);
+                using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream, columnNames: columnNames, logicalTypeFactory: logicalWriteTypeFactory, logicalWriteConverterFactory: logicalWriteConverterFactory);
 
                 writer.WriteRows(rows);
                 writer.Close();
@@ -499,6 +500,7 @@ namespace ParquetSharp.Test
         {
             public int A;
             public VolumeInDollars B;
+
             public bool Equals(Row3? other)
             {
                 if (ReferenceEquals(null, other)) return false;

--- a/csharp.test/TestRowOrientedParquetFile.cs
+++ b/csharp.test/TestRowOrientedParquetFile.cs
@@ -416,7 +416,7 @@ namespace ParquetSharp.Test
 
         private static void TestCustomTypeRoundtrip<TTuple>(TTuple[] rows)
         {
-            CustomTypeRoundTripAndCompare(rows, rows, columnNames: null);
+            CustomTypeRoundTripAndCompare(rows, rows);
         }
 
         private static void TestRoundtripMapped<TTupleWrite, TTupleRead>(TTupleWrite[] rows)
@@ -446,7 +446,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(expectedRows, values);
         }
 
-        private static void CustomTypeRoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows, string[]? columnNames)
+        private static void CustomTypeRoundTripAndCompare<TTupleWrite, TTupleRead>(TTupleWrite[] rows, IEnumerable<TTupleRead> expectedRows)
         {
             using var buffer = new ResizableBuffer();
             var logicalReadConverterFactory = new ReadConverterFactory();
@@ -456,7 +456,7 @@ namespace ParquetSharp.Test
 
             using (var outputStream = new BufferOutputStream(buffer))
             {
-                using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream, columnNames: columnNames, logicalTypeFactory: logicalWriteTypeFactory, logicalWriteConverterFactory: logicalWriteConverterFactory);
+                using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream, logicalTypeFactory: logicalWriteTypeFactory, logicalWriteConverterFactory: logicalWriteConverterFactory);
 
                 writer.WriteRows(rows);
                 writer.Close();

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -74,20 +74,30 @@ namespace ParquetSharp.RowOriented
             string path,
             string[]? columnNames = null,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             string path,
             WriterProperties writerProperties,
             string[]? columnNames = null,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null),
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         /// <summary>

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -74,7 +74,7 @@ namespace ParquetSharp.RowOriented
             string path,
             string[]? columnNames = null,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
@@ -89,7 +89,7 @@ namespace ParquetSharp.RowOriented
             string path,
             WriterProperties writerProperties,
             string[]? columnNames = null,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null),
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
@@ -107,20 +107,30 @@ namespace ParquetSharp.RowOriented
             OutputStream outputStream,
             string[]? columnNames = null,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             OutputStream outputStream,
             WriterProperties writerProperties,
             string[]? columnNames = null,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         /// <summary>
@@ -131,10 +141,15 @@ namespace ParquetSharp.RowOriented
             string path,
             Column[] columns,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            return new ParquetRowWriter<TTuple>(path, columnsToUse, compression, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(path, columnsToUse, compression, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         /// <summary>
@@ -145,10 +160,15 @@ namespace ParquetSharp.RowOriented
             string path,
             WriterProperties writerProperties,
             Column[] columns,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            return new ParquetRowWriter<TTuple>(path, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(path, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         /// <summary>
@@ -159,10 +179,15 @@ namespace ParquetSharp.RowOriented
             OutputStream outputStream,
             Column[] columns,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, compression, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(outputStream, columnsToUse, compression, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         /// <summary>
@@ -173,10 +198,15 @@ namespace ParquetSharp.RowOriented
             OutputStream outputStream,
             WriterProperties writerProperties,
             Column[] columns,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
+            var writer = new ParquetRowWriter<TTuple>(outputStream, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
+            if (logicalWriteConverterFactory != null) {
+                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            return writer;
         }
 
         private static ParquetRowReader<TTuple>.ReadAction GetOrCreateReadDelegate<TTuple>(MappedField[] fields)

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -20,51 +20,49 @@ namespace ParquetSharp.RowOriented
         /// <summary>
         /// Create a row-oriented reader from a file.
         /// </summary>
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
+            string path,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            var reader = new ParquetRowReader<TTuple>(path, readDelegate, fields);
-            if (logicalReadConverterFactory != null) {
-                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
-            }
-            return reader;
+            return new ParquetRowReader<TTuple>(path, readDelegate, fields, logicalTypeFactory, logicalReadConverterFactory);
         }
 
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path, ReaderProperties readerProperties, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
+            string path,
+            ReaderProperties readerProperties,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            var reader = new ParquetRowReader<TTuple>(path, readerProperties, readDelegate, fields);
-            if (logicalReadConverterFactory != null) {
-                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
-            }
-            return reader;
+            return new ParquetRowReader<TTuple>(path, readerProperties, readDelegate, fields, logicalTypeFactory, logicalReadConverterFactory);
         }
 
         /// <summary>
         /// Create a row-oriented reader from an input stream.
         /// </summary>
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
+            RandomAccessFile randomAccessFile,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            var reader = new ParquetRowReader<TTuple>(randomAccessFile, readDelegate, fields);
-            if (logicalReadConverterFactory != null) {
-                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
-            }
-            return reader;
+            return new ParquetRowReader<TTuple>(randomAccessFile, readDelegate, fields, logicalTypeFactory, logicalReadConverterFactory);
         }
 
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
+            RandomAccessFile randomAccessFile,
+            ReaderProperties readerProperties,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            var reader = new ParquetRowReader<TTuple>(randomAccessFile, readerProperties, readDelegate, fields);
-            if (logicalReadConverterFactory != null) {
-                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
-            }
-            return reader;
+            return new ParquetRowReader<TTuple>(randomAccessFile, readerProperties, readDelegate, fields, logicalTypeFactory, logicalReadConverterFactory);
         }
 
         /// <summary>

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -75,14 +75,11 @@ namespace ParquetSharp.RowOriented
             string[]? columnNames = null,
             Compression compression = Compression.Snappy,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            var writer = new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
@@ -90,14 +87,11 @@ namespace ParquetSharp.RowOriented
             WriterProperties writerProperties,
             string[]? columnNames = null,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            var writer = new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         /// <summary>
@@ -108,14 +102,11 @@ namespace ParquetSharp.RowOriented
             string[]? columnNames = null,
             Compression compression = Compression.Snappy,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            var writer = new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
@@ -123,14 +114,11 @@ namespace ParquetSharp.RowOriented
             WriterProperties writerProperties,
             string[]? columnNames = null,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            var writer = new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         /// <summary>
@@ -142,14 +130,11 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             Compression compression = Compression.Snappy,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            var writer = new ParquetRowWriter<TTuple>(path, columnsToUse, compression, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(path, columnsToUse, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         /// <summary>
@@ -161,14 +146,11 @@ namespace ParquetSharp.RowOriented
             WriterProperties writerProperties,
             Column[] columns,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            var writer = new ParquetRowWriter<TTuple>(path, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(path, columnsToUse, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         /// <summary>
@@ -180,14 +162,11 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             Compression compression = Compression.Snappy,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            var writer = new ParquetRowWriter<TTuple>(outputStream, columnsToUse, compression, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         /// <summary>
@@ -199,14 +178,11 @@ namespace ParquetSharp.RowOriented
             WriterProperties writerProperties,
             Column[] columns,
             IReadOnlyDictionary<string, string>? keyValueMetadata = null,
+            LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            var writer = new ParquetRowWriter<TTuple>(outputStream, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
-            if (logicalWriteConverterFactory != null) {
-                writer.LogicalWriteConverterFactory = logicalWriteConverterFactory;
-            }
-            return writer;
+            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
         }
 
         private static ParquetRowReader<TTuple>.ReadAction GetOrCreateReadDelegate<TTuple>(MappedField[] fields)

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -45,23 +45,26 @@ namespace ParquetSharp.RowOriented
         /// <summary>
         /// Create a row-oriented reader from an input stream.
         /// </summary>
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile, LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            return new ParquetRowReader<TTuple>(randomAccessFile, readDelegate, fields);
+            var reader = new ParquetRowReader<TTuple>(randomAccessFile, readDelegate, fields);
+            if (logicalReadConverterFactory != null) {
+                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
+            }
+            return reader;
         }
 
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile, ReaderProperties readerProperties)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            return new ParquetRowReader<TTuple>(randomAccessFile, readerProperties, readDelegate, fields);
-        }
-
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>()
-        {
-
+            var reader = new ParquetRowReader<TTuple>(randomAccessFile, readerProperties, readDelegate, fields);
+            if (logicalReadConverterFactory != null) {
+                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
+            }
+            return reader;
         }
 
         /// <summary>

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -20,10 +20,44 @@ namespace ParquetSharp.RowOriented
         /// <summary>
         /// Create a row-oriented reader from a file.
         /// </summary>
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path)
+        {
+            var fields = GetFieldsAndProperties(typeof(TTuple));
+            var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
+            return new ParquetRowReader<TTuple>(path, readDelegate, fields);
+        }
+
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path, ReaderProperties readerProperties)
+        {
+            var fields = GetFieldsAndProperties(typeof(TTuple));
+            var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
+            return new ParquetRowReader<TTuple>(path, readerProperties, readDelegate, fields);
+        }
+
+        /// <summary>
+        /// Create a row-oriented reader from an input stream.
+        /// </summary>
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile)
+        {
+            var fields = GetFieldsAndProperties(typeof(TTuple));
+            var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
+            return new ParquetRowReader<TTuple>(randomAccessFile, readDelegate, fields);
+        }
+
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(RandomAccessFile randomAccessFile, ReaderProperties readerProperties)
+        {
+            var fields = GetFieldsAndProperties(typeof(TTuple));
+            var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
+            return new ParquetRowReader<TTuple>(randomAccessFile, readerProperties, readDelegate, fields);
+        }
+
+        /// <summary>
+        /// Create a row-oriented reader from a file using custom types.
+        /// </summary>
         public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
             string path,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalReadConverterFactory logicalReadConverterFactory)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
@@ -33,8 +67,8 @@ namespace ParquetSharp.RowOriented
         public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
             string path,
             ReaderProperties readerProperties,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalReadConverterFactory logicalReadConverterFactory)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
@@ -42,12 +76,12 @@ namespace ParquetSharp.RowOriented
         }
 
         /// <summary>
-        /// Create a row-oriented reader from an input stream.
+        /// Create a row-oriented reader from an input stream using custom types.
         /// </summary>
         public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
             RandomAccessFile randomAccessFile,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalReadConverterFactory logicalReadConverterFactory)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
@@ -57,8 +91,8 @@ namespace ParquetSharp.RowOriented
         public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(
             RandomAccessFile randomAccessFile,
             ReaderProperties readerProperties,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalReadConverterFactory logicalReadConverterFactory)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
@@ -72,24 +106,20 @@ namespace ParquetSharp.RowOriented
             string path,
             string[]? columnNames = null,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+            return new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate);
         }
 
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             string path,
             WriterProperties writerProperties,
             string[]? columnNames = null,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+            return new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate);
         }
 
         /// <summary>
@@ -99,24 +129,20 @@ namespace ParquetSharp.RowOriented
             OutputStream outputStream,
             string[]? columnNames = null,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+            return new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate);
         }
 
         public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
             OutputStream outputStream,
             WriterProperties writerProperties,
             string[]? columnNames = null,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
-            return new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+            return new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate);
         }
 
         /// <summary>
@@ -127,12 +153,10 @@ namespace ParquetSharp.RowOriented
             string path,
             Column[] columns,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            return new ParquetRowWriter<TTuple>(path, columnsToUse, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+            return new ParquetRowWriter<TTuple>(path, columnsToUse, compression, keyValueMetadata, writeDelegate);
         }
 
         /// <summary>
@@ -143,12 +167,10 @@ namespace ParquetSharp.RowOriented
             string path,
             WriterProperties writerProperties,
             Column[] columns,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            return new ParquetRowWriter<TTuple>(path, columnsToUse, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+            return new ParquetRowWriter<TTuple>(path, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
         }
 
         /// <summary>
@@ -159,12 +181,10 @@ namespace ParquetSharp.RowOriented
             OutputStream outputStream,
             Column[] columns,
             Compression compression = Compression.Snappy,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
-            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, compression, keyValueMetadata, writeDelegate);
         }
 
         /// <summary>
@@ -175,12 +195,128 @@ namespace ParquetSharp.RowOriented
             OutputStream outputStream,
             WriterProperties writerProperties,
             Column[] columns,
-            IReadOnlyDictionary<string, string>? keyValueMetadata = null,
-            LogicalTypeFactory? logicalTypeFactory = null,
-            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
         {
             var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
             return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, writerProperties, keyValueMetadata, writeDelegate);
+        }
+
+        /// <summary>
+        /// Create a row-oriented writer to a file using custom types. By default, the column names are reflected from the tuple public fields and properties.
+        /// </summary>
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            string path,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            string[]? columnNames = null,
+            Compression compression = Compression.Snappy,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
+            return new ParquetRowWriter<TTuple>(path, columns, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+        }
+
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            string path,
+            WriterProperties writerProperties,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            string[]? columnNames = null,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
+            return new ParquetRowWriter<TTuple>(path, columns, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+        }
+
+        /// <summary>
+        /// Create a row-oriented writer to an output stream using custom types. By default, the column names are reflected from the tuple public fields and properties.
+        /// </summary>
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            OutputStream outputStream,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            string[]? columnNames = null,
+            Compression compression = Compression.Snappy,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
+            return new ParquetRowWriter<TTuple>(outputStream, columns, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+        }
+
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            OutputStream outputStream,
+            WriterProperties writerProperties,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            string[]? columnNames = null,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columns, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columnNames);
+            return new ParquetRowWriter<TTuple>(outputStream, columns, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+        }
+
+        /// <summary>
+        /// Create a row-oriented writer to a file path using the specified column definitions and custom types.
+        /// Note that any MapToColumn or ParquetDecimalScale attributes will be overridden by the column definitions.
+        /// </summary>
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            string path,
+            Column[] columns,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            Compression compression = Compression.Snappy,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
+            return new ParquetRowWriter<TTuple>(path, columnsToUse, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+        }
+
+        /// <summary>
+        /// Create a row-oriented writer to a file path using the specified writerProperties and column definitions and custom types.
+        /// Note that any MapToColumn or ParquetDecimalScale attributes will be overridden by the column definitions.
+        /// </summary>
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            string path,
+            WriterProperties writerProperties,
+            Column[] columns,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
+            return new ParquetRowWriter<TTuple>(path, columnsToUse, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+        }
+
+        /// <summary>
+        /// Create a row-oriented writer to an output stream using the specified column definitions and custom types.
+        /// Note that any MapToColumn or ParquetDecimalScale attributes will be overridden by the column definitions.
+        /// </summary>
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            OutputStream outputStream,
+            Column[] columns,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            Compression compression = Compression.Snappy,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
+            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, compression, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
+        }
+
+        /// <summary>
+        /// Create a row-oriented writer to an output stream using the specified writerProperties, column definitions and custom types.
+        /// Note that any MapToColumn or ParquetDecimalScale attributes will be overridden by the column definitions.
+        /// </summary>
+        public static ParquetRowWriter<TTuple> CreateRowWriter<TTuple>(
+            OutputStream outputStream,
+            WriterProperties writerProperties,
+            Column[] columns,
+            LogicalTypeFactory logicalTypeFactory,
+            LogicalWriteConverterFactory logicalWriteConverterFactory,
+            IReadOnlyDictionary<string, string>? keyValueMetadata = null)
+        {
+            var (columnsToUse, writeDelegate) = GetOrCreateWriteDelegate<TTuple>(columns);
+            return new ParquetRowWriter<TTuple>(outputStream, columnsToUse, writerProperties, keyValueMetadata, writeDelegate, logicalTypeFactory, logicalWriteConverterFactory);
         }
 
         private static ParquetRowReader<TTuple>.ReadAction GetOrCreateReadDelegate<TTuple>(MappedField[] fields)

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -31,11 +31,15 @@ namespace ParquetSharp.RowOriented
             return reader;
         }
 
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path, ReaderProperties readerProperties)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path, ReaderProperties readerProperties, LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            return new ParquetRowReader<TTuple>(path, readerProperties, readDelegate, fields);
+            var reader = new ParquetRowReader<TTuple>(path, readerProperties, readDelegate, fields);
+            if (logicalReadConverterFactory != null) {
+                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
+            }
+            return reader;
         }
 
         /// <summary>

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -20,11 +20,15 @@ namespace ParquetSharp.RowOriented
         /// <summary>
         /// Create a row-oriented reader from a file.
         /// </summary>
-        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path)
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path, LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
-            return new ParquetRowReader<TTuple>(path, readDelegate, fields);
+            var reader = new ParquetRowReader<TTuple>(path, readDelegate, fields);
+            if (logicalReadConverterFactory != null) {
+                reader.LogicalReadConverterFactory = logicalReadConverterFactory;
+            }
+            return reader;
         }
 
         public static ParquetRowReader<TTuple> CreateRowReader<TTuple>(string path, ReaderProperties readerProperties)
@@ -49,6 +53,11 @@ namespace ParquetSharp.RowOriented
             var fields = GetFieldsAndProperties(typeof(TTuple));
             var readDelegate = GetOrCreateReadDelegate<TTuple>(fields);
             return new ParquetRowReader<TTuple>(randomAccessFile, readerProperties, readDelegate, fields);
+        }
+
+        public static ParquetRowReader<TTuple> CreateRowReader<TTuple>()
+        {
+
         }
 
         /// <summary>

--- a/csharp/RowOriented/ParquetRowReader.cs
+++ b/csharp/RowOriented/ParquetRowReader.cs
@@ -129,6 +129,9 @@ namespace ParquetSharp.RowOriented
         private readonly ParquetFileReader _parquetFileReader;
         private readonly ReadAction _readAction;
         private readonly ExplicitColumnMapping? _columnMapping;
-        private RowGroupReader? _rowGroupReader;
+        private RowGroupReader? _rowGroupReader;        
+
+        public LogicalTypeFactory LogicalTypeFactory { get; set; } = LogicalTypeFactory.Default;
+        public LogicalReadConverterFactory LogicalReadConverterFactory { get; set; } = LogicalReadConverterFactory.Default;
     }
 }

--- a/csharp/RowOriented/ParquetRowReader.cs
+++ b/csharp/RowOriented/ParquetRowReader.cs
@@ -14,63 +14,42 @@ namespace ParquetSharp.RowOriented
         internal delegate void ReadAction(ParquetRowReader<TTuple> parquetRowReader, TTuple[] rows, int length);
 
         /// <summary>
-        /// Create a new ParquetRowReader without custom logical type support.
+        /// Create a new ParquetRowReader.
         /// </summary>
-        internal ParquetRowReader(string path, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(path), readAction, fields)
-        {
-        }
-
-        internal ParquetRowReader(string path, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(path, readerProperties), readAction, fields)
-        {
-        }
-
-        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(randomAccessFile), readAction, fields)
-        {
-        }
-
-        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(randomAccessFile, readerProperties), readAction, fields)
-        {
-        }
-
-        /// <summary>
-        /// Create a new ParquetRowReader with custom logical type support.
-        /// </summary>
-        internal ParquetRowReader(string path, ReadAction readAction, MappedField[] fields, LogicalTypeFactory logicalTypeFactory, LogicalReadConverterFactory logicalReadConverterFactory)
+        internal ParquetRowReader(string path, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
             : this(new ParquetFileReader(path), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(string path, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory logicalTypeFactory, LogicalReadConverterFactory logicalReadConverterFactory)
+        internal ParquetRowReader(string path, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
             : this(new ParquetFileReader(path, readerProperties), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReadAction readAction, MappedField[] fields, LogicalTypeFactory logicalTypeFactory, LogicalReadConverterFactory logicalReadConverterFactory)
+        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
             : this(new ParquetFileReader(randomAccessFile), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory logicalTypeFactory, LogicalReadConverterFactory logicalReadConverterFactory)
+        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
             : this(new ParquetFileReader(randomAccessFile, readerProperties), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(ParquetFileReader parquetFileReader, ReadAction readAction, MappedField[] fields)
+        internal ParquetRowReader(ParquetFileReader parquetFileReader, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             _parquetFileReader = parquetFileReader;
-            _readAction = readAction;
-            _columnMapping = HasExplicitColumnMapping(fields) ? new ExplicitColumnMapping(this, fields) : null;
-        }
 
-        internal ParquetRowReader(ParquetFileReader parquetFileReader, ReadAction readAction, MappedField[] fields, LogicalTypeFactory logicalTypeFactory, LogicalReadConverterFactory logicalReadConverterFactory)
-        {
-            _parquetFileReader = parquetFileReader;
-            _parquetFileReader.LogicalTypeFactory = logicalTypeFactory;
-            _parquetFileReader.LogicalReadConverterFactory = logicalReadConverterFactory;
+            if (logicalTypeFactory != null)
+            {
+                _parquetFileReader.LogicalTypeFactory = logicalTypeFactory;
+            }
+
+            if (logicalReadConverterFactory != null)
+            {
+                _parquetFileReader.LogicalReadConverterFactory = logicalReadConverterFactory;
+            }
+            
             _readAction = readAction;
             _columnMapping = HasExplicitColumnMapping(fields) ? new ExplicitColumnMapping(this, fields) : null;
         }
@@ -165,8 +144,5 @@ namespace ParquetSharp.RowOriented
         private readonly ReadAction _readAction;
         private readonly ExplicitColumnMapping? _columnMapping;
         private RowGroupReader? _rowGroupReader;
-
-        public LogicalTypeFactory LogicalTypeFactory { get; set; } = LogicalTypeFactory.Default;
-        public LogicalReadConverterFactory LogicalReadConverterFactory { get; set; } = LogicalReadConverterFactory.Default;
     }
 }

--- a/csharp/RowOriented/ParquetRowReader.cs
+++ b/csharp/RowOriented/ParquetRowReader.cs
@@ -49,7 +49,7 @@ namespace ParquetSharp.RowOriented
             {
                 _parquetFileReader.LogicalReadConverterFactory = logicalReadConverterFactory;
             }
-            
+
             _readAction = readAction;
             _columnMapping = HasExplicitColumnMapping(fields) ? new ExplicitColumnMapping(this, fields) : null;
         }

--- a/csharp/RowOriented/ParquetRowReader.cs
+++ b/csharp/RowOriented/ParquetRowReader.cs
@@ -13,29 +13,30 @@ namespace ParquetSharp.RowOriented
     {
         internal delegate void ReadAction(ParquetRowReader<TTuple> parquetRowReader, TTuple[] rows, int length);
 
-        internal ParquetRowReader(string path, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(path), readAction, fields)
+        internal ParquetRowReader(string path, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            : this(new ParquetFileReader(path), readAction, fields, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(string path, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(path, readerProperties), readAction, fields)
+        internal ParquetRowReader(string path, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            : this(new ParquetFileReader(path, readerProperties), readAction, fields, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(randomAccessFile), readAction, fields)
+        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            : this(new ParquetFileReader(randomAccessFile), readAction, fields, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields)
-            : this(new ParquetFileReader(randomAccessFile, readerProperties), readAction, fields)
+        internal ParquetRowReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+            : this(new ParquetFileReader(randomAccessFile, readerProperties), readAction, fields, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(ParquetFileReader parquetFileReader, ReadAction readAction, MappedField[] fields)
+        internal ParquetRowReader(ParquetFileReader parquetFileReader, ReadAction readAction, MappedField[] fields, LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             _parquetFileReader = parquetFileReader;
+            _parquetFileReader.LogicalReadConverterFactory = logicalReadConverterFactory ?? LogicalReadConverterFactory.Default;
             _readAction = readAction;
             _columnMapping = HasExplicitColumnMapping(fields) ? new ExplicitColumnMapping(this, fields) : null;
         }

--- a/csharp/RowOriented/ParquetRowReader.cs
+++ b/csharp/RowOriented/ParquetRowReader.cs
@@ -14,28 +14,29 @@ namespace ParquetSharp.RowOriented
         internal delegate void ReadAction(ParquetRowReader<TTuple> parquetRowReader, TTuple[] rows, int length);
 
         internal ParquetRowReader(string path, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
-            : this(new ParquetFileReader(path), readAction, fields, logicalReadConverterFactory)
+            : this(new ParquetFileReader(path), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
         internal ParquetRowReader(string path, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
-            : this(new ParquetFileReader(path, readerProperties), readAction, fields, logicalReadConverterFactory)
+            : this(new ParquetFileReader(path, readerProperties), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
         internal ParquetRowReader(RandomAccessFile randomAccessFile, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
-            : this(new ParquetFileReader(randomAccessFile), readAction, fields, logicalReadConverterFactory)
+            : this(new ParquetFileReader(randomAccessFile), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
         internal ParquetRowReader(RandomAccessFile randomAccessFile, ReaderProperties readerProperties, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
-            : this(new ParquetFileReader(randomAccessFile, readerProperties), readAction, fields, logicalReadConverterFactory)
+            : this(new ParquetFileReader(randomAccessFile, readerProperties), readAction, fields, logicalTypeFactory, logicalReadConverterFactory)
         {
         }
 
-        internal ParquetRowReader(ParquetFileReader parquetFileReader, ReadAction readAction, MappedField[] fields, LogicalReadConverterFactory? logicalReadConverterFactory = null)
+        internal ParquetRowReader(ParquetFileReader parquetFileReader, ReadAction readAction, MappedField[] fields, LogicalTypeFactory? logicalTypeFactory = null, LogicalReadConverterFactory? logicalReadConverterFactory = null)
         {
             _parquetFileReader = parquetFileReader;
+            _parquetFileReader.LogicalTypeFactory = logicalTypeFactory ?? LogicalTypeFactory.Default;
             _parquetFileReader.LogicalReadConverterFactory = logicalReadConverterFactory ?? LogicalReadConverterFactory.Default;
             _readAction = readAction;
             _columnMapping = HasExplicitColumnMapping(fields) ? new ExplicitColumnMapping(this, fields) : null;

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -13,45 +13,6 @@ namespace ParquetSharp.RowOriented
     {
         internal delegate void WriteAction(ParquetRowWriter<TTuple> parquetRowWriter, TTuple[] rows, int length);
 
-        internal ParquetRowWriter(
-            string path,
-            Column[] columns,
-            Compression compression,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(path, columns, compression, keyValueMetadata), writeAction)
-        {
-        }
-
-        internal ParquetRowWriter(
-            string path,
-            Column[] columns,
-            WriterProperties writerProperties,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(path, columns, writerProperties, keyValueMetadata), writeAction)
-        {
-        }
-
-        internal ParquetRowWriter(
-            OutputStream outputStream,
-            Column[] columns,
-            Compression compression,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(outputStream, columns, compression, keyValueMetadata), writeAction)
-        {
-        }
-
-        internal ParquetRowWriter(
-            OutputStream outputStream,
-            Column[] columns,
-            WriterProperties writerProperties,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(outputStream, columns, writerProperties, keyValueMetadata), writeAction)
-        {
-        }
 
         internal ParquetRowWriter(
             string path,

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -109,7 +109,7 @@ namespace ParquetSharp.RowOriented
             {
                 _parquetFileWriter.LogicalWriteConverterFactory = logicalWriteConverterFactory;
             }
-            
+
             _rowGroupWriter = _parquetFileWriter.AppendRowGroup();
             _writeAction = writeAction;
             _rows = new TTuple[1024];

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -18,8 +18,10 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             Compression compression,
             IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(path, columns, compression, keyValueMetadata), writeAction)
+            WriteAction writeAction,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            : this(new ParquetFileWriter(path, columns, logicalTypeFactory, compression, keyValueMetadata), writeAction, logicalWriteConverterFactory)
         {
         }
 
@@ -28,8 +30,10 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             WriterProperties writerProperties,
             IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(path, columns, writerProperties, keyValueMetadata), writeAction)
+            WriteAction writeAction,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            : this(new ParquetFileWriter(path, columns, logicalTypeFactory, writerProperties, keyValueMetadata), writeAction, logicalWriteConverterFactory)
         {
         }
 
@@ -38,8 +42,10 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             Compression compression,
             IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(outputStream, columns, compression, keyValueMetadata), writeAction)
+            WriteAction writeAction,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            : this(new ParquetFileWriter(outputStream, columns, logicalTypeFactory, compression, keyValueMetadata), writeAction, logicalWriteConverterFactory)
         {
         }
 
@@ -48,14 +54,17 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             WriterProperties writerProperties,
             IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(outputStream, columns, writerProperties, keyValueMetadata), writeAction)
+            WriteAction writeAction,
+            LogicalTypeFactory? logicalTypeFactory = null,
+            LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
+            : this(new ParquetFileWriter(outputStream, columns, logicalTypeFactory, writerProperties, keyValueMetadata), writeAction, logicalWriteConverterFactory)
         {
         }
 
-        private ParquetRowWriter(ParquetFileWriter parquetFileWriter, WriteAction writeAction)
+        private ParquetRowWriter(ParquetFileWriter parquetFileWriter, WriteAction writeAction, LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             _parquetFileWriter = parquetFileWriter;
+            _parquetFileWriter.LogicalWriteConverterFactory = logicalWriteConverterFactory ?? LogicalWriteConverterFactory.Default;
             _rowGroupWriter = _parquetFileWriter.AppendRowGroup();
             _writeAction = writeAction;
             _rows = new TTuple[1024];

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -18,46 +18,6 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             Compression compression,
             IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(path, columns, compression), writeAction)
-        {
-        }
-
-        internal ParquetRowWriter(
-            string path,
-            Column[] columns,
-            WriterProperties writerProperties,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(path, columns, writerProperties, keyValueMetadata), writeAction)
-        {
-        }
-
-        internal ParquetRowWriter(
-            OutputStream outputStream,
-            Column[] columns,
-            Compression compression,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(outputStream, columns, compression, keyValueMetadata), writeAction)
-        {
-        }
-
-        internal ParquetRowWriter(
-            OutputStream outputStream,
-            Column[] columns,
-            WriterProperties writerProperties,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
-            WriteAction writeAction)
-            : this(new ParquetFileWriter(outputStream, columns, writerProperties, keyValueMetadata), writeAction)
-        {
-        }
-
-        internal ParquetRowWriter(
-            string path,
-            Column[] columns,
-            Compression compression,
-            IReadOnlyDictionary<string, string>? keyValueMetadata,
             WriteAction writeAction,
             LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
@@ -101,18 +61,15 @@ namespace ParquetSharp.RowOriented
         {
         }
 
-        private ParquetRowWriter(ParquetFileWriter parquetFileWriter, WriteAction writeAction)
-        {
-            _parquetFileWriter = parquetFileWriter;
-            _rowGroupWriter = _parquetFileWriter.AppendRowGroup();
-            _writeAction = writeAction;
-            _rows = new TTuple[1024];
-        }
-
         private ParquetRowWriter(ParquetFileWriter parquetFileWriter, WriteAction writeAction, LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
         {
             _parquetFileWriter = parquetFileWriter;
-            _parquetFileWriter.LogicalWriteConverterFactory = logicalWriteConverterFactory ?? LogicalWriteConverterFactory.Default;
+
+            if (logicalWriteConverterFactory != null)
+            {
+                _parquetFileWriter.LogicalWriteConverterFactory = logicalWriteConverterFactory;
+            }
+            
             _rowGroupWriter = _parquetFileWriter.AppendRowGroup();
             _writeAction = writeAction;
             _rows = new TTuple[1024];
@@ -135,8 +92,6 @@ namespace ParquetSharp.RowOriented
         public ColumnDescriptor ColumnDescriptor(int i) => _parquetFileWriter.ColumnDescriptor(i);
         public FileMetaData? FileMetaData => _parquetFileWriter.FileMetaData;
         public IReadOnlyDictionary<string, string> KeyValueMetadata => _parquetFileWriter.KeyValueMetadata;
-        public LogicalTypeFactory LogicalTypeFactory { get; set; } = LogicalTypeFactory.Default;
-        public LogicalWriteConverterFactory LogicalWriteConverterFactory { get; set; } = LogicalWriteConverterFactory.Default;
 
         public void StartNewRowGroup()
         {

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -78,6 +78,8 @@ namespace ParquetSharp.RowOriented
         public ColumnDescriptor ColumnDescriptor(int i) => _parquetFileWriter.ColumnDescriptor(i);
         public FileMetaData? FileMetaData => _parquetFileWriter.FileMetaData;
         public IReadOnlyDictionary<string, string> KeyValueMetadata => _parquetFileWriter.KeyValueMetadata;
+        public LogicalTypeFactory LogicalTypeFactory { get; set; } = LogicalTypeFactory.Default;
+        public LogicalWriteConverterFactory LogicalWriteConverterFactory { get; set; } = LogicalWriteConverterFactory.Default;
 
         public void StartNewRowGroup()
         {

--- a/csharp/RowOriented/ParquetRowWriter.cs
+++ b/csharp/RowOriented/ParquetRowWriter.cs
@@ -18,6 +18,46 @@ namespace ParquetSharp.RowOriented
             Column[] columns,
             Compression compression,
             IReadOnlyDictionary<string, string>? keyValueMetadata,
+            WriteAction writeAction)
+            : this(new ParquetFileWriter(path, columns, compression), writeAction)
+        {
+        }
+
+        internal ParquetRowWriter(
+            string path,
+            Column[] columns,
+            WriterProperties writerProperties,
+            IReadOnlyDictionary<string, string>? keyValueMetadata,
+            WriteAction writeAction)
+            : this(new ParquetFileWriter(path, columns, writerProperties, keyValueMetadata), writeAction)
+        {
+        }
+
+        internal ParquetRowWriter(
+            OutputStream outputStream,
+            Column[] columns,
+            Compression compression,
+            IReadOnlyDictionary<string, string>? keyValueMetadata,
+            WriteAction writeAction)
+            : this(new ParquetFileWriter(outputStream, columns, compression, keyValueMetadata), writeAction)
+        {
+        }
+
+        internal ParquetRowWriter(
+            OutputStream outputStream,
+            Column[] columns,
+            WriterProperties writerProperties,
+            IReadOnlyDictionary<string, string>? keyValueMetadata,
+            WriteAction writeAction)
+            : this(new ParquetFileWriter(outputStream, columns, writerProperties, keyValueMetadata), writeAction)
+        {
+        }
+
+        internal ParquetRowWriter(
+            string path,
+            Column[] columns,
+            Compression compression,
+            IReadOnlyDictionary<string, string>? keyValueMetadata,
             WriteAction writeAction,
             LogicalTypeFactory? logicalTypeFactory = null,
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
@@ -59,6 +99,14 @@ namespace ParquetSharp.RowOriented
             LogicalWriteConverterFactory? logicalWriteConverterFactory = null)
             : this(new ParquetFileWriter(outputStream, columns, logicalTypeFactory, writerProperties, keyValueMetadata), writeAction, logicalWriteConverterFactory)
         {
+        }
+
+        private ParquetRowWriter(ParquetFileWriter parquetFileWriter, WriteAction writeAction)
+        {
+            _parquetFileWriter = parquetFileWriter;
+            _rowGroupWriter = _parquetFileWriter.AppendRowGroup();
+            _writeAction = writeAction;
+            _rows = new TTuple[1024];
         }
 
         private ParquetRowWriter(ParquetFileWriter parquetFileWriter, WriteAction writeAction, LogicalWriteConverterFactory? logicalWriteConverterFactory = null)

--- a/docs/RowOriented.md
+++ b/docs/RowOriented.md
@@ -70,7 +70,7 @@ using (var rowReader = ParquetFile.CreateRowReader<MyRow>("example.parquet"))
 
 ## Reading and writing custom types
 
-The row-oriented API supports reading and writing custom types by providing a `LogicalReadConverterFactory` or `LogicalWriteConverterFactory`.
+The row-oriented API supports reading and writing custom types by providing a `LogicalTypeFactory` and a `LogicalReadConverterFactory` or `LogicalWriteConverterFactory`.
 
 ### Writing custom types
 

--- a/docs/RowOriented.md
+++ b/docs/RowOriented.md
@@ -68,6 +68,120 @@ using (var rowReader = ParquetFile.CreateRowReader<MyRow>("example.parquet"))
 }
 ```
 
+## Reading and writing custom types
+
+The row-oriented API supports reading and writing custom types by providing a `LogicalReadConverterFactory` or `LogicalWriteConverterFactory`.
+The `LogicalTypeFactory` is required if the custom type is used for creating the schema (when writing), or if accessing a `LogicalColumnReader`
+or `LogicalColumnWriter` without explicitly overriding the element type (e.g. `columnWriter.LogicalReaderOverride<CustomType>()`). It is needed
+in order to establish the proper logical type mapping.
+
+### Writing custom types
+
+```csharp
+using var buffer = new ResizableBuffer();
+var logicalWriteConverterFactory = new WriteConverterFactory();
+var logicalWriteTypeFactory = new WriteTypeFactory();
+
+var rows = new[]
+            {
+                new Row3 {A = 123, B = new VolumeInDollars(3.14f)},
+                new Row3 {A = 456, B = new VolumeInDollars(1.27f)},
+                new Row3 {A = 789, B = new VolumeInDollars(6.66f)}
+            };
+
+using (var outputStream = new BufferOutputStream(buffer))
+{
+    using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream, logicalTypeFactory: logicalWriteTypeFactory, logicalWriteConverterFactory: logicalWriteConverterFactory);
+
+    writer.WriteRows(rows);
+    writer.Close();
+}
+```
+
+### Reading custom types
+
+```csharp
+using var buffer = new ResizableBuffer();
+var logicalReadConverterFactory = new ReadConverterFactory();
+var logicalReadTypeFactory = new ReadTypeFactory();
+
+using var inputStream = new BufferReader(buffer);
+using var reader = ParquetFile.CreateRowReader<TTupleRead>(inputStream, logicalTypeFactory: logicalReadTypeFactory, logicalReadConverterFactory: logicalReadConverterFactory);
+
+var values = reader.ReadRows(rowGroup: 0);
+```
+
+### Example types and factories
+```csharp
+private sealed class Row3 : IEquatable<Row3>
+{
+    public int A;
+    public VolumeInDollars B;
+
+    public bool Equals(Row3? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return A == other.A && B.Equals(other.B);
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+private readonly struct VolumeInDollars : IEquatable<VolumeInDollars>
+{
+    public VolumeInDollars(float value) { Value = value; }
+    public readonly float Value;
+    public bool Equals(VolumeInDollars other) => Value.Equals(other.Value);
+}
+
+private sealed class WriteTypeFactory : LogicalTypeFactory
+{
+    public override bool TryGetParquetTypes(Type logicalSystemType, out (LogicalType? logicalType, Repetition repetition, PhysicalType physicalType) entry)
+    {
+        if (logicalSystemType == typeof(VolumeInDollars)) return base.TryGetParquetTypes(typeof(float), out entry);
+        return base.TryGetParquetTypes(logicalSystemType, out entry);
+    }
+}
+
+private sealed class WriteConverterFactory : LogicalWriteConverterFactory
+{
+    public override Delegate GetConverter<TLogical, TPhysical>(ColumnDescriptor columnDescriptor, ByteBuffer? byteBuffer)
+    {
+        if (typeof(TLogical) == typeof(VolumeInDollars)) return LogicalWrite.GetNativeConverter<VolumeInDollars, float>();
+        return base.GetConverter<TLogical, TPhysical>(columnDescriptor, byteBuffer);
+    }
+}
+
+private sealed class ReadTypeFactory : LogicalTypeFactory
+{
+    public override (Type physicalType, Type logicalType) GetSystemTypes(ColumnDescriptor descriptor, Type? columnLogicalTypeOverride)
+    {
+        // We have to use the column name to know what type to expose.
+        Assert.IsNull(columnLogicalTypeOverride);
+        using var descriptorPath = descriptor.Path;
+        return base.GetSystemTypes(descriptor, descriptorPath.ToDotVector().First() == "B" ? typeof(VolumeInDollars) : null);
+    }
+}
+
+private sealed class ReadConverterFactory : LogicalReadConverterFactory
+{
+    public override Delegate? GetDirectReader<TLogical, TPhysical>()
+    {
+        // Optional: the following is an optimisation and not stricly needed (but helps with speed).
+        // Since VolumeInDollars is bitwise identical to float, we can read the values in-place.
+        if (typeof(TLogical) == typeof(VolumeInDollars)) return LogicalRead.GetDirectReader<VolumeInDollars, float>();
+        return base.GetDirectReader<TLogical, TPhysical>();
+    }
+
+    public override Delegate GetConverter<TLogical, TPhysical>(ColumnDescriptor columnDescriptor, ColumnChunkMetaData columnChunkMetaData)
+    {
+        // VolumeInDollars is bitwise identical to float, so we can reuse the native converter.
+        if (typeof(TLogical) == typeof(VolumeInDollars)) return LogicalRead.GetNativeConverter<VolumeInDollars, float>();
+        return base.GetConverter<TLogical, TPhysical>(columnDescriptor, columnChunkMetaData);
+    }
+}
+```
+
 ## Using the row-oriented API from F#
 
 The row-oriented API works with F# types,

--- a/docs/RowOriented.md
+++ b/docs/RowOriented.md
@@ -71,9 +71,6 @@ using (var rowReader = ParquetFile.CreateRowReader<MyRow>("example.parquet"))
 ## Reading and writing custom types
 
 The row-oriented API supports reading and writing custom types by providing a `LogicalReadConverterFactory` or `LogicalWriteConverterFactory`.
-The `LogicalTypeFactory` is required if the custom type is used for creating the schema (when writing), or if accessing a `LogicalColumnReader`
-or `LogicalColumnWriter` without explicitly overriding the element type (e.g. `columnWriter.LogicalReaderOverride<CustomType>()`). It is needed
-in order to establish the proper logical type mapping.
 
 ### Writing custom types
 


### PR DESCRIPTION
### Changelog:
- Added support for custom conversion logic for Row-oriented API
  - Allow passing the `LogicalReadConverterFactory` and `LogicalTypeFactory` when invoking `ParquetFile.CreateRowReader()`
  - Allow passing the `LogicalWriteConverterFactory` and `LogicalTypeFactory` when invoking `ParquetFile.CreateRowWriter()`
  - Made internal changes to `ParquetFile`, `ParquetRowReader` and `ParquetRowWriter` to allow setting the factories
  - Added a unit test for new feature

**Note:** Currently, argument names must be explicitly mentioned when using the logical factories for writing:
`using var writer = ParquetFile.CreateRowWriter<TTupleWrite>(outputStream, columnNames: columnNames, logicalTypeFactory: logicalWriteTypeFactory, logicalWriteConverterFactory: logicalWriteConverterFactory);`

I wasn't sure how to implement the overloads in such a way that specifying the argument names isn't necessary.

I'm happy to implement any changes or suggestions you see fit to improve the readability and maintainability of the feature!