### PR TITLE
Support reading and writing decimals with arbitrary length fixed-length byte array columns and writing with int32 or int64

### DIFF
--- a/csharp.test/TestDecimal.cs
+++ b/csharp.test/TestDecimal.cs
@@ -436,17 +436,23 @@ namespace ParquetSharp.Test
 
         private static decimal RandomDecimal(Random random, int scale, int parquetPrecision = 29)
         {
-            var intRange = 1 + (long) int.MaxValue - (long) int.MinValue;
-            var low = (int) (int.MinValue + random.NextInt64(0, intRange));
-            var mid = (int) (int.MinValue + random.NextInt64(0, intRange));
-            var high = (int) (int.MinValue + random.NextInt64(0, intRange));
-            var negative = random.NextSingle() < 0.5;
+            var low = RandomInt(random);
+            var mid = RandomInt(random);
+            var high = RandomInt(random);
+            var negative = random.Next(0, 2) == 0;
             var value = new decimal(low, mid, high, negative, (byte) scale);
             if (parquetPrecision < 29)
             {
                 value = decimal.Round(value * new decimal(Math.Pow(10, parquetPrecision - 29)), scale);
             }
             return value;
+        }
+
+        private static int RandomInt(Random random)
+        {
+            var buffer = new byte[sizeof(int)];
+            random.NextBytes(buffer);
+            return BitConverter.ToInt32(buffer, 0);
         }
     }
 }

--- a/csharp.test/TestDecimal.cs
+++ b/csharp.test/TestDecimal.cs
@@ -30,7 +30,7 @@ namespace ParquetSharp.Test
             }
 
             var read = new decimal[numRows];
-            multiplier = Decimal128.GetScaleMultiplier(scale);
+            multiplier = DecimalConverter.GetScaleMultiplier(scale, precision);
             for (var i = 0; i < numRows; ++i)
             {
                 read[i] = (*(Decimal128*) converted[i].Pointer).ToDecimal(multiplier);
@@ -52,7 +52,7 @@ namespace ParquetSharp.Test
             using var byteBuffer = new ByteBuffer(8 * typeLength * numRows);
             var converted = new ByteArray[numRows];
 
-            var multiplier = Decimal128.GetScaleMultiplier(scale);
+            var multiplier = DecimalConverter.GetScaleMultiplier(scale, precision);
             for (var i = 0; i < numRows; ++i)
             {
                 converted[i] = byteBuffer.Allocate(typeLength);
@@ -251,6 +251,15 @@ namespace ParquetSharp.Test
             var readValues = columnReader.ReadAll((int) groupReader.MetaData.NumRows);
 
             Assert.That(readValues, Is.EqualTo(decimalValues.ToArray()));
+        }
+
+        [Test]
+        public static void TestScaleMultiplier()
+        {
+            Assert.AreEqual(1M, DecimalConverter.GetScaleMultiplier(0, 29));
+            Assert.AreEqual(10M, DecimalConverter.GetScaleMultiplier(1, 29));
+            Assert.AreEqual(100M, DecimalConverter.GetScaleMultiplier(2, 29));
+            Assert.AreEqual(1e+028M, DecimalConverter.GetScaleMultiplier(28, 29));
         }
     }
 }

--- a/csharp.test/TestDecimal.cs
+++ b/csharp.test/TestDecimal.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
+using Apache.Arrow;
 using NUnit.Framework;
 using ParquetSharp.IO;
 using ParquetSharp.Schema;
@@ -17,7 +19,7 @@ namespace ParquetSharp.Test
             const int typeLength = 16;
             const int numRows = 1000;
             var random = new Random(1);
-            var values = Enumerable.Range(0, numRows).Select(i => RandomDecimal(random, 3)).ToArray();
+            var values = Enumerable.Range(0, numRows).Select(_ => RandomDecimal(random, scale)).ToArray();
 
             using var byteBuffer = new ByteBuffer(8 * typeLength * numRows);
             var converted = new ByteArray[numRows];
@@ -47,7 +49,7 @@ namespace ParquetSharp.Test
             const int typeLength = 16;
             const int numRows = 1000;
             var random = new Random(2);
-            var values = Enumerable.Range(0, numRows).Select(i => RandomDecimal(random, 3)).ToArray();
+            var values = Enumerable.Range(0, numRows).Select(_ => RandomDecimal(random, scale)).ToArray();
 
             using var byteBuffer = new ByteBuffer(8 * typeLength * numRows);
             var converted = new ByteArray[numRows];
@@ -69,14 +71,97 @@ namespace ParquetSharp.Test
             Assert.That(read, Is.EqualTo(values));
         }
 
