### PR TITLE
Fix reading required string values inside an optional group

### DIFF
--- a/csharp/LogicalBatchReader/LogicalBatchReaderFactory.cs
+++ b/csharp/LogicalBatchReader/LogicalBatchReaderFactory.cs
@@ -56,7 +56,9 @@ namespace ParquetSharp.LogicalBatchReader
 
             // Otherwise we have a more complex structure and use a buffered reader
             var leafDefinitionLevel = (short) schemaNodes.Count(n => n.Repetition != Repetition.Required);
-            var nullableLeafValues = schemaNodes.Last().Repetition == Repetition.Optional;
+            // Reference typed leaf values are always treated as nullable as the converters are created based on the
+            // .NET type and don't consider the schema nullability.
+            var nullableLeafValues = schemaNodes.Last().Repetition == Repetition.Optional || !typeof(TLogical).IsValueType;
             _bufferedReader = new BufferedReader<TLogical, TPhysical>(
                 _physicalReader, _converter, _buffers.Values, _buffers.DefLevels, _buffers.RepLevels, leafDefinitionLevel, nullableLeafValues);
             return GetCompoundReader<TElement>(schemaNodes, 0, 0);


### PR DESCRIPTION
Fixes #480.

When string values are required and inside an optional nested group, the group is skipped over in `LogicalBatchReaderFactory` and we only use a single `LeafReader` instance to read values. This should read null into destination rows where the enclosing group is null. But when `_nullableLeafValues` is false in the `BufferedReader`, only the non-null values would be read so we'd reach the end of the values before reaching the expected number of rows/levels.

We don't have the same problem for a required int inside an optional group for example as this is detected in `GetCompoundReader` when `typeof(TElement) != typeof(TLogical)` and is handled specially with the `OptionalReader` class.