### PR TITLE
Bump version of macos used to build the native library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2022]
+        os: [ubuntu-20.04, macos-12, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022


### PR DESCRIPTION
The macos-11 images are being deprecated, see failures due to the brownout in https://github.com/G-Research/ParquetSharp/actions/runs/9643175788.

I've just bumped to macos-12 rather than 13 or the ARM based macos-14 images as I'm not certain whether a native library built on macos would be compatible with older versions. It sounds like we might be able to work around that by setting the `MACOSX_DEPLOYMENT_TARGET` environment variable but I'm not familiar with building on mac.