### PR TITLE
Make sure that RandomAccessFile is not freed prematurely

### DIFF
--- a/csharp.test/TestParquetFileReader.cs
+++ b/csharp.test/TestParquetFileReader.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using NUnit.Framework;
+using ParquetSharp.IO;
 
 namespace ParquetSharp.Test
 {
@@ -56,6 +57,43 @@ namespace ParquetSharp.Test
             });
 
             Assert.That(exception?.Message, Does.StartWith("Tried to get a LogicalColumnReader"));
+        }
+
+        /// <summary>
+        /// Test that finalizers work correctly and do not crash when we forget to dispose the ParquetFileReader 
+        /// </summary>
+        [Test]
+        public static void TestResourcesCleanupWithoutDispose()
+        {
+            var expected = Enumerable.Range(0, 1024).ToArray();
+            var filePath = "test.parquet";
+
+            // Write test data.
+            using (var writer = new ParquetFileWriter(filePath, new Column[] { new Column<int>("ids") }))
+            {
+                using var groupWriter = writer.AppendRowGroup();
+                using var columnWriter = groupWriter.NextColumn().LogicalWriter<int>();
+                columnWriter.WriteBatch(expected);
+                writer.Close();
+            }
+
+            var resourceLeak = new Action(() =>
+            {
+                var fileStream = File.OpenRead(filePath); // no explicit dispose
+                using var managedFile = new ManagedRandomAccessFile(fileStream);
+                var reader = new ParquetFileReader(managedFile); // no explicit dispose
+                using var groupReader = reader.RowGroup(0);
+                using var columnReader = groupReader.Column(0).LogicalReader<int>();
+                columnReader.ReadAll(expected.Length);
+            });
+
+            // We use an action delegate, to make sure that lifespan of objects is not extended beyond the `{}` scope
+            resourceLeak.Invoke();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.DoesNotThrow(() => File.Delete(filePath));
         }
 
         [Test]

--- a/csharp.test/TestParquetFileReader.cs
+++ b/csharp.test/TestParquetFileReader.cs
@@ -69,7 +69,7 @@ namespace ParquetSharp.Test
             var filePath = "test.parquet";
 
             // Write test data.
-            using (var writer = new ParquetFileWriter(filePath, new Column[] { new Column<int>("ids") }))
+            using (var writer = new ParquetFileWriter(filePath, new Column[] {new Column<int>("ids")}))
             {
                 using var groupWriter = writer.AppendRowGroup();
                 using var columnWriter = groupWriter.NextColumn().LogicalWriter<int>();


### PR DESCRIPTION
Fixes https://github.com/G-Research/ParquetSharp/issues/432

By capturing the `RandomAccessFile` in the `Free` method, we make sure that it is not collected before the `Free` method is called.