-        private static decimal RandomDecimal(Random random, int scale)
+        [TestCase(2, 0, 1)]
+        [TestCase(6, 0, 3)]
+        [TestCase(6, 2, 3)]
+        [TestCase(6, 2, 3)]
+        [TestCase(9, 8, 4)]
+        [TestCase(17, 3, 8)]
+        [TestCase(18, 2, 8)]
+        [TestCase(21, 3, 9)]
+        [TestCase(28, 0, 12)]
+        [TestCase(28, 4, 12)]
+        [TestCase(29, 0, 16)] // Only requires 13 bytes but we use Decimal128 for this
+        [TestCase(29, 5, 16)]
+        [TestCase(30, 6, 13)]
+        [TestCase(30, 28, 13)]
+        [TestCase(38, 27, 16)]
+        public static async Task TestDecimalRoundTrip(int precision, int scale, int expectedTypeLength)
         {
-            var intRange = 1 + (long) int.MaxValue - (long) int.MinValue;
-            var low = (int) (int.MinValue + random.NextInt64(0, intRange));
-            var mid = (int) (int.MinValue + random.NextInt64(0, intRange));
-            var high = (int) (int.MinValue + random.NextInt64(0, intRange));
-            var negative = random.NextSingle() < 0.5;
-            return new decimal(low, mid, high, negative, (byte) scale);
+            const int rowCount = 1000;
+            using var decimalType = LogicalType.Decimal(precision: precision, scale: scale);
+
+            var columns = new Column[]
+            {
+                new Column<decimal>("decimals", decimalType),
+                new Column<decimal?>("nullable_decimals", decimalType),
+            };
+
+            var random = new Random(123);
+            var decimalValues = Enumerable.Range(0, rowCount)
+                .Select(_ => RandomDecimal(random, scale, precision))
+                .ToArray();
+            var nullableDecimalValues = Enumerable.Range(0, rowCount)
+                .Select(i => i % 10 == 3 ? (decimal?) null : RandomDecimal(random, scale, precision))
+                .ToArray();
+
+            using var buffer = new ResizableBuffer();
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(outStream, columns);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+
+                using var columnWriter = (LogicalColumnWriter<decimal>) rowGroupWriter.NextColumn().LogicalWriter();
+                columnWriter.WriteBatch(decimalValues);
+
+                using var nullableColumnWriter = (LogicalColumnWriter<decimal?>) rowGroupWriter.NextColumn().LogicalWriter();
+                nullableColumnWriter.WriteBatch(nullableDecimalValues);
+
+                fileWriter.Close();
+            }
+
+            using (var input = new BufferReader(buffer))
+            {
+                using var fileReader = new ParquetFileReader(input);
+                using var groupReader = fileReader.RowGroup(0);
+
+                using var columnReader = groupReader.Column(0).LogicalReader<decimal>();
+
+                Assert.That(columnReader.ColumnDescriptor.TypeLength, Is.EqualTo(expectedTypeLength));
+                var readValues = columnReader.ReadAll((int) groupReader.MetaData.NumRows);
+                Assert.That(readValues, Is.EqualTo(decimalValues));
+
+                using var nullableColumnReader = groupReader.Column(1).LogicalReader<decimal?>();
+
+                Assert.That(nullableColumnReader.ColumnDescriptor.TypeLength, Is.EqualTo(expectedTypeLength));
+                var nullableReadValues = nullableColumnReader.ReadAll((int) groupReader.MetaData.NumRows);
+                Assert.That(nullableReadValues, Is.EqualTo(nullableDecimalValues));
+            }
+
+            using (var input = new BufferReader(buffer))
+            {
+                // Verify we get the same values if using the Arrow format reader
+                using var fileReader = new ParquetSharp.Arrow.FileReader(input);
+                using var batchReader = fileReader.GetRecordBatchReader();
+                while (await batchReader.ReadNextRecordBatchAsync() is { } batch)
+                {
+                    using (batch)
+                    {
+                        var column = batch.Column(0) as Decimal128Array;
+                        Assert.That(column, Is.Not.Null);
+                        Assert.That(column!.NullCount, Is.Zero);
+                        var readValues = Enumerable.Range(0, rowCount).Select(i => column.GetValue(i)!.Value).ToArray();
+
+                        Assert.That(readValues, Is.EqualTo(decimalValues));
+
+                        var nullableColumn = batch.Column(1) as Decimal128Array;
+                        Assert.That(nullableColumn, Is.Not.Null);
+                        var nullableReadValues = Enumerable.Range(0, rowCount).Select(i => nullableColumn!.GetValue(i)).ToArray();
+
+                        Assert.That(nullableReadValues, Is.EqualTo(nullableDecimalValues));
+                    }
+                }
+            }
         }
 
         [Test]
@@ -254,12 +339,114 @@ namespace ParquetSharp.Test
         }
 
         [Test]
