### PR TITLE
Support buffered writing with the Arrow API

### DIFF
--- a/cpp/arrow/FileWriter.cpp
+++ b/cpp/arrow/FileWriter.cpp
@@ -97,9 +97,30 @@ extern "C"
     )
   }
 
+  PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_WriteRecordBatches(
+      FileWriter* writer, struct ArrowArrayStream* stream, int64_t chunk_size)
+  {
+    TRYCATCH
+    (
+        std::shared_ptr<arrow::RecordBatchReader> reader;
+        PARQUET_ASSIGN_OR_THROW(reader, arrow::ImportRecordBatchReader(stream));
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+        PARQUET_ASSIGN_OR_THROW(batches, reader->ToRecordBatches());
+        for (const auto& batch : batches)
+        {
+          PARQUET_THROW_NOT_OK(writer->WriteRecordBatch(*batch));
+        }
+    )
+  }
+
   PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewRowGroup(FileWriter* writer, int64_t chunk_size)
   {
     TRYCATCH(PARQUET_THROW_NOT_OK(writer->NewRowGroup(chunk_size));)
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewBufferedRowGroup(FileWriter* writer)
+  {
+    TRYCATCH(PARQUET_THROW_NOT_OK(writer->NewBufferedRowGroup());)
   }
 
   PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_WriteColumnChunk(

--- a/csharp/Encryption/CryptoFactory.cs
+++ b/csharp/Encryption/CryptoFactory.cs
@@ -35,7 +35,7 @@ namespace ParquetSharp.Encryption
         /// </summary>
         /// <param name="connectionConfig">The KMS connection configuration to use</param>
         /// <param name="encryptionConfig">The encryption configuration to use</param>
-        /// <param name="filePath">The path to the Parquet file being written</param>
+        /// <param name="filePath">The path to the Parquet file being written. Can be null if internal key material is used.</param>
         /// <returns>Encryption properties for the file</returns>
         public FileEncryptionProperties GetFileEncryptionProperties(
             KmsConnectionConfig connectionConfig,
@@ -58,7 +58,7 @@ namespace ParquetSharp.Encryption
         /// </summary>
         /// <param name="connectionConfig">The KMS connection configuration to use</param>
         /// <param name="decryptionConfig">The decryption configuration to use</param>
-        /// <param name="filePath">The path to the Parquet file being read</param>
+        /// <param name="filePath">The path to the Parquet file being read. Can be null if internal key material is used.</param>
         /// <returns>Decryption properties for the file</returns>
         public FileDecryptionProperties GetFileDecryptionProperties(
             KmsConnectionConfig connectionConfig,

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <Version>15.0.0-beta2</Version>
+    <Version>15.0.0-beta3</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/docs/Arrow.md
+++ b/docs/Arrow.md
@@ -164,8 +164,9 @@ if it contains more rows than the chunk size, which can be specified when writin
 writer.WriteRecordBatch(recordBatch, chunkSize: 1024);
 ```
 
-Calling `WriteRecordBatch` always starts a new row group, but you can also write
-buffered record batches, so that multiple batches may be written to the same row group:
+Calling `WriteRecordBatch` always starts a new row group, but since ParquetSharp 15.0.0,
+you can also write buffered record batches,
+so that multiple batches may be written to the same row group:
 
 ```csharp
 writer.WriteBufferedRecordBatch(recordBatch);

--- a/docs/Arrow.md
+++ b/docs/Arrow.md
@@ -164,6 +164,18 @@ if it contains more rows than the chunk size, which can be specified when writin
 writer.WriteRecordBatch(recordBatch, chunkSize: 1024);
 ```
 
+Calling `WriteRecordBatch` always starts a new row group, but you can also write
+buffered record batches, so that multiple batches may be written to the same row group:
+
+```csharp
+writer.WriteBufferedRecordBatch(recordBatch);
+```
+
+When using `WriteBufferedRecordBatch`, data will be flushed when the `FileWriter`
+is closed or `NewBufferedRowGroup` is called to start a new row group.
+A new row group will also be started if the row group size reaches the `MaxRowGroupLength`
+value configured in the `WriterProperties`.
+
 ### Writing data one column at a time
 
 Rather than writing record batches, you may also explicitly start Parquet row groups


### PR DESCRIPTION
This adds support for writing Arrow format data in buffered mode, so that multiple record batches can be written to the same Parquet row group.

This diverges a bit from the C++ API, which has `WriteTable` which starts a new row group, and `WriteRecordBatch` which is buffered. As we already have a `WriteRecordBatch` method that uses `WriteTable` internally, I've added a new `WriteBufferedRecordBatch` method.