### PR TITLE
Allow getting a ParquetFileReader and the SchemaManifest from an Arrow.FileReader

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -67,6 +67,8 @@ add_library(ParquetSharpNative SHARED
 	arrow/ArrowWriterPropertiesBuilder.cpp
 	arrow/FileReader.cpp
 	arrow/FileWriter.cpp
+	arrow/SchemaField.cpp
+	arrow/SchemaManifest.cpp
 	encryption/CryptoFactory.cpp
 	encryption/DecryptionConfiguration.cpp
 	encryption/EncryptionConfiguration.cpp

--- a/cpp/arrow/FileReader.cpp
+++ b/cpp/arrow/FileReader.cpp
@@ -4,6 +4,7 @@
 #include <arrow/c/bridge.h>
 #include <arrow/record_batch.h>
 #include <parquet/arrow/reader.h>
+#include <parquet/file_reader.h>
 
 #include "cpp/ParquetSharpExport.h"
 #include "../ExceptionInfo.h"
@@ -102,6 +103,13 @@ extern "C"
       }
       PARQUET_THROW_NOT_OK(arrow::ExportRecordBatchReader(batch_reader, stream_out));
     )
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* FileReader_ParquetReader(
+      FileReader* reader,
+      parquet::ParquetFileReader** parquet_reader)
+  {
+    TRYCATCH(*parquet_reader = reader->parquet_reader();)
   }
 
   PARQUETSHARP_EXPORT void FileReader_Free(FileReader* reader)

--- a/cpp/arrow/FileReader.cpp
+++ b/cpp/arrow/FileReader.cpp
@@ -112,6 +112,13 @@ extern "C"
     TRYCATCH(*parquet_reader = reader->parquet_reader();)
   }
 