+        public static void ThrowsWithInvalidScale()
+        {
+            Assert.Throws<ParquetException>(() => LogicalType.Decimal(precision: 28, scale: 29));
+        }
+
+        [Test]
+        public static void ThrowsWithInsufficientTypeLength()
+        {
+            using var decimalType = LogicalType.Decimal(precision: 20, scale: 3);
+            var columns = new Column[] {new Column(typeof(decimal), "Decimal", decimalType, length: 5)};
+
+            using var buffer = new ResizableBuffer();
+            using var outStream = new BufferOutputStream(buffer);
+            Assert.Throws<ParquetException>(() => new ParquetFileWriter(outStream, columns));
+        }
+
+        [Test]
+        public static void WriteValueTooLargeForPrecision()
+        {
+            using var decimalType = LogicalType.Decimal(precision: 9, scale: 3);
+            var columns = new Column[]
+            {
+                new Column<decimal>("decimals", decimalType),
+            };
+
+            var decimalValues = new[]
+            {
+                new decimal(10_000_000_000) / 1000,
+            };
+
+            using var buffer = new ResizableBuffer();
+            using var outStream = new BufferOutputStream(buffer);
+            using var fileWriter = new ParquetFileWriter(outStream, columns);
+            using var rowGroupWriter = fileWriter.AppendRowGroup();
+
+            using var columnWriter = (LogicalColumnWriter<decimal>) rowGroupWriter.NextColumn().LogicalWriter();
+            Assert.Throws<OverflowException>(() => columnWriter.WriteBatch(decimalValues));
+
+            fileWriter.Close();
+        }
+
+        [TestCase(30)]
+        [TestCase(33)]
+        [TestCase(38)]
+        public static unsafe void ReadValueTooLargeForDecimal(int precision)
+        {
+            using var decimalType = LogicalType.Decimal(precision: precision, scale: 3);
+            var columns = new Column[]
+            {
+                new Column<decimal>("decimals", decimalType),
+            };
+
+            using var buffer = new ResizableBuffer();
+            int typeLength;
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var fileWriter = new ParquetFileWriter(outStream, columns);
+                using var rowGroupWriter = fileWriter.AppendRowGroup();
+
+                using var columnWriter = (ColumnWriter<FixedLenByteArray>) rowGroupWriter.NextColumn();
+                typeLength = columnWriter.ColumnDescriptor.TypeLength;
+                using var byteBuffer = new ByteBuffer(typeLength);
+                var byteArray = byteBuffer.Allocate(typeLength);
+                // Leave the most significant bit (the sign bit) as zero and set all other bits to 1
+                ((byte*) byteArray.Pointer)[0] = 127;
+                for (int i = 1; i < typeLength; ++i)
+                {
+                    ((byte*) byteArray.Pointer)[i] = 255;
+                }
+                columnWriter.WriteBatch(new[] {new FixedLenByteArray(byteArray.Pointer)});
+
+                fileWriter.Close();
+            }
+
+            using (var input = new BufferReader(buffer))
+            {
+                using var fileReader = new ParquetFileReader(input);
+                using var groupReader = fileReader.RowGroup(0);
+
+                using var columnReader = groupReader.Column(0).LogicalReader<decimal>();
+
+                Assert.That(columnReader.ColumnDescriptor.TypeLength, Is.EqualTo(typeLength));
+                Assert.Throws<OverflowException>(() => columnReader.ReadAll((int) groupReader.MetaData.NumRows));
+            }
+        }
+
+        [Test]
         public static void TestScaleMultiplier()
         {
             Assert.AreEqual(1M, DecimalConverter.GetScaleMultiplier(0, 29));
             Assert.AreEqual(10M, DecimalConverter.GetScaleMultiplier(1, 29));
             Assert.AreEqual(100M, DecimalConverter.GetScaleMultiplier(2, 29));
             Assert.AreEqual(1e+028M, DecimalConverter.GetScaleMultiplier(28, 29));
+        }
+
+        private static decimal RandomDecimal(Random random, int scale, int parquetPrecision = 29)
+        {
+            var intRange = 1 + (long) int.MaxValue - (long) int.MinValue;
+            var low = (int) (int.MinValue + random.NextInt64(0, intRange));
+            var mid = (int) (int.MinValue + random.NextInt64(0, intRange));
+            var high = (int) (int.MinValue + random.NextInt64(0, intRange));
+            var negative = random.NextSingle() < 0.5;
+            var value = new decimal(low, mid, high, negative, (byte) scale);
+            if (parquetPrecision < 29)
+            {
+                value = decimal.Round(value * new decimal(Math.Pow(10, parquetPrecision - 29)), scale);
+            }
+            return value;
         }
     }
 }

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -25,7 +25,7 @@ namespace ParquetSharp.Test
 
             list.Add(decimal.MaxValue);
 
-            var multiplier = Decimal128.GetScaleMultiplier(scale);
+            var multiplier = DecimalConverter.GetScaleMultiplier(scale, precision: 29);
             var decimals = list.Select(v => v / multiplier).ToArray();
 
             foreach (var value in decimals)
@@ -34,15 +34,6 @@ namespace ParquetSharp.Test
 
                 Assert.That(-value, Is.EqualTo(new Decimal128(-value, multiplier).ToDecimal(multiplier)));
             }
