### PR TITLE
Add comparison operators and FromDotnetTicks to DateTimeNanos

### DIFF
--- a/csharp/DateTimeNanos.cs
+++ b/csharp/DateTimeNanos.cs
@@ -10,6 +10,16 @@ namespace ParquetSharp
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct DateTimeNanos : IEquatable<DateTimeNanos>, IComparable, IComparable<DateTimeNanos>
     {
+        /// <summary>
+        /// Minimum DateTime representable: 1677-09-21 00:12:43.
+        /// </summary>
+        public static readonly DateTime MinDateTimeValue = new DateTimeNanos(long.MinValue).DateTime;
+
+        /// <summary>
+        /// Maximum DateTime representable: 2262-04-11 23:47:16.
+        /// </summary>
+        public static readonly DateTime MaxDateTimeValue = new DateTimeNanos(long.MaxValue).DateTime;
+
         public DateTimeNanos(long ticks)
         {
             Ticks = ticks;
@@ -17,7 +27,15 @@ namespace ParquetSharp
 
         public DateTimeNanos(DateTime dateTime)
         {
-            Ticks = (dateTime.Ticks - DateTimeOffset) * (1_000_000L / TimeSpan.TicksPerMillisecond);
+            Ticks = DotnetTicksToNanosSinceEpoch(dateTime.Ticks);
+        }
+
+        /// <summary>
+        /// Make a new <see cref="DateTimeNanos"/> object from a specified dotnet ticks value
+        /// </summary>
+        public static DateTimeNanos FromDotnetTicks(long dotnetTicks)
+        {
+            return new DateTimeNanos(DotnetTicksToNanosSinceEpoch(dotnetTicks));
         }
 
         /// <summary>
@@ -28,7 +46,7 @@ namespace ParquetSharp
         /// <summary>
         /// Convert to System.DateTime with reduced precision.
         /// </summary>
-        public DateTime DateTime => new DateTime(DateTimeOffset + Ticks / (1_000_000L / TimeSpan.TicksPerMillisecond));
+        public DateTime DateTime => new(NanosSinceEpochToDotnetTicks(Ticks));
 
         public bool Equals(DateTimeNanos other)
         {
@@ -60,6 +78,36 @@ namespace ParquetSharp
             return Ticks.CompareTo(other.Ticks);
         }
 
+        public static bool operator ==(DateTimeNanos left, DateTimeNanos right)
+        {
+            return left.Ticks == right.Ticks;
+        }
+
+        public static bool operator !=(DateTimeNanos left, DateTimeNanos right)
+        {
+            return left.Ticks != right.Ticks;
+        }
+
+        public static bool operator <(DateTimeNanos left, DateTimeNanos right)
+        {
+            return left.Ticks < right.Ticks;
+        }
+
+        public static bool operator <=(DateTimeNanos left, DateTimeNanos right)
+        {
+            return left.Ticks <= right.Ticks;
+        }
+
+        public static bool operator >=(DateTimeNanos left, DateTimeNanos right)
+        {
+            return left.Ticks >= right.Ticks;
+        }
+
+        public static bool operator >(DateTimeNanos left, DateTimeNanos right)
+        {
+            return left.Ticks > right.Ticks;
+        }
+
         /// <summary>
         /// Converts this DateTimeNanos object to a string using a default formatting string with nanosecond precision
         /// and the current culture's formatting conventions.
@@ -89,18 +137,18 @@ namespace ParquetSharp
             return DateTime.ToString(adjustedFormat, formatProvider);
         }
 
-        /// <summary>
-        /// Minimum DateTime representable: 1677-09-21 00:12:43.
-        /// </summary>
-        public static readonly DateTime MinDateTimeValue = new DateTimeNanos(long.MinValue).DateTime;
-
-        /// <summary>
-        /// Maximum DateTime representable: 2262-04-11 23:47:16.
-        /// </summary>
-        public static readonly DateTime MaxDateTimeValue = new DateTimeNanos(long.MaxValue).DateTime;
-
-        private const long DateTimeOffset = 621355968000000000; // new DateTime(1970, 01, 01).Ticks
-
+        private const long DateTimeOffsetTicks = 621355968000000000; // new DateTime(1970, 01, 01).Ticks
         private const string DefaultFormat = "yyyy-MM-dd HH:mm:ss.fffffffff";
+        private const long NanosPerTick = 1_000_000L / TimeSpan.TicksPerMillisecond;
+
+        private static long DotnetTicksToNanosSinceEpoch(long dotnetTicks)
+        {
+            return (dotnetTicks - DateTimeOffsetTicks) * NanosPerTick;
+        }
+
+        private static long NanosSinceEpochToDotnetTicks(long nanosSinceEpoch)
+        {
+            return DateTimeOffsetTicks + nanosSinceEpoch / NanosPerTick;
+        }
     }
 }