+  PARQUETSHARP_EXPORT ExceptionInfo* FileReader_Manifest(
+      FileReader* reader,
+      const SchemaManifest** manifest)
+  {
+    TRYCATCH(*manifest = &(reader->manifest());)
+  }
+
   PARQUETSHARP_EXPORT void FileReader_Free(FileReader* reader)
   {
     delete reader;

--- a/cpp/arrow/SchemaField.cpp
+++ b/cpp/arrow/SchemaField.cpp
@@ -1,0 +1,42 @@
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <parquet/arrow/schema.h>
+#include <parquet/exception.h>
+
+#include "cpp/ParquetSharpExport.h"
+#include "../ExceptionInfo.h"
+
+using namespace parquet::arrow;
+
+extern "C"
+{
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaField_ChildrenLength(const SchemaField* field, int32_t* length)
+  {
+    TRYCATCH(*length = static_cast<int32_t>(field->children.size());)
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaField_Child(const SchemaField* field, int32_t index, const SchemaField** child)
+  {
+    TRYCATCH(
+      if (index >= static_cast<int32_t>(field->children.size()))
+      {
+        throw std::out_of_range("Child field index out of range");
+      }
+      *child = &(field->children[index]);
+    )
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaField_ColumnIndex(const SchemaField* field, int32_t* column_index)
+  {
+    TRYCATCH(
+      *column_index = field->column_index;
+    )
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaField_Field(const SchemaField* field, struct ArrowSchema* arrow_field)
+  {
+    TRYCATCH(
+      PARQUET_THROW_NOT_OK(arrow::ExportField(*(field->field), arrow_field));
+    )
+  }
+}

--- a/cpp/arrow/SchemaManifest.cpp
+++ b/cpp/arrow/SchemaManifest.cpp
@@ -1,4 +1,5 @@
 #include <parquet/arrow/schema.h>
+#include <parquet/exception.h>
 
 #include "cpp/ParquetSharpExport.h"
 #include "../ExceptionInfo.h"
@@ -21,5 +22,17 @@ extern "C"
       }
       *field = &(manifest->schema_fields[index]);
     )
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaManifest_GetColumnField(const SchemaManifest* manifest, int32_t column_index, const SchemaField** field)
+  {
+    TRYCATCH(
+      PARQUET_THROW_NOT_OK(manifest->GetColumnField(column_index, field));
+    )
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaManifest_GetParent(const SchemaManifest* manifest, const SchemaField* field, const SchemaField** parent)
+  {
+    TRYCATCH(*parent = manifest->GetParent(field);)
   }
 }

--- a/cpp/arrow/SchemaManifest.cpp
+++ b/cpp/arrow/SchemaManifest.cpp
@@ -1,0 +1,25 @@
+#include <parquet/arrow/schema.h>
+
+#include "cpp/ParquetSharpExport.h"
+#include "../ExceptionInfo.h"
+
+using namespace parquet::arrow;
+
+extern "C"
+{
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaManifest_SchemaFieldsLength(const SchemaManifest* manifest, int32_t* length)
+  {
+    TRYCATCH(*length = static_cast<int32_t>(manifest->schema_fields.size());)
+  }
+
+  PARQUETSHARP_EXPORT ExceptionInfo* SchemaManifest_SchemaField(const SchemaManifest* manifest, int32_t index, const SchemaField** field)
+  {
+    TRYCATCH(
+      if (index >= static_cast<int32_t>(manifest->schema_fields.size()))
+      {
+        throw std::out_of_range("Field index out of range");
+      }
+      *field = &(manifest->schema_fields[index]);
+    )
+  }
+}

--- a/csharp.test/Arrow/TestFileReader.cs
+++ b/csharp.test/Arrow/TestFileReader.cs
@@ -279,6 +279,26 @@ namespace ParquetSharp.Test.Arrow
         }
 
         [Test]
+        public void TestSchemaManifestGetSingleField()
+        {
+            using var buffer = new ResizableBuffer();
+            WriteNestedTestFile(buffer);
+
+            using var inStream = new BufferReader(buffer);
+            using var fileReader = new FileReader(inStream);
+
+            var manifest = fileReader.SchemaManifest;
+            var field = manifest.SchemaField(1);
+            Assert.That(field, Is.Not.Null);
+            var arrowField = field.Field;
+            Assert.That(arrowField.Name, Is.EqualTo("x"));
+            Assert.That(arrowField.DataType.TypeId, Is.EqualTo(ArrowTypeId.Int32));
+
+            var exception = Assert.Throws<ParquetException>(() => manifest.SchemaField(2));
+            Assert.That(exception!.Message, Does.Contain("out of range"));
+        }
+
+        [Test]
         public void TestSchemaManifestGetColumnField()
         {
             using var buffer = new ResizableBuffer();

--- a/csharp/Arrow/FileReader.cs
+++ b/csharp/Arrow/FileReader.cs
@@ -138,6 +138,18 @@ namespace ParquetSharp.Arrow
             return CArrowArrayStreamImporter.ImportArrayStream(&cStream);
         }
 
+        /// <summary>
+        /// Get the underlying ParquetFileReader used by this Arrow FileReader
+        /// </summary>
+        public ParquetFileReader ParquetReader
+        {
+            get
+            {
+                var readerPtr = ExceptionInfo.Return<IntPtr>(_handle, FileReader_ParquetReader);
+                return new ParquetFileReader(new ChildParquetHandle(readerPtr, _handle));
+            }
+        }
+
         public void Dispose()
         {
             _handle.Dispose();
@@ -164,6 +176,9 @@ namespace ParquetSharp.Arrow
         [DllImport(ParquetDll.Name)]
         private static extern unsafe IntPtr FileReader_GetRecordBatchReader(
             IntPtr reader, int* rowGroups, int rowGroupsCount, int* columns, int columnsCount, CArrowArrayStream* stream);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileReader_ParquetReader(IntPtr reader, out IntPtr parquetReader);
 
         [DllImport(ParquetDll.Name)]
         private static extern void FileReader_Free(IntPtr reader);

--- a/csharp/Arrow/FileReader.cs
+++ b/csharp/Arrow/FileReader.cs
@@ -150,6 +150,18 @@ namespace ParquetSharp.Arrow
             }
         }
 
