### PR TITLE
Add support for reading and writing the .NET Half type

### DIFF
--- a/cpp/LogicalType.cpp
+++ b/cpp/LogicalType.cpp
@@ -106,6 +106,11 @@ extern "C"
 		TRYCATCH(*logical_type = new std::shared_ptr(LogicalType::UUID());)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* LogicalType_Float16(const std::shared_ptr<const LogicalType>** logical_type)
+	{
+		TRYCATCH(*logical_type = new std::shared_ptr(LogicalType::Float16());)
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* LogicalType_None(const std::shared_ptr<const LogicalType>** logical_type)
 	{
 		TRYCATCH(*logical_type = new std::shared_ptr(LogicalType::None());)

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -1631,6 +1631,7 @@ namespace ParquetSharp.Test
                     Values = Enumerable.Range(0, NumRows).Select(i => i % 11 == 0 ? (Int96?) null : new Int96(i, i * i, i * i * i)).ToArray(),
                     HasStatistics = false
                 },
+#if NET5_0_OR_GREATER
                 new ExpectedColumn
                 {
                     Name = "half_field",
@@ -1655,6 +1656,7 @@ namespace ParquetSharp.Test
                     Max = (Half) Math.Sqrt(NumRows - 1),
                     Converter = (v, _) => LogicalRead.ToHalf((FixedLenByteArray) v)
                 },
+#endif
                 new ExpectedColumn
                 {
                     Name = "float_field",

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -1633,6 +1633,30 @@ namespace ParquetSharp.Test
                 },
                 new ExpectedColumn
                 {
+                    Name = "half_field",
+                    PhysicalType = PhysicalType.FixedLenByteArray,
+                    LogicalType = LogicalType.Float16(),
+                    Length = 2,
+                    Values = Enumerable.Range(0, NumRows).Select(i => i % 5 == 0 ? Half.NaN : (Half) Math.Sqrt(i)).ToArray(),
+                    Min = (Half) 1.0,
+                    Max = (Half) Math.Sqrt(NumRows - 1),
+                    Converter = (v, _) => LogicalRead.ToHalf((FixedLenByteArray) v)
+                },
+                new ExpectedColumn
+                {
+                    Name = "half?_field",
+                    PhysicalType = PhysicalType.FixedLenByteArray,
+                    LogicalType = LogicalType.Float16(),
+                    Length = 2,
+                    Values = Enumerable.Range(0, NumRows).Select(i => i % 11 == 0 ? (Half?) null : i % 5 == 0 ? Half.NaN : (Half) Math.Sqrt(i)).ToArray(),
+                    NullCount = (NumRows + 10) / 11,
+                    NumValues = NumRows - (NumRows + 10) / 11,
+                    Min = (Half) 1.0,
+                    Max = (Half) Math.Sqrt(NumRows - 1),
+                    Converter = (v, _) => LogicalRead.ToHalf((FixedLenByteArray) v)
+                },
+                new ExpectedColumn
+                {
                     Name = "float_field",
                     PhysicalType = PhysicalType.Float,
                     Values = Enumerable.Range(0, NumRows).Select(i => i % 5 == 0 ? float.NaN : (float) Math.Sqrt(i)).ToArray(),

--- a/csharp/AadPrefixVerifier.cs
+++ b/csharp/AadPrefixVerifier.cs
@@ -26,7 +26,7 @@ namespace ParquetSharp
 
         internal static AadPrefixVerifier GetGcHandleTarget(IntPtr handle)
         {
-            return (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target;
+            return (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target!;
         }
 
         internal delegate void FreeGcHandleFunc(IntPtr handle);
@@ -46,7 +46,7 @@ namespace ParquetSharp
 
             try
             {
-                var obj = (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target;
+                var obj = (AadPrefixVerifier) GCHandle.FromIntPtr(handle).Target!;
                 var aadPrefixStr = StringUtil.PtrToStringUtf8(aadPrefix);
                 obj.Verify(aadPrefixStr);
             }

--- a/csharp/ByteArray.cs
+++ b/csharp/ByteArray.cs
@@ -23,7 +23,7 @@ namespace ParquetSharp
             return Length == other.Length && Pointer == other.Pointer;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ByteArray other && Equals(other);
         }

--- a/csharp/ByteArrayReaderCache.cs
+++ b/csharp/ByteArrayReaderCache.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -40,7 +41,11 @@ namespace ParquetSharp
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER)
+        public bool TryGetValue(TPhysical physical, [MaybeNullWhen(false)] out TLogical logical)
+#else
         public bool TryGetValue(TPhysical physical, out TLogical logical)
+#endif
         {
             if (_map == null) throw new InvalidOperationException("cache is not in a usable state");
             return _map.TryGetValue(physical, out logical);

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -27,7 +27,7 @@ namespace ParquetSharp
             var isHalf = false;
 #endif
 
-            if (length != -1 && !isDecimal && !isUuid && !isHalf)
+            if (length != -1 && !(isDecimal || isUuid || isHalf))
             {
                 throw new ArgumentException("length can only be set with the decimal, Guid or Half type");
             }

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -21,10 +21,15 @@ namespace ParquetSharp
         {
             var isDecimal = logicalSystemType == typeof(decimal) || logicalSystemType == typeof(decimal?);
             var isUuid = logicalSystemType == typeof(Guid) || logicalSystemType == typeof(Guid?);
+#if NET5_0_OR_GREATER
+            var isHalf = logicalSystemType == typeof(Half) || logicalSystemType == typeof(Half?);
+#else
+            var isHalf = false;
+#endif
 
-            if (length != -1 && !isDecimal && !isUuid)
+            if (length != -1 && !isDecimal && !isUuid && !isHalf)
             {
-                throw new ArgumentException("length can only be set with the decimal or Guid type");
+                throw new ArgumentException("length can only be set with the decimal, Guid or Half type");
             }
 
             if (isDecimal && !(logicalTypeOverride is DecimalLogicalType))
@@ -105,6 +110,13 @@ namespace ParquetSharp
             {
                 return 16;
             }
+
+#if NET5_0_OR_GREATER
+            if (logicalSystemType == typeof(Half) || logicalSystemType == typeof(Half?))
+            {
+                return 2;
+            }
+#endif
 
             return -1;
         }

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -119,7 +119,7 @@ namespace ParquetSharp
 
             if (type.IsArray)
             {
-                var item = CreateSchemaNode(logicalTypeFactory, type.GetElementType(), "item", logicalTypeOverride, length);
+                var item = CreateSchemaNode(logicalTypeFactory, type.GetElementType()!, "item", logicalTypeOverride, length);
                 var list = new GroupNode("list", Repetition.Repeated, new[] {item});
 
                 try

--- a/csharp/Date.cs
+++ b/csharp/Date.cs
@@ -39,7 +39,7 @@ namespace ParquetSharp
             return Days == other.Days;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Date date && Equals(date);
         }
@@ -49,7 +49,7 @@ namespace ParquetSharp
             return Days;
         }
 
-        public int CompareTo(object obj)
+        public int CompareTo(object? obj)
         {
             return obj switch
             {

--- a/csharp/DateTimeNanos.cs
+++ b/csharp/DateTimeNanos.cs
@@ -35,7 +35,7 @@ namespace ParquetSharp
             return Ticks == other.Ticks;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is DateTimeNanos date && Equals(date);
         }
@@ -45,7 +45,7 @@ namespace ParquetSharp
             return Ticks.GetHashCode();
         }
 
-        public int CompareTo(object obj)
+        public int CompareTo(object? obj)
         {
             return obj switch
             {

--- a/csharp/DecryptionKeyRetriever.cs
+++ b/csharp/DecryptionKeyRetriever.cs
@@ -25,7 +25,7 @@ namespace ParquetSharp
 
         internal static DecryptionKeyRetriever GetGcHandleTarget(IntPtr handle)
         {
-            return (DecryptionKeyRetriever) GCHandle.FromIntPtr(handle).Target;
+            return (DecryptionKeyRetriever) GCHandle.FromIntPtr(handle).Target!;
         }
 
         internal delegate void FreeGcHandleFunc(IntPtr handle);
@@ -45,7 +45,7 @@ namespace ParquetSharp
 
             try
             {
-                var obj = (DecryptionKeyRetriever) GCHandle.FromIntPtr(handle).Target;
+                var obj = (DecryptionKeyRetriever) GCHandle.FromIntPtr(handle).Target!;
                 var keyMetadataStr = StringUtil.PtrToStringUtf8(keyMetadata);
                 key = new AesKey(obj.GetKey(keyMetadataStr));
             }

--- a/csharp/FixedLenByteArray.cs
+++ b/csharp/FixedLenByteArray.cs
@@ -21,7 +21,7 @@ namespace ParquetSharp
             return Pointer == other.Pointer;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FixedLenByteArray other && Equals(other);
         }

--- a/csharp/LogicalBatchReader/LogicalBatchReaderFactory.cs
+++ b/csharp/LogicalBatchReader/LogicalBatchReaderFactory.cs
@@ -168,7 +168,7 @@ namespace ParquetSharp.LogicalBatchReader
 
             var arrayReaderType = typeof(ArrayReader<,,>).MakeGenericType(typeof(TPhysical), typeof(TLogical), containedType);
             return (ILogicalBatchReader<TElement>) Activator.CreateInstance(
-                arrayReaderType, innerReader, _bufferedReader!, arrayDefinitionLevel, repetitionLevel, innerNodeIsOptional);
+                arrayReaderType, innerReader, _bufferedReader!, arrayDefinitionLevel, repetitionLevel, innerNodeIsOptional)!;
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace ParquetSharp.LogicalBatchReader
             var innerReader = MakeGenericReader(nestedType, innerSchema, definitionLevel, repetitionLevel);
 
             var nestedReaderType = typeof(NestedReader<>).MakeGenericType(nestedType);
-            return (ILogicalBatchReader<TElement>) Activator.CreateInstance(nestedReaderType, innerReader, _buffers.Length);
+            return (ILogicalBatchReader<TElement>) Activator.CreateInstance(nestedReaderType, innerReader, _buffers.Length)!;
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace ParquetSharp.LogicalBatchReader
             var optionalNestedReaderType = typeof(OptionalNestedReader<,,>).MakeGenericType(
                 typeof(TPhysical), typeof(TLogical), nestedType);
             return (ILogicalBatchReader<TElement>) Activator.CreateInstance(
-                optionalNestedReaderType, innerReader, _bufferedReader!, definitionLevel);
+                optionalNestedReaderType, innerReader, _bufferedReader!, definitionLevel)!;
         }
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace ParquetSharp.LogicalBatchReader
             var optionalReaderType = typeof(OptionalReader<,,>).MakeGenericType(
                 typeof(TPhysical), typeof(TLogical), innerType);
             return (ILogicalBatchReader<TElement>) Activator.CreateInstance(
-                optionalReaderType, innerReader, _bufferedReader!, definitionLevel);
+                optionalReaderType, innerReader, _bufferedReader!, definitionLevel)!;
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace ParquetSharp.LogicalBatchReader
             return genericMethod.MakeGenericMethod(elementType).Invoke(this, new object[]
             {
                 schemaNodes, nullDefinitionLevel, repetitionLevel
-            });
+            })!;
         }
 
         private readonly ColumnReader<TPhysical> _physicalReader;

