### PR TITLE
add caching to save time on CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,15 +60,6 @@ jobs:
       uses: actions/cache@v3
       with:
         path: cache/vcpkg
-        # https://vcpkg.readthedocs.io/en/stable/users/binarycaching/
-        # Binary caching relies on hashing everything that contributes to a particular package build. This includes:
-        # - The triplet file and name
-        # - The C and C++ compilers executable
-        # - The version of CMake used
-        # - Every file in the port directory
-        # - & more... (subject to change without notice)
-        #
-        # We use Vcpkg and C/C++ compilers which are preinstalled on the runner, so we include the runner's image identity as part of the hash key.
         key: vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake:${{ steps.cmake-info.outputs.version }}-vcpkg_json:${{ hashFiles('vcpkg*.json') }}-runner:${{ steps.runner-info.outputs.info }}
         restore-keys: |
           vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake:${{ steps.cmake-info.outputs.version }}-vcpkg_json:${{ hashFiles('vcpkg*.json') }}


### PR DESCRIPTION
After https://github.com/G-Research/ParquetSharp/pull/392 this PR should save time on CodeQL run

Example run on forked repo: https://github.com/ljubon/ParquetSharp/actions/runs/7493616704/job/20399707365