### PR TITLE
Cancelled is not a valid value for a conclusion in octo-nudge

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -15,4 +15,3 @@ jobs:
         uses: pavlovic-ivan/octo-nudge@v2
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}
-          conclusions: failure,cancelled


### PR DESCRIPTION
As per the comment on https://github.com/G-Research/ParquetSharp/pull/489/files#r1912894991, 'cancelled'  value for conclusions is not supported by octo-nudge.