+        /// <summary>
+        /// Get the schema manifest, which describes the relationship between the Arrow schema and Parquet schema
+        /// </summary>
+        public SchemaManifest SchemaManifest
+        {
+            get
+            {
+                var manifestPtr = ExceptionInfo.Return<IntPtr>(_handle, FileReader_Manifest);
+                return new SchemaManifest(new ChildParquetHandle(manifestPtr, _handle));
+            }
+        }
+
         public void Dispose()
         {
             _handle.Dispose();
@@ -179,6 +191,9 @@ namespace ParquetSharp.Arrow
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileReader_ParquetReader(IntPtr reader, out IntPtr parquetReader);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr FileReader_Manifest(IntPtr reader, out IntPtr manifest);
 
         [DllImport(ParquetDll.Name)]
         private static extern void FileReader_Free(IntPtr reader);

--- a/csharp/Arrow/SchemaField.cs
+++ b/csharp/Arrow/SchemaField.cs
@@ -13,7 +13,7 @@ namespace ParquetSharp.Arrow
     {
         internal SchemaField(INativeHandle handle)
         {
-            _handle = handle;
+            Handle = handle;
         }
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace ParquetSharp.Arrow
             get
             {
                 var cSchema = new CArrowSchema();
-                ExceptionInfo.Check(SchemaField_Field(_handle.IntPtr, &cSchema));
+                ExceptionInfo.Check(SchemaField_Field(Handle.IntPtr, &cSchema));
                 return CArrowSchemaImporter.ImportField(&cSchema);
             }
         }
@@ -33,7 +33,7 @@ namespace ParquetSharp.Arrow
         /// The Parquet column index associated with this field, or -1 if the field
         /// does not correspond to a leaf-level column.
         /// </summary>
-        public int ColumnIndex => ExceptionInfo.Return<int>(_handle, SchemaField_ColumnIndex);
+        public int ColumnIndex => ExceptionInfo.Return<int>(Handle, SchemaField_ColumnIndex);
 
         /// <summary>
         /// The child schema fields of this field
@@ -42,12 +42,12 @@ namespace ParquetSharp.Arrow
         {
             get
             {
-                var numChildren = ExceptionInfo.Return<int>(_handle, SchemaField_ChildrenLength);
+                var numChildren = ExceptionInfo.Return<int>(Handle, SchemaField_ChildrenLength);
                 var children = new SchemaField[numChildren];
                 for (var childIdx = 0; childIdx < numChildren; ++childIdx)
                 {
-                    var childPtr = ExceptionInfo.Return<int, IntPtr>(_handle, childIdx, SchemaField_Child);
-                    children[childIdx] = new SchemaField(new ChildParquetHandle(childPtr, _handle));
+                    var childPtr = ExceptionInfo.Return<int, IntPtr>(Handle, childIdx, SchemaField_Child);
+                    children[childIdx] = new SchemaField(new ChildParquetHandle(childPtr, Handle));
                 }
                 return children;
             }
@@ -65,6 +65,6 @@ namespace ParquetSharp.Arrow
         [DllImport(ParquetDll.Name)]
         private static extern unsafe IntPtr SchemaField_Field(IntPtr schemaField, CArrowSchema* schema);
 
-        private readonly INativeHandle _handle;
+        internal readonly INativeHandle Handle;
     }
 }

