### PR TITLE
Support the TimeOnly and DateOnly types added in .NET 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ For more detailed information on how to use ParquetSharp, see the following docu
 * [Working with nested data](docs/Nested.md)
 * [Reading and writing Arrow data](docs/Arrow.md) &mdash; how to read and write data using the [Apache Arrow format](https://arrow.apache.org/)
 * [Row-oriented API](docs/RowOriented.md) &mdash; a higher level API that abstracts away the column-oriented nature of Parquet files
-* [Custom types](docs/TypeFactories.md) &mdash; how to override the mapping between .NET and Parquet types
+* [Custom types](docs/TypeFactories.md) &mdash; how to customize the mapping between .NET and Parquet types,
+    including using the `DateOnly` and `TimeOnly` types added in .NET 6.
 * [Writing TimeSpan data](docs/TimeSpan.md) &mdash; interoperability with other libraries when writing TimeSpan data
 * [Use from PowerShell](docs/PowerShell.md)
 

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -118,6 +118,125 @@ namespace ParquetSharp.Test
             }
         }
 
+#if NET6_0_OR_GREATER
+        [Test]
+        public static void TestRoundTripDateOnly()
+        {
+            var schemaColumns = new Column[]
+            {
+                new Column<DateOnly>("date"),
+                new Column<DateOnly?>("nullable_date"),
+            };
+
+            const int numRows = 100;
+            var dateValues = Enumerable.Range(0, numRows)
+                .Select(i => new DateOnly(2024, 1, 1).AddDays(i))
+                .ToArray();
+            var nullableDateValues = Enumerable.Range(0, numRows)
+                .Select(i => i % 5 == 1 ? (DateOnly?) null : new DateOnly(2024, 1, 1).AddDays(i))
+                .ToArray();
+
+            using var buffer = new ResizableBuffer();
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(outStream, schemaColumns);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                {
+                    using var columnWriter = rowGroupWriter.NextColumn().LogicalWriter<DateOnly>();
+                    columnWriter.WriteBatch(dateValues);
+                }
+                {
+                    using var columnWriter = rowGroupWriter.NextColumn().LogicalWriter<DateOnly?>();
+                    columnWriter.WriteBatch(nullableDateValues);
+                }
+                fileWriter.Close();
+            }
+
+            DateOnly[] readDateValues;
+            DateOnly?[] readNullableDateValues;
+            using (var inStream = new BufferReader(buffer))
+            {
+                using var fileReader = new ParquetFileReader(inStream);
+                using var rowGroupReader = fileReader.RowGroup(0);
+                {
+                    using var columnReader = rowGroupReader.Column(0);
+                    using var logicalReader = columnReader.LogicalReaderOverride<DateOnly>();
+                    readDateValues = logicalReader.ReadAll(numRows);
+                }
+                {
+                    using var columnReader = rowGroupReader.Column(1);
+                    using var logicalReader = columnReader.LogicalReaderOverride<DateOnly?>();
+                    readNullableDateValues = logicalReader.ReadAll(numRows);
+                }
+            }
+
+            Assert.AreEqual(dateValues, readDateValues);
+            Assert.AreEqual(nullableDateValues, readNullableDateValues);
+        }
+
+        [TestCase(null)]
+        [TestCase(TimeUnit.Micros)]
+        [TestCase(TimeUnit.Millis)]
+        public static void TestRoundTripTimeOnly(TimeUnit? timeUnit)
+        {
+            LogicalType? logicalTypeOverride = null;
+            if (timeUnit.HasValue)
+            {
+                logicalTypeOverride = LogicalType.Time(isAdjustedToUtc: true, timeUnit.Value);
+            }
+            var schemaColumns = new Column[]
+            {
+                new Column<TimeOnly>("time", logicalTypeOverride: logicalTypeOverride),
+                new Column<TimeOnly?>("nullable_time", logicalTypeOverride: logicalTypeOverride),
+            };
+
+            const int numRows = 100;
+            var timeValues = Enumerable.Range(0, numRows)
+                .Select(i => new TimeOnly(0, 0, 0).Add(TimeSpan.FromSeconds(i)))
+                .ToArray();
+            var nullableTimeValues = Enumerable.Range(0, numRows)
+                .Select(i => i % 5 == 1 ? (TimeOnly?) null : new TimeOnly(0, 0, 0).Add(TimeSpan.FromSeconds(i)))
+                .ToArray();
+
+            using var buffer = new ResizableBuffer();
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(outStream, schemaColumns);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+                {
+                    using var columnWriter = rowGroupWriter.NextColumn().LogicalWriter<TimeOnly>();
+                    columnWriter.WriteBatch(timeValues);
+                }
+                {
+                    using var columnWriter = rowGroupWriter.NextColumn().LogicalWriter<TimeOnly?>();
+                    columnWriter.WriteBatch(nullableTimeValues);
+                }
+                fileWriter.Close();
+            }
+
+            TimeOnly[] readTimeValues;
+            TimeOnly?[] readNullableTimeValues;
+            using (var inStream = new BufferReader(buffer))
+            {
+                using var fileReader = new ParquetFileReader(inStream);
+                using var rowGroupReader = fileReader.RowGroup(0);
+                {
+                    using var columnReader = rowGroupReader.Column(0);
+                    using var logicalReader = columnReader.LogicalReaderOverride<TimeOnly>();
+                    readTimeValues = logicalReader.ReadAll(numRows);
+                }
+                {
+                    using var columnReader = rowGroupReader.Column(1);
+                    using var logicalReader = columnReader.LogicalReaderOverride<TimeOnly?>();
+                    readNullableTimeValues = logicalReader.ReadAll(numRows);
+                }
+            }
+
+            Assert.AreEqual(timeValues, readTimeValues);
+            Assert.AreEqual(nullableTimeValues, readNullableTimeValues);
+        }
+#endif
+
         [TestCase(DateTimeKind.Utc, TimeUnit.Micros)]
         [TestCase(DateTimeKind.Utc, TimeUnit.Millis)]
         [TestCase(DateTimeKind.Unspecified, TimeUnit.Micros)]

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -254,6 +254,12 @@ namespace ParquetSharp
                 {typeof(TimeSpan?), (LogicalType.Time(isAdjustedToUtc: true, timeUnit: TimeUnit.Micros), Repetition.Optional, PhysicalType.Int64)},
                 {typeof(TimeSpanNanos), (LogicalType.Time(isAdjustedToUtc: true, timeUnit: TimeUnit.Nanos), Repetition.Required, PhysicalType.Int64)},
                 {typeof(TimeSpanNanos?), (LogicalType.Time(isAdjustedToUtc: true, timeUnit: TimeUnit.Nanos), Repetition.Optional, PhysicalType.Int64)},
