### PR TITLE
ci: use pypa/manylinux image instead of vanilla CentOS image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,8 @@ jobs:
     - name: Start CentOS container and install toolchain
       if: runner.os == 'Linux' && matrix.arch == 'x64'
       run: |
-        docker run -d --name centos --entrypoint tail -v $PWD:$PWD -v $VCPKG_INSTALLATION_ROOT:$VCPKG_INSTALLATION_ROOT centos:7 -f /dev/null
-        docker exec centos sh -c "yum install -y centos-release-scl epel-release && \
-                                  yum install -y devtoolset-7 rh-git227 httpd24-curl flex bison perl-Data-Dumper perl-IPC-Cmd && \
+        docker run -d --name centos --entrypoint tail -v $PWD:$PWD -v $VCPKG_INSTALLATION_ROOT:$VCPKG_INSTALLATION_ROOT quay.io/pypa/manylinux2014_x86_64 -f /dev/null
+        docker exec centos sh -c "yum install -y devtoolset-7 rh-git227 httpd24-curl flex bison perl-Data-Dumper perl-IPC-Cmd && \
                                   curl -fsSL -o /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v${{ steps.cmake-info.outputs.version }}/cmake-${{ steps.cmake-info.outputs.version }}-linux-x86_64.sh && \
                                   sh /tmp/cmake.sh --skip-license --prefix=/usr/local && \
                                   rm /tmp/cmake.sh"


### PR DESCRIPTION
Following the EOL of CentOS 7, `mirrorlist.centos.org` no longer resolves. The [pypa/manylinux](https://github.com/pypa/manylinux) 2014 image has been updated to use `vault.centos.org` instead and will likely keep up with any other changes so I suggest we switch to it for now.