### PR TITLE
Fix CI breakage following `macos-12` runner image deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-20.04, macos-13, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
@@ -218,7 +218,7 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04-arm64, macos-12, macos-13, macos-14, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04-arm64, macos-13, macos-14, windows-2022]
         dotnet: [netcoreapp3.1, net6.0, net7.0, net8.0]
         include:
         - os: windows-2022

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -15,3 +15,4 @@ jobs:
         uses: pavlovic-ivan/octo-nudge@v2
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}
+          conclusions: failure,cancelled


### PR DESCRIPTION
The `macos-12` image we use for building has been [deprecated](https://github.com/actions/runner-images/issues/10721). This PR replaces its use by `macos-13` for building, and remove the use of `macos-12` for testing.

The `nudge` workflow configuration is also adjusted to notify us when the main CI workflow is cancelled, which was its conclusion when using a deprecated image, rather than a failure.
