### PR TITLE
Fix out of memory errors causing logic_error when using ManagedRandomAccessFile

### DIFF
--- a/cpp/Enums.cpp
+++ b/cpp/Enums.cpp
@@ -97,6 +97,10 @@ namespace
 		static_assert(::arrow::TimeUnit::type::MILLI == 1);
 		static_assert(::arrow::TimeUnit::type::MICRO == 2);
 		static_assert(::arrow::TimeUnit::type::NANO == 3);
-	}
 
+		// Arrow StatusCode values that should be kept up to date with ArrowStatusCode.cs
+		static_assert((int) ::arrow::StatusCode::OutOfMemory == 1);
+		static_assert((int) ::arrow::StatusCode::IOError == 5);
+		static_assert((int) ::arrow::StatusCode::UnknownError == 9);
+	}
 }

--- a/cpp/ExceptionInfo.h
+++ b/cpp/ExceptionInfo.h
@@ -3,6 +3,8 @@
 #include <exception>
 #include <string>
 
+#include <parquet/exception.h>
+
 struct ExceptionInfo final
 {
 	ExceptionInfo(const char* type, const char* message);
@@ -14,23 +16,28 @@ struct ExceptionInfo final
 };
 
 #define SINGLE_ARG(...) __VA_ARGS__
-#define TRYCATCH(expression)												\
-	try																		\
-	{																		\
-		expression															\
-		return nullptr;														\
-	}																		\
-	catch (const std::bad_alloc& exception)									\
-	{																		\
-		return new ExceptionInfo("OutOfMemoryException", exception.what()); \
-	}																		\
-	catch (const std::exception& exception)									\
-	{																		\
-		return new ExceptionInfo(exception);								\
-	}																		\
-	catch (...)																\
-	{																		\
-		return new ExceptionInfo("unkown", "uncaught exception");			\
-	}																		\
-
+#define TRYCATCH(expression)                                             \
+  try                                                                    \
+  {                                                                      \
+    expression                                                           \
+    return nullptr;                                                      \
+  }                                                                      \
+  catch (const std::bad_alloc& exception)                                \
+  {                                                                      \
+    return new ExceptionInfo("OutOfMemoryException", exception.what());  \
+  }                                                                      \
+  catch (const parquet::ParquetStatusException& exception)               \
+  {                                                                      \
+    return exception.status().IsOutOfMemory()                            \
+      ? new ExceptionInfo("OutOfMemoryException", exception.what())      \
+      : new ExceptionInfo(exception);                                    \
+  }                                                                      \
+  catch (const std::exception& exception)                                \
+  {                                                                      \
+    return new ExceptionInfo(exception);                                 \
+  }                                                                      \
+  catch (...)                                                            \
+  {                                                                      \
+    return new ExceptionInfo("unknown", "uncaught exception");           \
+  }                                                                      \
 

--- a/cpp/ManagedRandomAccessFile.cpp
+++ b/cpp/ManagedRandomAccessFile.cpp
@@ -121,7 +121,7 @@ private:
 			return Result<T>(result);
 		}
 
-		return Result<T>(Status(statusCode, exception));
+		return Result<T>(Status(statusCode, exception == nullptr ? "" : exception));
 	}
 
 	static Status GetStatus(const StatusCode statusCode, const char* const exception)

--- a/csharp/ArrowStatusCode.cs
+++ b/csharp/ArrowStatusCode.cs
@@ -1,0 +1,12 @@
+namespace ParquetSharp
+{
+    /// <summary>
+    /// Subset of Arrow StatusCode enums used from ParquetSharp.
+    /// </summary>
+    internal enum ArrowStatusCode
+    {
+        OutOfMemory = 1,
+        IOError = 5,
+        UnknownError = 9,
+    }
+}

--- a/csharp/IO/ManagedRandomAccessFile.cs
+++ b/csharp/IO/ManagedRandomAccessFile.cs
@@ -168,16 +168,16 @@ namespace ParquetSharp.IO
             if (error is OutOfMemoryException)
             {
                 exception = _exceptionMessage = null;
-                return 1;
+                return (byte) ArrowStatusCode.OutOfMemory;
             }
             if (error is IOException)
             {
                 exception = _exceptionMessage = error.ToString();
-                return 5;
+                return (byte) ArrowStatusCode.IOError;
             }
 
             exception = _exceptionMessage = error.ToString();
-            return 9;
+            return (byte) ArrowStatusCode.UnknownError;
         }
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <VersionPrefix>16.1.0-beta1</VersionPrefix>
+    <VersionPrefix>16.1.0-beta2</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>


### PR DESCRIPTION
When one of the `ManagedRandomAccessFile` methods called from C++ caused an `OutOfMemoryException`, the exception message was set to `null` in `HandleException`, but this caused a `std::logic_error` on the C++ side when trying to convert `nullptr` to `std::string` when constructing an `arrow::Status` in  `ManagedRandomAccessFile::GetResult`. The error looks like:

```
ParquetSharp.ParquetException: St11logic_error (message: 'basic_string::_S_construct null not valid')
```

I've added a check for `exception == nullptr` to fix this.

I've also changed the `TRYCATCH` macro so that these errors are propagated out as an `OutOfMemoryException` again, and fixed the use of plain integers for status codes.