--- a/csharp/Arrow/SchemaField.cs
+++ b/csharp/Arrow/SchemaField.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Apache.Arrow;
+using Apache.Arrow.C;
+
+namespace ParquetSharp.Arrow
+{
+    /// <summary>
+    /// An Arrow field in a SchemaManifest
+    /// </summary>
+    public sealed class SchemaField
+    {
+        internal SchemaField(INativeHandle handle)
+        {
+            _handle = handle;
+        }
+
+        /// <summary>
+        /// The Arrow field associated with this schema field
+        /// </summary>
+        public unsafe Field Field
+        {
+            get
+            {
+                var cSchema = new CArrowSchema();
+                ExceptionInfo.Check(SchemaField_Field(_handle.IntPtr, &cSchema));
+                return CArrowSchemaImporter.ImportField(&cSchema);
+            }
+        }
+
+        /// <summary>
+        /// The Parquet column index associated with this field, or -1 if the field
+        /// does not correspond to a leaf-level column.
+        /// </summary>
+        public int ColumnIndex => ExceptionInfo.Return<int>(_handle, SchemaField_ColumnIndex);
+
+        /// <summary>
+        /// The child schema fields of this field
+        /// </summary>
+        public IReadOnlyList<SchemaField> Children
+        {
+            get
+            {
+                var numChildren = ExceptionInfo.Return<int>(_handle, SchemaField_ChildrenLength);
+                var children = new SchemaField[numChildren];
+                for (var childIdx = 0; childIdx < numChildren; ++childIdx)
+                {
+                    var childPtr = ExceptionInfo.Return<int, IntPtr>(_handle, childIdx, SchemaField_Child);
+                    children[childIdx] = new SchemaField(new ChildParquetHandle(childPtr, _handle));
+                }
+                return children;
+            }
+        }
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaField_ChildrenLength(IntPtr schemaField, out int length);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaField_Child(IntPtr schemaManifest, int index, out IntPtr child);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaField_ColumnIndex(IntPtr schemaField, out int columnIndex);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern unsafe IntPtr SchemaField_Field(IntPtr schemaField, CArrowSchema* schema);
+
+        private readonly INativeHandle _handle;
+    }
+}

--- a/csharp/Arrow/SchemaManifest.cs
+++ b/csharp/Arrow/SchemaManifest.cs
@@ -33,11 +33,41 @@ namespace ParquetSharp.Arrow
             }
         }
 
+        /// <summary>
+        /// Get the schema field for a Parquet column
+        /// </summary>
+        /// <param name="columnIndex">The Parquet column index to get the field for</param>
+        public SchemaField GetColumnField(int columnIndex)
+        {
+            var fieldPtr = ExceptionInfo.Return<int, IntPtr>(_handle, columnIndex, SchemaManifest_GetColumnField);
+            return new SchemaField(new ChildParquetHandle(fieldPtr, _handle));
+        }
+
+        /// <summary>
+        /// Get the parent field of a schema field. Returns null for top-level fields
+        /// </summary>
+        /// <param name="field">The field to get the parent for</param>
+        public SchemaField? GetParent(SchemaField field)
+        {
+            var fieldPtr = ExceptionInfo.Return<IntPtr, IntPtr>(_handle, field.Handle.IntPtr, SchemaManifest_GetParent);
+            if (fieldPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+            return new SchemaField(new ChildParquetHandle(fieldPtr, _handle));
+        }
+
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr SchemaManifest_SchemaFieldsLength(IntPtr schemaManifest, out int length);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr SchemaManifest_SchemaField(IntPtr schemaManifest, int index, out IntPtr field);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaManifest_GetColumnField(IntPtr schemaManifest, int column, out IntPtr field);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaManifest_GetParent(IntPtr schemaManifest, IntPtr field, out IntPtr parent);
 
         private readonly INativeHandle _handle;
     }

--- a/csharp/Arrow/SchemaManifest.cs
+++ b/csharp/Arrow/SchemaManifest.cs
@@ -34,6 +34,16 @@ namespace ParquetSharp.Arrow
         }
 
         /// <summary>
+        /// Get a single schema field
+        /// </summary>
+        /// <param name="fieldIndex">The index of the field in the Arrow schema</param>
+        public SchemaField SchemaField(int fieldIndex)
+        {
+            var fieldPtr = ExceptionInfo.Return<int, IntPtr>(_handle, fieldIndex, SchemaManifest_SchemaField);
+            return new SchemaField(new ChildParquetHandle(fieldPtr, _handle));
+        }
+
+        /// <summary>
         /// Get the schema field for a Parquet column
         /// </summary>
         /// <param name="columnIndex">The Parquet column index to get the field for</param>

