### PR TITLE
Expose page checksum verification reader and writer properties

### DIFF
--- a/cpp/ReaderProperties.cpp
+++ b/cpp/ReaderProperties.cpp
@@ -56,4 +56,19 @@ extern "C"
 			*file_decryption_properties = p ? new std::shared_ptr(p) : nullptr;
 		)
 	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Page_Checksum_Verification(const ReaderProperties* reader_properties, bool* verification_enabled)
+	{
+		TRYCATCH(*verification_enabled = reader_properties->page_checksum_verification();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Enable_Page_Checksum_Verification(ReaderProperties* reader_properties)
+	{
+		TRYCATCH(reader_properties->set_page_checksum_verification(true);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Disable_Page_Checksum_Verification(ReaderProperties* reader_properties)
+	{
+		TRYCATCH(reader_properties->set_page_checksum_verification(false);)
+	}
 }

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -75,6 +75,11 @@ extern "C"
 		TRYCATCH(*enabled = (*writer_properties)->page_index_enabled(*path);)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Page_Checksum_Enabled(const std::shared_ptr<WriterProperties>* writer_properties, bool* enabled)
+	{
+		TRYCATCH(*enabled = (*writer_properties)->page_checksum_enabled();)
+	}
+
 	// ColumnPath taking methods.
 
 	//PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Column_Properties(const std::shared_ptr<WriterProperties>* writer_properties, const std::shared_ptr<schema::ColumnPath>* path, const ColumnProperties** columnProperties)

--- a/cpp/WriterPropertiesBuilder.cpp
+++ b/cpp/WriterPropertiesBuilder.cpp
@@ -199,4 +199,14 @@ extern "C"
 	{
 		TRYCATCH(builder->disable_write_page_index(*path);)
 	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Enable_Page_Checksum(WriterProperties::Builder* builder)
+	{
+		TRYCATCH(builder->enable_page_checksum();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Disable_Page_Checksum(WriterProperties::Builder* builder)
+	{
+		TRYCATCH(builder->disable_page_checksum();)
+	}
 }

--- a/csharp.test/TestReaderProperties.cs
+++ b/csharp.test/TestReaderProperties.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using ParquetSharp.IO;
+using ParquetSharp.Schema;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    internal static class TestReaderProperties
+    {
+
+        [Test]
+        public static void TestDefaultProperties()
+        {
+            using var p = ReaderProperties.GetDefaultReaderProperties();
+
+            Assert.That(p.BufferSize, Is.EqualTo(1 << 14));
+            Assert.That(p.IsBufferedStreamEnabled, Is.False);
+            Assert.That(p.PageChecksumVerification, Is.False);
+        }
+
+        [Test]
+        public static void TestModifyProperties()
+        {
+            using var p = ReaderProperties.GetDefaultReaderProperties();
+
+            p.BufferSize = 1 << 13;
+            Assert.That(p.BufferSize, Is.EqualTo(1 << 13));
+
+            p.EnablePageChecksumVerification();
+            Assert.That(p.PageChecksumVerification, Is.True);
+            p.DisablePageChecksumVerification();
+            Assert.That(p.PageChecksumVerification, Is.False);
+
+            p.EnableBufferedStream();
+            Assert.That(p.IsBufferedStreamEnabled, Is.True);
+            p.DisableBufferedStream();
+            Assert.That(p.IsBufferedStreamEnabled, Is.False);
+        }
+    }
+}

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -25,6 +25,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(ParquetVersion.PARQUET_2_6, p.Version);
             Assert.AreEqual(1024, p.WriteBatchSize);
             Assert.False(p.WritePageIndex);
+            Assert.False(p.PageChecksumEnabled);
         }
 
         [Test]
@@ -42,6 +43,7 @@ namespace ParquetSharp.Test
                 .WriteBatchSize(666)
                 .DisableWritePageIndex()
                 .EnableWritePageIndex()
+                .EnablePageChecksum()
                 .Build();
 
             Assert.AreEqual("Meeeee!!!", p.CreatedBy);
@@ -55,6 +57,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(ParquetVersion.PARQUET_1_0, p.Version);
             Assert.AreEqual(666, p.WriteBatchSize);
             Assert.True(p.WritePageIndex);
+            Assert.True(p.PageChecksumEnabled);
         }
 
         [Test]
@@ -110,6 +113,7 @@ namespace ParquetSharp.Test
                 DefaultWriterProperties.Version = ParquetVersion.PARQUET_1_0;
                 DefaultWriterProperties.WriteBatchSize = 666;
                 DefaultWriterProperties.WritePageIndex = true;
+                DefaultWriterProperties.PageChecksumEnabled = true;
 
                 using var builder = new WriterPropertiesBuilder();
                 using var p = builder.Build();
@@ -127,6 +131,7 @@ namespace ParquetSharp.Test
                 Assert.AreEqual(ParquetVersion.PARQUET_1_0, p.Version);
                 Assert.AreEqual(666, p.WriteBatchSize);
                 Assert.True(p.WritePageIndex);
+                Assert.True(p.PageChecksumEnabled);
             }
             finally
             {
@@ -143,6 +148,7 @@ namespace ParquetSharp.Test
                 DefaultWriterProperties.Version = null;
                 DefaultWriterProperties.WriteBatchSize = null;
                 DefaultWriterProperties.WritePageIndex = null;
+                DefaultWriterProperties.PageChecksumEnabled = null;
             }
         }
 

