### PR TITLE
Upgrade Arrow C++ to 14.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ devcontainer exec dotnet test csharp.test
 Building ParquetSharp natively requires the following dependencies:
 - A modern C++ compiler toolchain
 - .NET SDK 7.0
-- Apache Arrow (14.0.1)
+- Apache Arrow (14.0.2)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://vcpkg.io).
 The build scripts will use an existing vcpkg installation if either of the `VCPKG_INSTALLATION_ROOT` or `VCPKG_ROOT` environment variables are defined, otherwise vcpkg will be downloaded into the build directory.

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -163,7 +163,7 @@ namespace ParquetSharp.Test
 
             var numRows = expectedColumns.First().Values.Length;
 
-            Assert.AreEqual("parquet-cpp-arrow version 14.0.1", fileMetaData.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 14.0.2", fileMetaData.CreatedBy);
             Assert.AreEqual(new Dictionary<string, string> {{"case", "Test"}, {"Awesome", "true"}}, fileMetaData.KeyValueMetadata);
             Assert.AreEqual(expectedColumns.Length, fileMetaData.NumColumns);
             Assert.AreEqual(numRows, fileMetaData.NumRows);
@@ -174,7 +174,7 @@ namespace ParquetSharp.Test
             // The parquet format only stores an integer file version (1 or 2) and
             // 2 gets mapped to the latest 2.x version.
             Assert.AreEqual(ParquetVersion.PARQUET_2_6, fileMetaData.Version);
-            Assert.AreEqual("parquet-cpp-arrow version 14.0.1", fileMetaData.WriterVersion.ToString());
+            Assert.AreEqual("parquet-cpp-arrow version 14.0.2", fileMetaData.WriterVersion.ToString());
 
             using var rowGroupReader = fileReader.RowGroup(0);
             var rowGroupMetaData = rowGroupReader.MetaData;

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -14,7 +14,7 @@ namespace ParquetSharp.Test
         {
             var p = WriterProperties.GetDefaultWriterProperties();
 
-            Assert.AreEqual("parquet-cpp-arrow version 14.0.1", p.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 14.0.2", p.CreatedBy);
             Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
             Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024 * 1024, p.DataPageSize);

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>14.0.1-beta1</Version>
+    <Version>14.0.2-beta1</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,14 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "parquetsharp",
   "version-string": "undefined",
-  "builtin-baseline": "ce8fd9e7246969886ee31cbd76955b6d444289cb",
+  "builtin-baseline": "3bc5ff7f7ab72b57f0945d35bbbdaac2060bc268",
   "dependencies": [
     "arrow"
   ],
   "overrides": [
     {
       "name": "arrow",
-      "version": "14.0.1#1"
+      "version": "14.0.2"
     }
   ]
 }


### PR DESCRIPTION
This upgrades to Arrow version 14.0.2, which contains a bug fix for an error being raised with large dictionary encoded columns (https://github.com/apache/arrow/issues/38577)