### PR TITLE
Copy vcpkg.json before cloning vcpkg in devcontainer Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,15 +46,15 @@ FROM cpp AS vcpkg
 
 USER vscode
 
+# Copy our vcpkg manifest
+COPY --chown=vscode:vscode vcpkg.json /tmp/build/
+
 # Install vcpkg
 RUN sudo mkdir -p $VCPKG_ROOT \
  && sudo chown vscode:vscode $VCPKG_ROOT \
  && git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT \
  && cd $VCPKG_ROOT \
  && ./bootstrap-vcpkg.sh -disableMetrics
-
-# Copy our vcpkg manifest
-COPY --chown=vscode:vscode vcpkg.json /tmp/build/
 
 # Populate the vcpkg binary cache with all of our dependencies
 RUN cd /tmp/build \


### PR DESCRIPTION
After upgrading to Arrow 14.0.2 the devcontainer build failed due to not finding that Arrow version in vcpkg (https://github.com/G-Research/ParquetSharp/actions/runs/7458957587/job/20293957096), although the devcontainer build had passed in the PR.

It looks like this is because the docker build used a cached result of checking out the vcpkg repository from before Arrow 14.0.2 was added.

I've moved the copy of vcpkg.json to before the vcpkg repo checkout, so any changes to vcpkg.json should force a new checkout of vcpkg rather than use the previously cached result.