--- a/csharp/Arrow/SchemaManifest.cs
+++ b/csharp/Arrow/SchemaManifest.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace ParquetSharp.Arrow
+{
+    /// <summary>
+    /// Describes the relationship between the Arrow schema and the Parquet schema
+    /// </summary>
+    public sealed class SchemaManifest
+    {
+        internal SchemaManifest(INativeHandle handle)
+        {
+            _handle = handle;
+        }
+
+        /// <summary>
+        /// A list of fields in this schema manifest.
+        /// The field indices correspond to the fields of the associated Arrow Schema.
+        /// </summary>
+        public IReadOnlyList<SchemaField> SchemaFields
+        {
+            get
+            {
+                var numFields = ExceptionInfo.Return<int>(_handle, SchemaManifest_SchemaFieldsLength);
+                var fields = new SchemaField[numFields];
+                for (var fieldIdx = 0; fieldIdx < numFields; ++fieldIdx)
+                {
+                    var fieldPtr = ExceptionInfo.Return<int, IntPtr>(_handle, fieldIdx, SchemaManifest_SchemaField);
+                    fields[fieldIdx] = new SchemaField(new ChildParquetHandle(fieldPtr, _handle));
+                }
+                return fields;
+            }
+        }
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaManifest_SchemaFieldsLength(IntPtr schemaManifest, out int length);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr SchemaManifest_SchemaField(IntPtr schemaManifest, int index, out IntPtr field);
+
+        private readonly INativeHandle _handle;
+    }
+}

--- a/csharp/ChildParquetHandle.cs
+++ b/csharp/ChildParquetHandle.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Holds a pointer to a native object that we don't have direct ownership of,
+    /// but is a child of another object we own.
+    /// Required when a C++ class method returns a raw pointer.
+    /// </summary>
+    internal sealed class ChildParquetHandle : INativeHandle
+    {
+        public ChildParquetHandle(IntPtr handle, ParquetHandle parentHandle)
+        {
+            _handle = handle;
+            _parentHandle = parentHandle;
+        }
+
+        public IntPtr IntPtr
+        {
+            get
+            {
+                if (_parentHandle.Disposed)
+                {
+                    throw new NullReferenceException(
+                        "Attempted to access an object whose owning parent has been disposed");
+                }
+                return _handle;
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private readonly IntPtr _handle;
+        private readonly ParquetHandle _parentHandle;
+    }
+}

--- a/csharp/ChildParquetHandle.cs
+++ b/csharp/ChildParquetHandle.cs
@@ -9,7 +9,7 @@ namespace ParquetSharp
     /// </summary>
     internal sealed class ChildParquetHandle : INativeHandle
     {
-        public ChildParquetHandle(IntPtr handle, ParquetHandle parentHandle)
+        public ChildParquetHandle(IntPtr handle, INativeHandle parentHandle)
         {
             _handle = handle;
             _parentHandle = parentHandle;
@@ -32,7 +32,9 @@ namespace ParquetSharp
         {
         }
 
+        public bool Disposed => _parentHandle.Disposed;
+
         private readonly IntPtr _handle;
-        private readonly ParquetHandle _parentHandle;
+        private readonly INativeHandle _parentHandle;
     }
 }

--- a/csharp/ExceptionInfo.cs
+++ b/csharp/ExceptionInfo.cs
@@ -69,7 +69,7 @@ namespace ParquetSharp
             return value;
         }
 
-        public static TValue Return<TValue>(ParquetHandle handle, GetFunction<TValue> getter)
+        public static TValue Return<TValue>(INativeHandle handle, GetFunction<TValue> getter)
         {
             var value = Return(handle.IntPtr, getter);
             GC.KeepAlive(handle);
@@ -82,21 +82,21 @@ namespace ParquetSharp
             return value;
         }
 
-        public static TValue Return<TValue>(ParquetHandle handle, ParquetHandle arg0, GetFunction<IntPtr, TValue> getter)
+        public static TValue Return<TValue>(INativeHandle handle, INativeHandle arg0, GetFunction<IntPtr, TValue> getter)
         {
             var value = Return(handle.IntPtr, arg0.IntPtr, getter);
             GC.KeepAlive(handle);
             return value;
         }
 
-        public static TValue Return<TArg0, TValue>(ParquetHandle handle, TArg0 arg0, GetFunction<TArg0, TValue> getter)
+        public static TValue Return<TArg0, TValue>(INativeHandle handle, TArg0 arg0, GetFunction<TArg0, TValue> getter)
         {
             var value = Return(handle.IntPtr, arg0, getter);
             GC.KeepAlive(handle);
             return value;
         }
 
