### PR TITLE
Use a newer version of curl in the CentOS 7 container to fix vcpkg cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       run: |
         docker run -d --name centos --entrypoint tail -v $PWD:$PWD -v $VCPKG_INSTALLATION_ROOT:$VCPKG_INSTALLATION_ROOT centos:7 -f /dev/null
         docker exec centos sh -c "yum install -y centos-release-scl epel-release && \
-                                  yum install -y devtoolset-7 rh-git227 flex bison perl-Data-Dumper perl-IPC-Cmd && \
+                                  yum install -y devtoolset-7 rh-git227 httpd24-curl flex bison perl-Data-Dumper perl-IPC-Cmd && \
                                   curl -fsSL -o /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v${{ steps.cmake-info.outputs.version }}/cmake-${{ steps.cmake-info.outputs.version }}-linux-x86_64.sh && \
                                   sh /tmp/cmake.sh --skip-license --prefix=/usr/local && \
                                   rm /tmp/cmake.sh"
@@ -138,7 +138,7 @@ jobs:
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: |
         if [ "${{ runner.os }}" == "Linux" ] && [ "${{ matrix.arch }}" == "x64" ]; then
-          exec="docker exec -w $PWD -e GITHUB_ACTIONS -e ACTIONS_CACHE_URL -e ACTIONS_RUNTIME_TOKEN -e VCPKG_BINARY_SOURCES -e VCPKG_INSTALLATION_ROOT centos scl enable devtoolset-7 rh-git227 --"
+          exec="docker exec -w $PWD -e GITHUB_ACTIONS -e ACTIONS_CACHE_URL -e ACTIONS_RUNTIME_TOKEN -e VCPKG_BINARY_SOURCES -e VCPKG_INSTALLATION_ROOT centos scl enable devtoolset-7 rh-git227 httpd24 --"
         fi
         $exec ./build_unix.sh ${{ matrix.arch }}
       env:


### PR DESCRIPTION
GHA vcpkg binary caching uses the `--data-raw` curl parameter, which is not supported in the default version of curl that ships with CentOS 7 (7.29.0). Using curl 7.61.1 instead fixes vcpkg binary caching upload.