### PR TITLE
Fix specifying version-suffix parameter in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
         echo "version=${version}" >> $env:GITHUB_OUTPUT
         echo "version_suffix=${version_suffix}" >> $env:GITHUB_OUTPUT
     - name: Build NuGet package
-      run: dotnet build csharp --configuration=Release --version-suffix="${{ steps.get-version.outputs.version_suffix }}"
+      run: dotnet build csharp --configuration=Release --version-suffix "${{ steps.get-version.outputs.version_suffix }}"
     - name: Upload NuGet artifact
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
For some reason:
```
dotnet build csharp --version-suffix="something"
```
is ok, but
```
dotnet build csharp --version-suffix=""
```
fails with "Required argument missing for option: '--version-suffix'." (see https://github.com/G-Research/ParquetSharp/actions/runs/9636767326/job/26575196786)

We need to instead use:
```
dotnet build csharp --version-suffix ""
```