### PR TITLE
Use GitHub provided arm64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,12 +219,14 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, macos-13, macos-14, windows-2022, ubuntu-20.04-arm64]
+        os: [ubuntu-20.04, ubuntu-22.04-arm64, macos-12, macos-13, macos-14, windows-2022]
         dotnet: [netcoreapp3.1, net6.0, net7.0, net8.0]
         include:
         - os: windows-2022
           dotnet: net472
         exclude:
+        - os: ubuntu-22.04-arm64
+          dotnet: netcoreapp3.1
         - os: macos-14
           dotnet: netcoreapp3.1
       fail-fast: false

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, ubuntu-20.04-arm64]
+        runner: [ubuntu-latest, ubuntu-22.04-arm64]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
Following [GitHub's announcement](https://github.blog/2024-06-03-arm64-on-github-actions-powering-faster-more-efficient-build-systems/) of provided arm64 runners, this PR switches us to these built-in ones. This requires us to bump the version of Ubuntu we test on to 22.04 for arm64, which is fair enough as this ecosystem has less legacy than x64.