--- a/csharp/LogicalBatchWriter/LogicalBatchWriterFactory.cs
+++ b/csharp/LogicalBatchWriter/LogicalBatchWriterFactory.cs
@@ -121,7 +121,7 @@ namespace ParquetSharp.LogicalBatchWriter
             var arrayWriterType = typeof(ArrayWriter<,>).MakeGenericType(containedType, typeof(TPhysical));
             return (ILogicalBatchWriter<TElement>) Activator.CreateInstance(
                 arrayWriterType, writer0, writer1, _physicalWriter, optional,
-                arrayDefinitionLevel, repetitionLevel, firstRepetitionLevel);
+                arrayDefinitionLevel, repetitionLevel, firstRepetitionLevel)!;
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace ParquetSharp.LogicalBatchWriter
 
             var nestedWriterType = typeof(NestedWriter<>).MakeGenericType(nestedType);
             return (ILogicalBatchWriter<TElement>) Activator.CreateInstance(
-                nestedWriterType, firstInnerWriter, innerWriter, _buffers.Length);
+                nestedWriterType, firstInnerWriter, innerWriter, _buffers.Length)!;
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace ParquetSharp.LogicalBatchWriter
             var optionalNestedWriterType = typeof(OptionalNestedWriter<,>).MakeGenericType(nestedType, typeof(TPhysical));
             return (ILogicalBatchWriter<TElement>) Activator.CreateInstance(
                 optionalNestedWriterType, firstInnerWriter, innerWriter, _physicalWriter, _buffers,
-                definitionLevel, repetitionLevel, firstRepetitionLevel);
+                definitionLevel, repetitionLevel, firstRepetitionLevel)!;
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace ParquetSharp.LogicalBatchWriter
             return genericMethod.MakeGenericMethod(elementType).Invoke(this, new object[]
             {
                 schemaNodes, nullDefinitionLevel, repetitionLevel, firstRepetitionLevel
-            });
+            })!;
         }
 
         private readonly ByteBuffer? _byteBuffer;

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -664,7 +664,20 @@ namespace ParquetSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Half ToHalf(FixedLenByteArray source)
         {
-            return *(Half*) source.Pointer;
+            if (BitConverter.IsLittleEndian)
+            {
+                return *(Half*) source.Pointer;
+            }
+            else
+            {
+                // Float-16 values are always stored in little-endian order
+                var value = (Half) 0.0f;
+                var dest = (byte*) &value;
+                var src = (byte*) source.Pointer;
+                dest[1] = src[0];
+                dest[0] = src[1];
+                return value;
+            }
         }
 #endif
 

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -167,6 +167,18 @@ namespace ParquetSharp
                 return (LogicalRead<Guid?, FixedLenByteArray>.Converter) LogicalRead.ConvertUuid;
             }
 