--- a/csharp/DefaultWriterProperties.cs
+++ b/csharp/DefaultWriterProperties.cs
@@ -70,5 +70,10 @@ namespace ParquetSharp
         /// Write the page index
         /// </summary>
         public static bool? WritePageIndex { get; set; }
+
+        /// <summary>
+        /// Write CRC page checksums
+        /// </summary>
+        public static bool? PageChecksumEnabled { get; set; }
     }
 }

--- a/csharp/ReaderProperties.cs
+++ b/csharp/ReaderProperties.cs
@@ -59,6 +59,23 @@ namespace ParquetSharp
             GC.KeepAlive(Handle);
         }
 
+        /// <summary>
+        /// Whether page checksums are verified during reading to check for data corruption
+        /// </summary>
+        public bool PageChecksumVerification => ExceptionInfo.Return<bool>(Handle, ReaderProperties_Page_Checksum_Verification);
+
+        public void EnablePageChecksumVerification()
+        {
+            ExceptionInfo.Check(ReaderProperties_Enable_Page_Checksum_Verification(Handle.IntPtr));
+            GC.KeepAlive(Handle);
+        }
+
+        public void DisablePageChecksumVerification()
+        {
+            ExceptionInfo.Check(ReaderProperties_Disable_Page_Checksum_Verification(Handle.IntPtr));
+            GC.KeepAlive(Handle);
+        }
+
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ReaderProperties_Get_Default_Reader_Properties(out IntPtr readerProperties);
 
@@ -85,6 +102,15 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ReaderProperties_Get_File_Decryption_Properties(IntPtr readerProperties, out IntPtr fileDecryptionProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Page_Checksum_Verification(IntPtr readerProperties, [MarshalAs(UnmanagedType.I1)] out bool enabled);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Enable_Page_Checksum_Verification(IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Disable_Page_Checksum_Verification(IntPtr readerProperties);
 
         internal readonly ParquetHandle Handle;
     }

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -74,6 +74,11 @@ namespace ParquetSharp
             return ExceptionInfo.Return<ulong>(Handle, path.Handle, WriterProperties_Max_Statistics_Size);
         }
 
+        /// <summary>
+        /// Whether CRC checksums are written for data pages
+        /// </summary>
+        public bool PageChecksumEnabled => ExceptionInfo.Return<bool>(Handle, WriterProperties_Page_Checksum_Enabled);
+
         internal readonly ParquetHandle Handle;
 
         [DllImport(ParquetDll.Name)]
@@ -114,6 +119,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterProperties_Page_Index_Enabled_For_Path(IntPtr writerProperties, IntPtr path, out bool enabled);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterProperties_Page_Checksum_Enabled(IntPtr writerProperties, out bool enabled);
 
         //[DllImport(ParquetDll.Name)]
         //private static extern IntPtr WriterProperties_Column_Properties(IntPtr writerProperties, IntPtr path, out IntPtr columnProperties);

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -302,6 +302,26 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Enable writing CRC checksums for data pages
+        /// </summary>
+        public WriterPropertiesBuilder EnablePageChecksum()
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Page_Checksum(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
+        /// <summary>
+        /// Disable writing CRC checksums for data pages
+        /// </summary>
+        public WriterPropertiesBuilder DisablePageChecksum()
+        {
+            ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Page_Checksum(_handle.IntPtr));
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
         private void ApplyDefaults()
         {
             OnDefaultProperty(DefaultWriterProperties.EnableDictionary, enabled =>
@@ -355,6 +375,18 @@ namespace ParquetSharp
                 else
                 {
                     DisableWritePageIndex();
+                }
+            });
+
+            OnDefaultProperty(DefaultWriterProperties.PageChecksumEnabled, checksumEnabled =>
+            {
+                if (checksumEnabled)
+                {
+                    EnablePageChecksum();
+                }
+                else
+                {
+                    DisablePageChecksum();
                 }
             });
         }
@@ -494,6 +526,12 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Disable_Write_Page_Index_By_ColumnPath(IntPtr builder, IntPtr path);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Enable_Page_Checksum(IntPtr builder);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Disable_Page_Checksum(IntPtr builder);
 
         private readonly ParquetHandle _handle;
     }


### PR DESCRIPTION
These options were added back in Arrow 12, but I noticed Arrow 15 added them to the Python API, and it seemed like an easy thing to add and could be useful for some users.