### PR TITLE
Use net8.0 SDK

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:0-7.0-bullseye-slim AS dotnet
+FROM mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm-slim AS dotnet
 
 #====================================================================
 
@@ -19,13 +19,12 @@ RUN for project in /tmp/build/csharp*; do \
 FROM dotnet AS cpp
 
 # Install the C++ dev tools
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list \
- && apt-get update \
+RUN apt-get update \
  && export DEBIAN_FRONTEND=noninteractive \
  && apt-get -y install --no-install-recommends \
     bison \
     build-essential \
-    cmake/bullseye-backports \
+    cmake \
     cppcheck \
     flex \
     gdb \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v7.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Code formating check
         run: |
           dotnet tool restore
@@ -148,10 +148,10 @@ jobs:
       run: brew install bison
 
     # .NET Core Setup (and also MSBuild for Windows).
-    - name: Setup .NET SDK v7.0.x
+    - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Setup MSBuild
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v2
@@ -217,10 +217,10 @@ jobs:
       run: |
         mkdir bin
         cp -rv artifacts/*-native-library/* bin/
-    - name: Setup .NET SDK v7.0.x
+    - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Get version
       id: get-version
       shell: pwsh
@@ -248,13 +248,13 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, macos-12, macos-13-xlarge, windows-2022, ubuntu-20.04-arm64]
-        dotnet: [netcoreapp3.1, net6.0, net7.0]
+        os: [ubuntu-20.04, macos-12, macos-13, macos-14, windows-2022, ubuntu-20.04-arm64]
+        dotnet: [netcoreapp3.1, net6.0, net7.0, net8.0]
         include:
         - os: windows-2022
           dotnet: net472
         exclude:
-        - os: macos-13-xlarge
+        - os: macos-14
           dotnet: netcoreapp3.1
       fail-fast: false
     name: Test NuGet package (${{ matrix.dotnet }} on ${{ matrix.os }})
@@ -279,9 +279,14 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Setup .NET SDK v7.0.x
+      if: matrix.dotnet == 'net7.0'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 7.0.x
+    - name: Setup .NET SDK v8.0.x
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
     - name: Add local NuGet feed
       run: |
         dotnet new nugetconfig
@@ -336,10 +341,10 @@ jobs:
       with:
         name: nuget-package
         path: nuget
-    - name: Setup .NET SDK v7.0.x
+    - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     # if version contains "-" treat it as pre-release
     # example: 1.0.0-beta1
     - name: Create release

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ devcontainer exec dotnet test csharp.test
 
 Building ParquetSharp natively requires the following dependencies:
 - A modern C++ compiler toolchain
-- .NET SDK 7.0
+- .NET SDK 8.0
 - Apache Arrow (15.0.2)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://vcpkg.io).

--- a/csharp.benchmark/ParquetSharp.Benchmark.csproj
+++ b/csharp.benchmark/ParquetSharp.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp.Benchmark</AssemblyName>

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
-    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/fsharp.test/ParquetSharp.Test.FSharp.fsproj
+++ b/fsharp.test/ParquetSharp.Test.FSharp.fsproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
-    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <PlatformTarget Condition="'$(TargetFramework)'=='net472'">x64</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.100",
+      "version": "8.0.100",
       "rollForward": "latestMinor"
     }
   }


### PR DESCRIPTION
This PR updates our project files, devcontainer, and CI to use the latest .NET 8 SDK.

It also updates the macOS test targets in the CI: `macos-11` is deprecated and thus removed, `macos-14` is added and runs on Apple Silicon (aka arm64), `macos-13-xlarge` wasn't free and is replaced by `macos-13` which runs on Intel (aka x86_64) instead of Apple Silicon.