+#if NET5_0_OR_GREATER
+            if (typeof(TLogical) == typeof(Half))
+            {
+                return (LogicalRead<Half, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertHalf(s, d));
+            }
+
+            if (typeof(TLogical) == typeof(Half?))
+            {
+                return (LogicalRead<Half?, FixedLenByteArray>.Converter) LogicalRead.ConvertHalf;
+            }
+#endif
+
             if (typeof(TLogical) == typeof(Date))
             {
                 return LogicalRead.GetNativeConverter<Date, int>();
@@ -478,6 +490,24 @@ namespace ParquetSharp
             }
         }
 
+#if NET5_0_OR_GREATER
+        public static void ConvertHalf(ReadOnlySpan<FixedLenByteArray> source, Span<Half> destination)
+        {
+            for (int i = 0; i < destination.Length; ++i)
+            {
+                destination[i] = ToHalf(source[i]);
+            }
+        }
+
+        public static void ConvertHalf(ReadOnlySpan<FixedLenByteArray> source, ReadOnlySpan<short> defLevels, Span<Half?> destination, short definedLevel)
+        {
+            for (int i = 0, src = 0; i < destination.Length; ++i)
+            {
+                destination[i] = defLevels[i] != definedLevel ? default(Half?) : ToHalf(source[src++]);
+            }
+        }
+#endif
+
         public static void ConvertDateTimeMicros(ReadOnlySpan<long> source, Span<DateTime> destination, DateTimeKind kind = DateTimeKind.Unspecified)
         {
             for (int i = 0; i < destination.Length; ++i)
@@ -629,6 +659,14 @@ namespace ParquetSharp
                 return new Guid(a, b, c, p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
             }
         }
