### PR TITLE
Use vcpkg binary caching in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,61 +22,27 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Compute vcpkg triplet and root
-    - name: Compute vcpkg triplet and root
-      id: vcpkg-info
-      run: |
-        triplet="x64-"
-        case ${{ runner.os }} in
-          Linux)
-            triplet+="linux"
-            ;;
-          macOS)
-            triplet+="osx"
-            ;;
-          Windows)
-            triplet+="windows-static"
-            ;;
-        esac
-        echo "triplet=$triplet" >> $GITHUB_OUTPUT
-        echo "root=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_OUTPUT
-      shell: bash
-
-    # Get cmake version, which is used by vcpkg binary caching
-    - name: Get cmake version
-      id: cmake-info
-      run: echo "version=$(cmake --version | head -n1 | awk '{print $3}')" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Runner-info
-      id: runner-info
-      run: |
-        echo "info=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
-      shell: bash
-
-    # Check for cached vcpkg dependencies (use these if we can).
-    - name: Get cached vcpkg dependencies
-      id: get-cached-vcpkg
-      uses: actions/cache@v4
-      with:
-        path: cache/vcpkg
-        key: vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake:${{ steps.cmake-info.outputs.version }}-vcpkg_json:${{ hashFiles('vcpkg*.json') }}-runner:${{ steps.runner-info.outputs.info }}
-        restore-keys: |
-          vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake:${{ steps.cmake-info.outputs.version }}-vcpkg_json:${{ hashFiles('vcpkg*.json') }}
-          vcpkg-${{ steps.vcpkg-info.outputs.triplet }}-cmake:${{ steps.cmake-info.outputs.version }}
-          vcpkg-${{ steps.vcpkg-info.outputs.triplet }}
-
     # Ensure vcpkg builtin registry is up-to-date
     - name: Update vcpkg builtin registry
-      working-directory: ${{ steps.vcpkg-info.outputs.root }}
       run: |
+        cd $VCPKG_INSTALLATION_ROOT
         git reset --hard
         git pull
+
+    - name: Setup .NET SDK v8.0.x
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: cpp, csharp
+
+    # Expose GitHub Runtime environment variables for vcpkg caching.
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v3
 
     - name: Build C++ library and CSharp projects
       run: |
@@ -84,6 +50,8 @@ jobs:
         dotnet build csharp.benchmark --configuration=Release
         dotnet build csharp.test --configuration=Release
         dotnet build csharp --configuration=Release
+      env:
+        VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
The CodeQL workflow has never properly used vcpkg binary caching, even with our previous all-or-nothing approach, as `VCPKG_BINARY_SOURCES` was not set. This PR updates the workflow to follow the approach introduced in #457.