### PR TITLE
Configuring nudge workflow to notify on cancelled runs

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -12,6 +12,7 @@ jobs:
     environment: nudge
     steps:
       - name: Send notification
-        uses: pavlovic-ivan/octo-nudge@v2
+        uses: pavlovic-ivan/octo-nudge@v3
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}
+          conclusions: failure,cancelled


### PR DESCRIPTION
Reintroducing changes from https://github.com/G-Research/ParquetSharp/pull/489 as supports for `cancelled` conclusion is added to octo-nudge.