+
+#if NET5_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe Half ToHalf(FixedLenByteArray source)
+        {
+            return *(Half*) source.Pointer;
+        }
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DateTime ToDateTimeMicros(long source)

--- a/csharp/LogicalType.cs
+++ b/csharp/LogicalType.cs
@@ -76,6 +76,7 @@ namespace ParquetSharp
         /// </summary>
         /// <returns>New Float16 LogicalType</returns>
         public static LogicalType Float16() => Create(ExceptionInfo.Return<IntPtr>(LogicalType_Float16));
+
         public static LogicalType None() => Create(ExceptionInfo.Return<IntPtr>(LogicalType_None));
 
         internal static LogicalType Create(IntPtr handle)

--- a/csharp/LogicalType.cs
+++ b/csharp/LogicalType.cs
@@ -68,6 +68,14 @@ namespace ParquetSharp
         public static LogicalType Json() => Create(ExceptionInfo.Return<IntPtr>(LogicalType_JSON));
         public static LogicalType Bson() => Create(ExceptionInfo.Return<IntPtr>(LogicalType_BSON));
         public static LogicalType Uuid() => Create(ExceptionInfo.Return<IntPtr>(LogicalType_UUID));
+
+        /// <summary>
+        /// Create a Float16 LogicalType
+        ///
+        /// This can be used to annotate a 2-byte fixed-length byte array
+        /// </summary>
+        /// <returns>New Float16 LogicalType</returns>
+        public static LogicalType Float16() => Create(ExceptionInfo.Return<IntPtr>(LogicalType_Float16));
         public static LogicalType None() => Create(ExceptionInfo.Return<IntPtr>(LogicalType_None));
 
         internal static LogicalType Create(IntPtr handle)
@@ -95,6 +103,7 @@ namespace ParquetSharp
                 LogicalTypeEnum.Json => new JsonLogicalType(handle),
                 LogicalTypeEnum.Bson => new BsonLogicalType(handle),
                 LogicalTypeEnum.Uuid => new UuidLogicalType(handle),
