### PR TITLE
ci: use `macos-12` to build the native library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2022]
+        os: [ubuntu-20.04, macos-12, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022


### PR DESCRIPTION
The macOS-11 environment is deprecated and will be removed on June 28th, 2024. More info here: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/.