--- a/csharp/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/csharp/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -831,6 +831,13 @@ static ParquetSharp.Arrow.ArrowReaderProperties.GetDefault() -> ParquetSharp.Arr
 static ParquetSharp.Arrow.ArrowWriterProperties.GetDefault() -> ParquetSharp.Arrow.ArrowWriterProperties!
 static ParquetSharp.Column.CreateSchemaNode(ParquetSharp.Column![]! columns, ParquetSharp.LogicalTypeFactory! logicalTypeFactory, string! nodeName = "schema") -> ParquetSharp.Schema.GroupNode!
 static ParquetSharp.Column.CreateSchemaNode(ParquetSharp.Column![]! columns, string! nodeName = "schema") -> ParquetSharp.Schema.GroupNode!
+static ParquetSharp.DateTimeNanos.FromDotnetTicks(long dotnetTicks) -> ParquetSharp.DateTimeNanos
+static ParquetSharp.DateTimeNanos.operator !=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator <(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator <=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator ==(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator >(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator >=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
 static ParquetSharp.DefaultWriterProperties.Compression.get -> ParquetSharp.Compression?
 static ParquetSharp.DefaultWriterProperties.Compression.set -> void
 static ParquetSharp.DefaultWriterProperties.CompressionLevel.get -> int?

--- a/csharp/PublicAPI/net6/PublicAPI.Shipped.txt
+++ b/csharp/PublicAPI/net6/PublicAPI.Shipped.txt
@@ -835,6 +835,13 @@ static ParquetSharp.Arrow.ArrowReaderProperties.GetDefault() -> ParquetSharp.Arr
 static ParquetSharp.Arrow.ArrowWriterProperties.GetDefault() -> ParquetSharp.Arrow.ArrowWriterProperties!
 static ParquetSharp.Column.CreateSchemaNode(ParquetSharp.Column![]! columns, ParquetSharp.LogicalTypeFactory! logicalTypeFactory, string! nodeName = "schema") -> ParquetSharp.Schema.GroupNode!
 static ParquetSharp.Column.CreateSchemaNode(ParquetSharp.Column![]! columns, string! nodeName = "schema") -> ParquetSharp.Schema.GroupNode!
+static ParquetSharp.DateTimeNanos.FromDotnetTicks(long dotnetTicks) -> ParquetSharp.DateTimeNanos
+static ParquetSharp.DateTimeNanos.operator !=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator <(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator <=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator ==(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator >(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator >=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
 static ParquetSharp.DefaultWriterProperties.Compression.get -> ParquetSharp.Compression?
 static ParquetSharp.DefaultWriterProperties.Compression.set -> void
 static ParquetSharp.DefaultWriterProperties.CompressionLevel.get -> int?

--- a/csharp/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/csharp/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -831,6 +831,13 @@ static ParquetSharp.Arrow.ArrowReaderProperties.GetDefault() -> ParquetSharp.Arr
 static ParquetSharp.Arrow.ArrowWriterProperties.GetDefault() -> ParquetSharp.Arrow.ArrowWriterProperties!
 static ParquetSharp.Column.CreateSchemaNode(ParquetSharp.Column![]! columns, ParquetSharp.LogicalTypeFactory! logicalTypeFactory, string! nodeName = "schema") -> ParquetSharp.Schema.GroupNode!
 static ParquetSharp.Column.CreateSchemaNode(ParquetSharp.Column![]! columns, string! nodeName = "schema") -> ParquetSharp.Schema.GroupNode!
+static ParquetSharp.DateTimeNanos.FromDotnetTicks(long dotnetTicks) -> ParquetSharp.DateTimeNanos
+static ParquetSharp.DateTimeNanos.operator !=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator <(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator <=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator ==(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator >(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
+static ParquetSharp.DateTimeNanos.operator >=(ParquetSharp.DateTimeNanos left, ParquetSharp.DateTimeNanos right) -> bool
 static ParquetSharp.DefaultWriterProperties.Compression.get -> ParquetSharp.Compression?
 static ParquetSharp.DefaultWriterProperties.Compression.set -> void
 static ParquetSharp.DefaultWriterProperties.CompressionLevel.get -> int?


### PR DESCRIPTION
This reapplies the changes from #476 after they were reverted for the 16.1.0 release in #477