-        public static TValue Return<TArg0, TArg1, TValue>(ParquetHandle handle, TArg0 arg0, TArg1 arg1, GetFunction<TArg0, TArg1, TValue> getter)
+        public static TValue Return<TArg0, TArg1, TValue>(INativeHandle handle, TArg0 arg0, TArg1 arg1, GetFunction<TArg0, TArg1, TValue> getter)
         {
             var value = Return(handle.IntPtr, arg0, arg1, getter);
             GC.KeepAlive(handle);
@@ -121,7 +121,7 @@ namespace ParquetSharp
             return ConvertPtrToString(handle, deleter, value);
         }
 
-        public static string ReturnString(ParquetHandle handle, GetFunction<IntPtr> getter, Action<IntPtr>? deleter = null)
+        public static string ReturnString(INativeHandle handle, GetFunction<IntPtr> getter, Action<IntPtr>? deleter = null)
         {
             Check(getter(handle.IntPtr, out var value));
             return ConvertPtrToString(handle, deleter, value);
@@ -134,7 +134,7 @@ namespace ParquetSharp
             return str;
         }
 
-        private static string ConvertPtrToString(ParquetHandle handle, Action<IntPtr>? deleter, IntPtr value)
+        private static string ConvertPtrToString(INativeHandle handle, Action<IntPtr>? deleter, IntPtr value)
         {
             var str = StringUtil.PtrToStringUtf8(value);
             deleter?.Invoke(value);

--- a/csharp/INativeHandle.cs
+++ b/csharp/INativeHandle.cs
@@ -5,5 +5,7 @@ namespace ParquetSharp
     internal interface INativeHandle : IDisposable
     {
         IntPtr IntPtr { get; }
+
+        bool Disposed { get; }
     }
 }

--- a/csharp/INativeHandle.cs
+++ b/csharp/INativeHandle.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace ParquetSharp
+{
+    internal interface INativeHandle : IDisposable
+    {
+        IntPtr IntPtr { get; }
+    }
+}

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -76,6 +76,11 @@ namespace ParquetSharp
             GC.KeepAlive(readerProperties);
         }
 
+        internal ParquetFileReader(INativeHandle handle)
+        {
+            _handle = handle;
+        }
+
         public void Dispose()
         {
             _fileMetaData?.Dispose();
@@ -119,7 +124,7 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ParquetFileReader_RowGroup(IntPtr reader, int i, out IntPtr rowGroupReader);
 
-        private readonly ParquetHandle _handle;
+        private readonly INativeHandle _handle;
         private FileMetaData? _fileMetaData;
         private readonly RandomAccessFile? _randomAccessFile; // Keep a handle to the input file to prevent GC
         private readonly bool _ownedFile; // Whether this reader created the RandomAccessFile

--- a/csharp/ParquetHandle.cs
+++ b/csharp/ParquetHandle.cs
@@ -5,7 +5,7 @@ namespace ParquetSharp
     /// <summary>
     /// Associate a native handle with its corresponding resource release method.
     /// </summary>
-    internal sealed class ParquetHandle : IDisposable
+    internal sealed class ParquetHandle : INativeHandle
     {
         public ParquetHandle(IntPtr handle, Action<IntPtr> free)
         {
@@ -47,6 +47,8 @@ namespace ParquetSharp
                 return _handle;
             }
         }
+
+        public bool Disposed => _handle == IntPtr.Zero;
 
         private IntPtr _handle;
         private readonly Action<IntPtr> _free;


### PR DESCRIPTION
* This allows getting a `ParquetFileReader` from an `Arrow.FileReader`, which might be required if you want to access things like the row group statistics
* In order to allow this in a safe way, I've added a new `ChildParquetHandle` class that holds a pointer to an object that is owned by some other disposable object, and added a new `INativeHandle` interface to support using either a `ParquetHandle` or `ChildParquetHandle`. There are other places in the code where we might want to use this, eg. the `RowGroupMetaData` returned from a `RowGroupReader` is one I noticed, but that should probably be a separate PR. See also #322
* Additionally, to be able to interpret the Parquet metadata when the file has a complex nested structure, expose the `SchemaManifest` associated with a `FileReader`
