### PR TITLE
Bump version to 15.0.0-beta2

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>15.0.0-beta1</Version>
+    <Version>15.0.0-beta2</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>


### PR DESCRIPTION
This bumps the version to 15.0.0-beta2 so we can make a new beta release with the new encryption API