### PR TITLE
Use a local port of re2 with a patch to work with cmake 3.29.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,7 +48,7 @@ USER vscode
 
 # Copy our vcpkg manifest and ports
 COPY --chown=vscode:vscode vcpkg.json /tmp/build/
-COPY --chown=vscode:vscode ports /tmp/build/
+COPY --chown=vscode:vscode ports /tmp/build/ports
 
 # Install vcpkg
 RUN sudo mkdir -p $VCPKG_ROOT \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,8 +46,9 @@ FROM cpp AS vcpkg
 
 USER vscode
 
-# Copy our vcpkg manifest
+# Copy our vcpkg manifest and ports
 COPY --chown=vscode:vscode vcpkg.json /tmp/build/
+COPY --chown=vscode:vscode ports /tmp/build/
 
 # Install vcpkg
 RUN sudo mkdir -p $VCPKG_ROOT \

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 **
 !vcpkg.json
+!ports
 !*/*.csproj

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -9,6 +9,7 @@ on:
       - "vcpkg.json"
       - "*/*.csproj"
       - ".github/workflows/devcontainer.yml"
+      - "ports/**"
   pull_request:
     branches: [master]
     paths:
@@ -17,6 +18,7 @@ on:
       - "vcpkg.json"
       - "*/*.csproj"
       - ".github/workflows/devcontainer.yml"
+      - "ports/**"
   # Run once a week
   schedule:
     - cron: "34 2 * * 2"

--- a/ports/re2/portfile.cmake
+++ b/ports/re2/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/re2
+    REF "${VERSION}"
+    SHA512 b033bb38020947cce49f7fa27c711a49bd147a0286993852ed7fea6f653af5b2f48b8de9dae324596e44a1731e8747382a4151f6f5d44b1d92ce2748b83ca85c
+    HEAD_REF master
+    PATCHES
+        remove_include_dir.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DRE2_BUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/re2/remove_include_dir.patch
+++ b/ports/re2/remove_include_dir.patch
@@ -1,0 +1,13 @@
+diff --git a/re2Config.cmake.in b/re2Config.cmake.in
+index 6a177c6..be7b6bc 100644
+--- a/re2Config.cmake.in
++++ b/re2Config.cmake.in
+@@ -6,8 +6,6 @@
+ 
+ include(CMakeFindDependencyMacro)
+ 
+-set_and_check(re2_INCLUDE_DIR ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@)
+-
+ if(UNIX)
+   set(THREADS_PREFER_PTHREAD_FLAG ON)
+   find_dependency(Threads REQUIRED)

--- a/ports/re2/vcpkg.json
+++ b/ports/re2/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "re2",
+  "version-date": "2023-07-01",
+  "description": "RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.",
+  "homepage": "https://github.com/google/re2",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "abseil",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,5 +11,8 @@
       "name": "arrow",
       "version": "15.0.2"
     }
-  ]
+  ],
+  "vcpkg-configuration": {
+    "overlay-ports": ["./ports"]
+  }
 }


### PR DESCRIPTION
See https://github.com/google/re2/issues/488 and https://github.com/microsoft/vcpkg/issues/38064 for context