-        }
-
-        [Test]
-        public static void TestScaleMultiplier()
-        {
-            Assert.AreEqual(1M, Decimal128.GetScaleMultiplier(0));
-            Assert.AreEqual(10M, Decimal128.GetScaleMultiplier(1));
-            Assert.AreEqual(100M, Decimal128.GetScaleMultiplier(2));
-            Assert.AreEqual(1e+028M, Decimal128.GetScaleMultiplier(28));
         }
 
         [Test]

--- a/csharp.test/TestDecimal128.cs
+++ b/csharp.test/TestDecimal128.cs
@@ -96,35 +96,5 @@ namespace ParquetSharp.Test
             var read = (decimal[]) rowGroupReader.ReadColumn(fileReader.Schema.GetDataFields()[0]).Data;
             Assert.AreEqual(values, read);
         }
-
-        [Test]
-        public static void TestThrowsWithUnsupportedPrecision()
-        {
-            using var decimalType = LogicalType.Decimal(precision: 28, scale: 3);
-            var columns = new Column[] {new Column<decimal>("Decimal", decimalType)};
-
-            using var buffer = new ResizableBuffer();
-            using var outStream = new BufferOutputStream(buffer);
-            using var fileWriter = new ParquetFileWriter(outStream, columns);
-            using var rowGroupWriter = fileWriter.AppendRowGroup();
-            var exception = Assert.Throws<NotSupportedException>(() => { rowGroupWriter.NextColumn().LogicalWriter<decimal>(); });
-            Assert.That(exception!.Message, Does.Contain("29 digits of precision"));
-            fileWriter.Close();
-        }
-
-        [Test]
-        public static void TestThrowsWithUnsupportedLength()
-        {
-            using var decimalType = LogicalType.Decimal(precision: 29, scale: 3);
-            var columns = new Column[] {new Column(typeof(decimal), "Decimal", decimalType, 13)};
-
-            using var buffer = new ResizableBuffer();
-            using var outStream = new BufferOutputStream(buffer);
-            using var fileWriter = new ParquetFileWriter(outStream, columns);
-            using var rowGroupWriter = fileWriter.AppendRowGroup();
-            var exception = Assert.Throws<NotSupportedException>(() => { rowGroupWriter.NextColumn().LogicalWriter<decimal>(); });
-            Assert.That(exception!.Message, Does.Contain("16 bytes of decimal length"));
-            fileWriter.Close();
-        }
     }
 }

--- a/csharp.test/TestLogicalTypeRoundtrip.cs
+++ b/csharp.test/TestLogicalTypeRoundtrip.cs
@@ -2076,7 +2076,7 @@ namespace ParquetSharp.Test
                     Min = -10m,
                     Max = ((NumRows - 1m) * (NumRows - 1m) * (NumRows - 1m)) / 1000 - 10,
                     Converter = (v, descr) => LogicalRead.ToDecimal(
-                        (FixedLenByteArray) v, Decimal128.GetScaleMultiplier(descr.TypeScale))
+                        (FixedLenByteArray) v, DecimalConverter.GetScaleMultiplier(descr.TypeScale, descr.TypePrecision))
                 },
                 new ExpectedColumn
                 {
@@ -2091,7 +2091,7 @@ namespace ParquetSharp.Test
                     Min = -9.999m,
                     Max = ((NumRows - 1m) * (NumRows - 1m) * (NumRows - 1m)) / 1000 - 10,
                     Converter = (v, descr) => LogicalRead.ToDecimal(
-                        (FixedLenByteArray) v, Decimal128.GetScaleMultiplier(descr.TypeScale))
+                        (FixedLenByteArray) v, DecimalConverter.GetScaleMultiplier(descr.TypeScale, descr.TypePrecision))
                 },
                 new ExpectedColumn
                 {

--- a/csharp/Decimal128.cs
+++ b/csharp/Decimal128.cs
@@ -101,16 +101,6 @@ namespace ParquetSharp
             return unscaled / multiplier;
         }
 