+                LogicalTypeEnum.Float16 => new Float16LogicalType(handle),
                 LogicalTypeEnum.None => new NoneLogicalType(handle),
                 _ => throw new ArgumentOutOfRangeException($"unknown logical type {type}")
             };
@@ -156,6 +165,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr LogicalType_UUID(out IntPtr logicalType);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr LogicalType_Float16(out IntPtr logicalType);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr LogicalType_None(out IntPtr logicalType);
@@ -275,6 +287,11 @@ namespace ParquetSharp
     public sealed class UuidLogicalType : LogicalType
     {
         internal UuidLogicalType(IntPtr handle) : base(handle) { }
+    }
+
+    public sealed class Float16LogicalType : LogicalType
+    {
+        internal Float16LogicalType(IntPtr handle) : base(handle) { }
     }
 
     public sealed class NoneLogicalType : LogicalType

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -50,7 +50,7 @@ namespace ParquetSharp
 
                 if (type.IsArray)
                 {
-                    type = type.GetElementType();
+                    type = type.GetElementType()!;
                     continue;
                 }
 

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -232,6 +232,10 @@ namespace ParquetSharp
                 {typeof(ulong?), (LogicalType.Int(64, isSigned: false), Repetition.Optional, PhysicalType.Int64)},
                 {typeof(Int96), (LogicalType.None(), Repetition.Required, PhysicalType.Int96)},
                 {typeof(Int96?), (LogicalType.None(), Repetition.Optional, PhysicalType.Int96)},
+#if NET5_0_OR_GREATER
+                {typeof(Half), (LogicalType.Float16(), Repetition.Required, PhysicalType.FixedLenByteArray)},
+                {typeof(Half?), (LogicalType.Float16(), Repetition.Optional, PhysicalType.FixedLenByteArray)},
+#endif
                 {typeof(float), (LogicalType.None(), Repetition.Required, PhysicalType.Float)},
                 {typeof(float?), (LogicalType.None(), Repetition.Optional, PhysicalType.Float)},
                 {typeof(double), (LogicalType.None(), Repetition.Required, PhysicalType.Double)},

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6;net471;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp</AssemblyName>

--- a/csharp/RowOriented/ParquetFile.cs
+++ b/csharp/RowOriented/ParquetFile.cs
@@ -438,7 +438,7 @@ namespace ParquetSharp.RowOriented
                 );
 
                 // Write the buffer to Parquet.
-                var writeCall = Expression.Call(writer, GetWriteMethod<TTuple>(buffer.Type.GetElementType()), buffer, length);
+                var writeCall = Expression.Call(writer, GetWriteMethod<TTuple>(buffer.Type.GetElementType()!), buffer, length);
 
                 return Expression.Block(
                     new[] {buffer, index},


### PR DESCRIPTION
Fixes #413 

This adds support for the new `Float16` logical type added in Arrow 15. I've added a new .NET 6 target to the ParquetSharp project to allow using the new `Half` type, which required fixing a few errors related to nullable reference type checking when building with the newer target.

One thing to be aware of is that writing `Half` values can be a bit slower than floats because of the extra overhead of writing these as fixed-length byte arrays rather than having a dedicated physical type. We could possibly improve this in future if it turns out to be a problem. I did some quick benchmarking of reading and writing 1 million random floats, doubles and half values, with dictionary encoding disabled:


|     Method |     Mean |     Error |    StdDev | Ratio | RatioSD |
|----------- |---------:|----------:|----------:|------:|--------:|
|   ReadHalf | 1.267 ms | 0.0253 ms | 0.0329 ms |  1.02 |    0.02 |
|  ReadFloat | 1.240 ms | 0.0236 ms | 0.0299 ms |  1.00 |    0.00 |
| ReadDouble | 2.292 ms | 0.0411 ms | 0.0563 ms |  1.85 |    0.07 | 

|      Method |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |
|------------ |----------:|----------:|----------:|----------:|------:|--------:|
|   WriteHalf | 16.771 ms | 0.3318 ms | 0.5452 ms | 16.466 ms |  3.13 |    0.25 |
|  WriteFloat |  5.336 ms | 0.1280 ms | 0.3775 ms |  5.324 ms |  1.00 |    0.00 |
| WriteDouble |  8.845 ms | 0.1759 ms | 0.2408 ms |  8.849 ms |  1.64 |    0.11 |