+#if NET6_0_OR_GREATER
+                {typeof(TimeOnly), (LogicalType.Time(isAdjustedToUtc: true, timeUnit: TimeUnit.Micros), Repetition.Required, PhysicalType.Int64)},
+                {typeof(TimeOnly?), (LogicalType.Time(isAdjustedToUtc: true, timeUnit: TimeUnit.Micros), Repetition.Optional, PhysicalType.Int64)},
+                {typeof(DateOnly), (LogicalType.Date(), Repetition.Required, PhysicalType.Int32)},
+                {typeof(DateOnly?), (LogicalType.Date(), Repetition.Optional, PhysicalType.Int32)},
+#endif
                 {typeof(string), (LogicalType.String(), Repetition.Optional, PhysicalType.ByteArray)},
                 {typeof(byte[]), (LogicalType.None(), Repetition.Optional, PhysicalType.ByteArray)}
             };

--- a/docs/TypeFactories.md
+++ b/docs/TypeFactories.md
@@ -1,33 +1,104 @@
 # Type Factories
 
-ParquetSharp API exposes the logic that maps the C# types (called "logical system types" by ParquetSharp, as per Parquet's LogicalType) to the actual Parquet physical types, as well as the converters that are associated with them.
+The ParquetSharp API exposes the logic that maps .NET types
+(called "logical system types" by ParquetSharp, as per Parquet's LogicalType)
+to the actual Parquet physical types, as well as the converters that are associated with them.
 
 This means that:
 - a user can potentially read/write any type they want, as long as they provide a viable mapping,
-- a user can override the default ParquetSharp mapping and change how existing C# types are handled.
+- a user can override the default ParquetSharp mapping and change how existing .NET types are handled.
 
 ## API
 
-The API at the core of this is encompassed by `LogicalTypeFactory`, `LogicalReadConverterFactory` and `LogicalWriteConverterFactory`.
+The API at the core of this is encompassed by the `LogicalTypeFactory`, `LogicalReadConverterFactory`
+and `LogicalWriteConverterFactory` classes.
+These classes implement the default ParquetSharp type mapping and conversion logic,
+but may be subclassed in order to implement custom type mapping logic.
+The `LogicalTypeFactory` class also allows some customization of the default type mappings
+without needing to subclass it.
 
-Whenever the user uses a custom type to read or write values to a Parquet file, a `LogicalReadConverterFactory` or `LogicalWriteConverterFactory` needs to be provided. This converter factory tells to the `LogicalColumnReader` or `LogicalColumnWriter` how to convert the user custom type into a physical type that is understood by Parquet.
+Both `ParquetFileReader` and `ParquetFileWriter` have `LogicalTypeFactory` properties that can
+be set to an instance of the `LogicalTypeFactory` class,
+while `LogicalReadConverterFactory` is only used by `ParquetFileReader`,
+and `LogicalWriteConverterFactory` is only used by `ParquetFileWriter`.
 
-On top of that, if the custom type is used for creating the schema (when writing), or if accessing a `LogicalColumnReader` or `LogicalColumnWriter` without explicitly overriding the element type (e.g. `columnWriter.LogicalReaderOverride<CustomType>()`), then a `LogicalTypeFactory` is needed in order to establish the proper logical type mapping.
+Whenever the user uses a custom type to read or write values to a Parquet file,
+a `LogicalReadConverterFactory` or `LogicalWriteConverterFactory` needs to be provided, respectively.
+This converter factory tells to the `LogicalColumnReader` or `LogicalColumnWriter`
+how to convert between the user's custom type and a physical type that is understood by Parquet.
 
-In other words, the `LogicalTypeFactory` is required if the user provides a `Column` class with a custom type (writer only, the factory is needed to know the physical Parquet type) or gets the `LogicalColumnReader` or `LogicalColumnWriter` via the non type-overriding methods (in which case the factory is needed to know the full type of the logical column reader/writer). The corresponding converter factory is always needed.
+On top of that, if the custom type is used for creating the schema (when writing),
+or if accessing a `LogicalColumnReader` or `LogicalColumnWriter` without explicitly overriding the element type
+(e.g. `columnWriter.LogicalReaderOverride<CustomType>()`),
+then a `LogicalTypeFactory` is needed in order to establish the proper logical type mapping.
 
-## Examples
+In other words, the `LogicalTypeFactory` is required if the user provides a `Column` class with a custom type when writing,
+or gets the `LogicalColumnReader` or `LogicalColumnWriter` via the non type-overriding methods
+(in which case the factory is needed to know the full type of the logical column reader/writer).
+The corresponding converter factory is always needed if using a custom type that the default converter doesn't know how to handle.
 
-One of the approaches for reading custom values can be described by the following code:
+## DateOnly and TimeOnly
+
+Since ParquetSharp 15.0.0, when using ParquetSharp targeting .NET 6.0 or later,
+a column with the Parquet `Date` logical type can be read or written with the .NET `DateOnly` type,
+and the Parquet `Time` logical type can be read or written with the .NET `TimeOnly` type.
+
+When writing data and using the `Column` based API, this is as simple as using the
+desired type as the `Column` type parameter:
 
 ```csharp
-    using var fileReader = new ParquetFileReader(filename) { LogicalReadConverterFactory = new ReadConverterFactory() };
+var schemaColumns = new Column[]
+{
+    new Column<DateOnly>("date"),
+    new Column<TimeOnly>("time"),
+};
+```
+
+When reading data, you can use the `LogicalColumnReaderOverride` method to read data
+as `DateOnly` or `TimeOnly` instead of the default `Date` and `TimeSpan` types:
+
+```csharp
+using var dateReader = rowGroupReader.Column(dateColumnIndex).LogicalReaderOverride<DateOnly>();
+using var timeReader = rowGroupReader.Column(timeColumnIndex).LogicalReaderOverride<TimeOnly>();
+```
+
+Or alternatively, to change the default type mapping, you can customize the `LogicalTypeFactory` used:
+
+```csharp
+using var fileReader = new ParquetFileReader(filePath);
+fileReader.LogicalTypeFactory = new LogicalTypeFactory
+{
+    DateAsDateOnly = true,
+    TimeAsTimeOnly = true,
+};
+
+using var rowGroupReader = fileReader.RowGroup(0);
+using var dateColumnReader = rowGroupReader.Column(dateColumnIndex).LogicalReader<DateOnly>();
+using var timeColumnReader = rowGroupReader.Column(timeColumnIndex).LogicalReader<TimeOnly>();
+```
+
+The default `LogicalTypeFactory` may also be modified to change the default mapping behaviour process-wide:
+
+```csharp
+LogicalTypeFactory.Default.DateAsDateOnly = true;
+LogicalTypeFactory.Default.TimeAsTimeOnly = true;
+```
+
+## Custom Types
+
+The following example shows how to read Parquet float values as a custom `VolumeInDollars` type:
+
+```csharp
+    using var fileReader = new ParquetFileReader(filename)
+    {
+        LogicalReadConverterFactory = new ReadConverterFactory()
+    };
     using var groupReader = fileReader.RowGroup(0);
     using var columnReader = groupReader.Column(0).LogicalReaderOverride<VolumeInDollars>();
 
     var values = columnReader.ReadAll(checked((int) groupReader.MetaData.NumRows));
 
-    /* ... */
+    // Use read values...
 
     [StructLayout(LayoutKind.Sequential)]
     private readonly struct VolumeInDollars
@@ -38,14 +109,51 @@ One of the approaches for reading custom values can be described by the followin
 
     private sealed class ReadConverterFactory : LogicalReadConverterFactory
     {
-        public override Delegate GetConverter<TLogical, TPhysical>(ColumnDescriptor columnDescriptor, ColumnChunkMetaData columnChunkMetaData)
+        public override Delegate GetConverter<TLogical, TPhysical>(
+                ColumnDescriptor columnDescriptor, ColumnChunkMetaData columnChunkMetaData)
         {
-            if (typeof(TLogical) == typeof(VolumeInDollars)) return LogicalRead.GetNativeConverter<VolumeInDollars, float>();
+            if (typeof(TLogical) == typeof(VolumeInDollars))
+            {
+                return LogicalRead.GetNativeConverter<VolumeInDollars, float>();
+            }
+            if (typeof(TLogical) == typeof(VolumeInDollars?))
+            {
+                return LogicalRead.GetNullableNativeConverter<VolumeInDollars, float>();
+            }
             return base.GetConverter<TLogical, TPhysical>(columnDescriptor, columnChunkMetaData);
         }
     }
 ```
 
+This uses the `LogicalReaderOverride<VolumeInDollars>` method to specify the type
+to be used when reading, and the custom `ReadConverterFactory` implementation
+defines how to convert float Parquet data to the custom `VolumeInDollars` type.
+Since the struct layout exactly matches the `float` type, the `LogicalRead.GetNativeConverter`
+method can be used, or `GetNullableNativeConverter` for nullable values.
+
+If you wish to override the default type mapping,
+you will need to implement a custom `LogicalTypeFactory` and have some way to identify
+which columns should be read as the custom type.
+Usually this is done by matching on the column name:
+
+```csharp
+private sealed class CustomTypeFactory : LogicalTypeFactory
+{
+    public override (Type physicalType, Type logicalType) GetSystemTypes(
+            ColumnDescriptor descriptor, Type? columnLogicalTypeOverride)
+    {
+        using var descriptorPath = descriptor.Path;
+        // Compare with the first entry in the descriptor path to handle array values
+        if (columnLogicalTypeOverride == null && descriptorPath.ToDotVector().First() == "volumeInDollars")
+        {
+            return base.GetSystemTypes(descriptor, typeof(VolumeInDollars));
+        }
+        return base.GetSystemTypes(descriptor, columnLogicalTypeOverride);
+    }
+}
+```
+
 ### Learn More
 
-Check [TestLogicalTypeFactory.cs](../csharp.test/TestLogicalTypeFactory.cs) for a more comprehensive set of examples, as there are many places that can be customized and optimized by the user.
+Check [TestLogicalTypeFactory.cs](../csharp.test/TestLogicalTypeFactory.cs) for a more comprehensive set of examples,
+as there are many places that can be customized and optimized by the user.


### PR DESCRIPTION
Fixes #423 

This adds support for converting to and from the .NET `TimeOnly` and `DateOnly` types when using the .NET 6 target. For the `TimeOnly` type, I've added support for millisecond and microsecond precision, matching the existing `TimeSpan` conversion behaviour.

In addition, I've added two options to allow customizing the built-in `LogicalTypeFactory` class so that these types can be used by default instead of the `ParquetSharp.Date` and `TimeSpan` types. I've made these settable properties so that they can be modified on the default `LogicalTypeFactory` instance to allow changing the process-wide behaviour. I'd usually tend towards using immutable objects, but in this case it seems worthwhile to allow configuring this without too much boilerplate. I'm open to other suggestions on how to handle this though.

We've also previously used AppContext switches to allow customizing behaviour in csproj configuration files (see #288), and it could make sense to support that here too?