-        public static decimal GetScaleMultiplier(int scale)
-        {
-            if (scale < 0 || scale > 28)
-            {
-                throw new ArgumentOutOfRangeException(nameof(scale), "scale must be a value in [0, 28]");
-            }
-
-            return (decimal) Math.Pow(10, scale);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void TwosComplement(uint* ptr)
         {

--- a/csharp/DecimalConverter.cs
+++ b/csharp/DecimalConverter.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ParquetSharp
+{
+    /// <summary>
+    /// This is a more flexible converter for decimal data stored in arbitrary length byte arrays,
+    /// as opposed to Decimal128 which only works with 16 byte values but is more performant.
+    /// </summary>
+    internal static class DecimalConverter
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe decimal ReadDecimal(ByteArray byteArray, decimal multiplier)
+        {
+            if (byteArray.Length == 0)
+            {
+                return new decimal(0);
+            }
+
+            // Read into little-Endian ordered array
+            var tmp = stackalloc byte[byteArray.Length];
+            for (var byteIdx = 0; byteIdx < byteArray.Length; ++byteIdx)
+            {
+                tmp[byteArray.Length  - byteIdx - 1] = *((byte*) byteArray.Pointer + byteIdx);
+            }
+
+            var negative = false;
+            if ((tmp[byteArray.Length - 1] & (1 << 7)) == 1 << 7)
+            {
+                negative = true;
+                TwosComplement(tmp, byteArray.Length);
+            }
+
+            var unscaled = new decimal(0);
+            for (var byteIdx = 0; byteIdx < byteArray.Length; ++byteIdx)
+            {
+                var increment = new decimal(tmp[byteIdx]);
+                for (var shift = 0; shift < byteIdx; ++shift)
+                {
+                    increment *= 256;
+                }
+                unscaled += increment;
+            }
+
+            if (negative)
+            {
+                unscaled *= -1;
+            }
+
+            return unscaled / multiplier;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void WriteDecimal(decimal value, ByteArray byteArray, decimal multiplier)
+        {
+            decimal unscaled;
+
+            try
+            {
+                unscaled = decimal.Truncate(value * multiplier);
+            }
+            catch (OverflowException exception)
+            {
+                throw new OverflowException($"value {value:E} is too large for decimal scale {Math.Log10((double) multiplier)}", exception);
+            }
+
+            var negative = unscaled < 0;
+            if (negative)
+            {
+                unscaled *= -1;
+            }
+
+            // Compute little-endian representation of unscaled value
+            var tmp = stackalloc byte[byteArray.Length];
+            for (var byteIdx = 0; byteIdx < byteArray.Length; ++byteIdx)
+            {
+                var remainder = unscaled % 256;
+                tmp[byteIdx] = (byte) remainder;
+                unscaled = (unscaled - remainder) / 256;
+            }
+
+            if (unscaled != 0)
+            {
+                throw new OverflowException(
+                    $"value {value:E} is too large to be represented by {byteArray.Length} bytes with decimal scale {Math.Log10((double) multiplier)}");
+            }
+
+            if (negative)
+            {
+                TwosComplement(tmp, byteArray.Length);
+            }
+
+            // Reverse bytes to get big-Endian representation, writing into output
+            for (var i = 0; i < byteArray.Length; ++i)
+            {
+                *((byte*) byteArray.Pointer + i) = tmp[byteArray.Length - i - 1];
+            }
+        }
+
+        public static int MaxPrecision(int typeLength)
+        {
+            return (int) Math.Floor(Math.Log10(Math.Pow(2.0, 8.0 * typeLength - 1) - 1));
+        }
+
+        public static decimal GetScaleMultiplier(int scale, int precision)
+        {
+            if (scale < 0 || scale > precision)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scale), $"scale must be in the range [0, precision ({precision})]");
+            }
+
+            return (decimal) Math.Pow(10, scale);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void TwosComplement(byte* byteArray, int length)
+        {
+            byte carry = 0;
+            byteArray[0] = AddCarry((byte) ~byteArray[0], 1, ref carry);
+            for (int i = 1; i < length; ++i)
+            {
+                byteArray[i] = AddCarry((byte) ~byteArray[i], 0, ref carry);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte AddCarry(byte left, byte right, ref byte carry)
+        {
+            var r = (uint) left + right + carry;
+            carry = (byte) (r >> 8);
+            return (byte) r;
+        }
+    }
+}

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -146,7 +146,7 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(decimal?))
             {
-                var multiplier = DecimalConverter.GetScaleMultiplier(columnDescriptor.TypeScale, columnDescriptor.TypeScale);
+                var multiplier = DecimalConverter.GetScaleMultiplier(columnDescriptor.TypeScale, columnDescriptor.TypePrecision);
                 if (typeof(TPhysical) == typeof(int))
                 {
                     return (LogicalRead<decimal?, int>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal32(s, dl, d, multiplier, del));

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -125,7 +125,7 @@ namespace ParquetSharp
 
             if (typeof(TLogical) == typeof(decimal))
             {
-                var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
+                var multiplier = DecimalConverter.GetScaleMultiplier(columnDescriptor.TypeScale, columnDescriptor.TypePrecision);
                 if (typeof(TPhysical) == typeof(int))
                 {
                     return (LogicalRead<decimal, int>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal32(s, d, multiplier));
@@ -134,15 +134,19 @@ namespace ParquetSharp
                 {
                     return (LogicalRead<decimal, long>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal64(s, d, multiplier));
                 }
-                if (typeof(TPhysical) == typeof(FixedLenByteArray))
+                if (typeof(TPhysical) == typeof(FixedLenByteArray) && TypeUtils.UseDecimal128(columnDescriptor))
                 {
                     return (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal128(s, d, multiplier));
+                }
+                if (typeof(TPhysical) == typeof(FixedLenByteArray))
+                {
+                    return (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal(s, d, multiplier, columnDescriptor.TypeLength));
                 }
             }
 
             if (typeof(TLogical) == typeof(decimal?))
             {
-                var multiplier = Decimal128.GetScaleMultiplier(columnDescriptor.TypeScale);
+                var multiplier = DecimalConverter.GetScaleMultiplier(columnDescriptor.TypeScale, columnDescriptor.TypeScale);
                 if (typeof(TPhysical) == typeof(int))
                 {
                     return (LogicalRead<decimal?, int>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal32(s, dl, d, multiplier, del));
@@ -151,9 +155,13 @@ namespace ParquetSharp
                 {
                     return (LogicalRead<decimal?, long>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal64(s, dl, d, multiplier, del));
                 }
-                if (typeof(TPhysical) == typeof(FixedLenByteArray))
+                if (typeof(TPhysical) == typeof(FixedLenByteArray) && TypeUtils.UseDecimal128(columnDescriptor))
                 {
                     return (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal128(s, dl, d, multiplier, del));
+                }
+                if (typeof(TPhysical) == typeof(FixedLenByteArray))
+                {
+                    return (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal(s, dl, d, multiplier, columnDescriptor.TypeLength, del));
                 }
             }
 
@@ -508,6 +516,22 @@ namespace ParquetSharp
             for (int i = 0, src = 0; i < destination.Length; ++i)
             {
                 destination[i] = defLevels[i] != definedLevel ? default(decimal?) : ToDecimal(source[src++], multiplier);
+            }
+        }
+
+        public static void ConvertDecimal(ReadOnlySpan<FixedLenByteArray> source, Span<decimal> destination, decimal multiplier, int typeLength)
+        {
+            for (int i = 0; i < destination.Length; ++i)
+            {
+                destination[i] = DecimalConverter.ReadDecimal(new ByteArray(source[i].Pointer, typeLength), multiplier);
+            }
+        }
+
+        public static void ConvertDecimal(ReadOnlySpan<FixedLenByteArray> source, ReadOnlySpan<short> defLevels, Span<decimal?> destination, decimal multiplier, int typeLength, short definedLevel)
+        {
+            for (int i = 0, src = 0; i < destination.Length; ++i)
+            {
+                destination[i] = defLevels[i] != definedLevel ? default(decimal?) : DecimalConverter.ReadDecimal(new ByteArray(source[src++].Pointer, typeLength), multiplier);
             }
         }
 

--- a/csharp/LogicalRead.cs
+++ b/csharp/LogicalRead.cs
@@ -134,13 +134,11 @@ namespace ParquetSharp
                 {
                     return (LogicalRead<decimal, long>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal64(s, d, multiplier));
                 }
-                if (typeof(TPhysical) == typeof(FixedLenByteArray) && TypeUtils.UseDecimal128(columnDescriptor))
-                {
-                    return (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal128(s, d, multiplier));
-                }
                 if (typeof(TPhysical) == typeof(FixedLenByteArray))
                 {
-                    return (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal(s, d, multiplier, columnDescriptor.TypeLength));
+                    return TypeUtils.UseDecimal128(columnDescriptor)
+                        ? (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal128(s, d, multiplier))
+                        : (LogicalRead<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalRead.ConvertDecimal(s, d, multiplier, columnDescriptor.TypeLength));
                 }
             }
 
@@ -155,13 +153,11 @@ namespace ParquetSharp
                 {
                     return (LogicalRead<decimal?, long>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal64(s, dl, d, multiplier, del));
                 }
-                if (typeof(TPhysical) == typeof(FixedLenByteArray) && TypeUtils.UseDecimal128(columnDescriptor))
-                {
-                    return (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal128(s, dl, d, multiplier, del));
-                }
                 if (typeof(TPhysical) == typeof(FixedLenByteArray))
                 {
-                    return (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal(s, dl, d, multiplier, columnDescriptor.TypeLength, del));
+                    return TypeUtils.UseDecimal128(columnDescriptor)
+                        ? (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal128(s, dl, d, multiplier, del))
+                        : (LogicalRead<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, del) => LogicalRead.ConvertDecimal(s, dl, d, multiplier, columnDescriptor.TypeLength, del));
                 }
             }
 

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -145,13 +145,12 @@ namespace ParquetSharp
                     }
                     case PhysicalType.FixedLenByteArray:
                     {
-                        if (descriptor.TypeLength != sizeof(Decimal128))
+                        var maxPrecision = DecimalConverter.MaxPrecision(descriptor.TypeLength);
+                        if (descriptor.TypePrecision > maxPrecision)
                         {
-                            throw new NotSupportedException($"only {sizeof(Decimal128)} bytes of decimal length is supported with fixed-length byte array data");
-                        }
-                        if (descriptor.TypePrecision > 29)
-                        {
-                            throw new NotSupportedException("only max 29 digits of decimal precision is supported with fixed-length byte array data");
+                            throw new NotSupportedException(
+                                $"A maximum of {maxPrecision} digits of decimal precision is supported with fixed length byte arrays " +
+                                $"of length {descriptor.TypeLength} (specified precision is {descriptor.TypePrecision})");
                         }
                         return (typeof(FixedLenByteArray), nullable ? typeof(decimal?) : typeof(decimal));
                     }

--- a/csharp/LogicalWrite.cs
+++ b/csharp/LogicalWrite.cs
@@ -101,12 +101,13 @@ namespace ParquetSharp
                 var multiplier = DecimalConverter.GetScaleMultiplier(columnDescriptor.TypeScale, columnDescriptor.TypePrecision);
                 if (typeof(TPhysical) == typeof(FixedLenByteArray))
                 {
-                    if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
-                    if (TypeUtils.UseDecimal128(columnDescriptor))
+                    if (byteBuffer == null)
                     {
-                        return (LogicalWrite<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalWrite.ConvertDecimal128(s, d, multiplier, byteBuffer));
+                        throw new ArgumentNullException(nameof(byteBuffer));
                     }
-                    return (LogicalWrite<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalWrite.ConvertDecimal(s, d, multiplier, byteBuffer, columnDescriptor.TypeLength));
+                    return TypeUtils.UseDecimal128(columnDescriptor)
+                        ? (LogicalWrite<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalWrite.ConvertDecimal128(s, d, multiplier, byteBuffer))
+                        : (LogicalWrite<decimal, FixedLenByteArray>.Converter) ((s, _, d, _) => LogicalWrite.ConvertDecimal(s, d, multiplier, byteBuffer, columnDescriptor.TypeLength));
                 }
                 if (typeof(TPhysical) == typeof(int))
                 {
@@ -116,6 +117,7 @@ namespace ParquetSharp
                 {
                     return (LogicalWrite<decimal, long>.Converter) ((s, _, d, _) => LogicalWrite.ConvertDecimal(s, d, multiplier));
                 }
+
                 throw new NotSupportedException("Writing decimal data is only supported with fixed-length byte array, int32, and int64 physical types");
             }
 
@@ -125,15 +127,13 @@ namespace ParquetSharp
                 var multiplier = DecimalConverter.GetScaleMultiplier(columnDescriptor.TypeScale, columnDescriptor.TypePrecision);
                 if (typeof(TPhysical) == typeof(FixedLenByteArray))
                 {
-                    if (byteBuffer == null) throw new ArgumentNullException(nameof(byteBuffer));
-                    if (TypeUtils.UseDecimal128(columnDescriptor))
+                    if (byteBuffer == null)
                     {
-                        return (LogicalWrite<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, nl) =>
-                            LogicalWrite.ConvertDecimal128(s, dl, d, multiplier, nl, byteBuffer));
+                        throw new ArgumentNullException(nameof(byteBuffer));
                     }
-
-                    return (LogicalWrite<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, nl) =>
-                        LogicalWrite.ConvertDecimal(s, dl, d, multiplier, nl, byteBuffer, columnDescriptor.TypeLength));
+                    return TypeUtils.UseDecimal128(columnDescriptor)
+                        ? (LogicalWrite<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, nl) => LogicalWrite.ConvertDecimal128(s, dl, d, multiplier, nl, byteBuffer))
+                        : (LogicalWrite<decimal?, FixedLenByteArray>.Converter) ((s, dl, d, nl) => LogicalWrite.ConvertDecimal(s, dl, d, multiplier, nl, byteBuffer, columnDescriptor.TypeLength));
                 }
                 if (typeof(TPhysical) == typeof(int))
                 {
@@ -143,6 +143,7 @@ namespace ParquetSharp
                 {
                     return (LogicalWrite<decimal?, long>.Converter) ((s, dl, d, nl) => LogicalWrite.ConvertDecimal(s, dl, d, multiplier, nl));
                 }
+
                 throw new NotSupportedException("Writing decimal data is only supported with fixed-length byte array, int32, and int64 physical types");
             }
 

--- a/csharp/LogicalWrite.cs
+++ b/csharp/LogicalWrite.cs
@@ -860,7 +860,7 @@ namespace ParquetSharp
             // The value is encoded using big-endian, so that 00112233-4455-6677-8899-aabbccddeeff is encoded
             // as the bytes 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff.
             //
-            // But Guid endianess is platform dependent (and ToByteArray() uses a little endian representation).
+            // But Guid endianness is platform dependent (and ToByteArray() uses a little endian representation).
             if (BitConverter.IsLittleEndian)
             {
                 // ReSharper disable once PossibleNullReferenceException

--- a/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+static ParquetSharp.LogicalRead.ConvertDecimal(System.ReadOnlySpan<ParquetSharp.FixedLenByteArray> source, System.ReadOnlySpan<short> defLevels, System.Span<decimal?> destination, decimal multiplier, int typeLength, short definedLevel) -> void
+static ParquetSharp.LogicalRead.ConvertDecimal(System.ReadOnlySpan<ParquetSharp.FixedLenByteArray> source, System.Span<decimal> destination, decimal multiplier, int typeLength) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<int> destination, decimal multiplier) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<long> destination, decimal multiplier) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<ParquetSharp.FixedLenByteArray> destination, decimal multiplier, ParquetSharp.ByteBuffer! byteBuffer, int typeLength) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<int> destination, decimal multiplier, short nullLevel) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<long> destination, decimal multiplier, short nullLevel) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<ParquetSharp.FixedLenByteArray> destination, decimal multiplier, short nullLevel, ParquetSharp.ByteBuffer! byteBuffer, int typeLength) -> void

--- a/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+static ParquetSharp.LogicalRead.ConvertDecimal(System.ReadOnlySpan<ParquetSharp.FixedLenByteArray> source, System.ReadOnlySpan<short> defLevels, System.Span<decimal?> destination, decimal multiplier, int typeLength, short definedLevel) -> void
+static ParquetSharp.LogicalRead.ConvertDecimal(System.ReadOnlySpan<ParquetSharp.FixedLenByteArray> source, System.Span<decimal> destination, decimal multiplier, int typeLength) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<int> destination, decimal multiplier) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<long> destination, decimal multiplier) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<ParquetSharp.FixedLenByteArray> destination, decimal multiplier, ParquetSharp.ByteBuffer! byteBuffer, int typeLength) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<int> destination, decimal multiplier, short nullLevel) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<long> destination, decimal multiplier, short nullLevel) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<ParquetSharp.FixedLenByteArray> destination, decimal multiplier, short nullLevel, ParquetSharp.ByteBuffer! byteBuffer, int typeLength) -> void

--- a/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+static ParquetSharp.LogicalRead.ConvertDecimal(System.ReadOnlySpan<ParquetSharp.FixedLenByteArray> source, System.ReadOnlySpan<short> defLevels, System.Span<decimal?> destination, decimal multiplier, int typeLength, short definedLevel) -> void
+static ParquetSharp.LogicalRead.ConvertDecimal(System.ReadOnlySpan<ParquetSharp.FixedLenByteArray> source, System.Span<decimal> destination, decimal multiplier, int typeLength) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<int> destination, decimal multiplier) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<long> destination, decimal multiplier) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal> source, System.Span<ParquetSharp.FixedLenByteArray> destination, decimal multiplier, ParquetSharp.ByteBuffer! byteBuffer, int typeLength) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<int> destination, decimal multiplier, short nullLevel) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<long> destination, decimal multiplier, short nullLevel) -> void
+static ParquetSharp.LogicalWrite.ConvertDecimal(System.ReadOnlySpan<decimal?> source, System.Span<short> defLevels, System.Span<ParquetSharp.FixedLenByteArray> destination, decimal multiplier, short nullLevel, ParquetSharp.ByteBuffer! byteBuffer, int typeLength) -> void

--- a/csharp/TypeUtils.cs
+++ b/csharp/TypeUtils.cs
@@ -39,12 +39,14 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Whether to use the <see cref="Decimal128"/> type for conversion of decimal values to
-        /// fixed length byte array data.
+        /// Whether to use the <see cref="Decimal128"/> type for conversion between decimal values
+        /// and fixed length byte array data.
         /// </summary>
         public static unsafe bool UseDecimal128(ColumnDescriptor columnDescriptor)
         {
-            return columnDescriptor.TypeLength == sizeof(Decimal128);
+            // Even if the type length matches Decimal128, we want to use DecimalConverter for higher
+            // precision than decimal supports so that we check for overflow and don't silently read invalid data.
+            return columnDescriptor.TypeLength == sizeof(Decimal128) && columnDescriptor.TypePrecision <= 29;
         }
     }
 }

--- a/csharp/TypeUtils.cs
+++ b/csharp/TypeUtils.cs
@@ -37,5 +37,14 @@ namespace ParquetSharp
             inner = null!;
             return false;
         }
+
+        /// <summary>
+        /// Whether to use the <see cref="Decimal128"/> type for conversion of decimal values to
+        /// fixed length byte array data.
+        /// </summary>
+        public static unsafe bool UseDecimal128(ColumnDescriptor columnDescriptor)
+        {
+            return columnDescriptor.TypeLength == sizeof(Decimal128);
+        }
     }
 }


### PR DESCRIPTION
Fixes #252

This adds a new `DecimalConverter` class that works with arbitrary length fixed-length byte array columns (as long as values are still representable by a .NET decimal), while keeping the existing `Decimal128` class for backwards compatibility and improved performance. I've also added support for writing decimal columns backed by the int32 and int64 physical types.