### PR TITLE
Bump parquet-cpp-arrow to 18.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ devcontainer exec dotnet test csharp.test
 Building ParquetSharp natively requires the following dependencies:
 - A modern C++ compiler toolchain
 - .NET SDK 8.0
-- Apache Arrow (15.0.2)
+- Apache Arrow (18.1.0)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://vcpkg.io).
 The build scripts will use an existing vcpkg installation if either of the `VCPKG_INSTALLATION_ROOT` or `VCPKG_ROOT` environment variables are defined, otherwise vcpkg will be downloaded into the build directory.

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -163,7 +163,7 @@ namespace ParquetSharp.Test
 
             var numRows = expectedColumns.First().Values.Length;
 
-            Assert.AreEqual("parquet-cpp-arrow version 17.0.0", fileMetaData.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 18.1.0", fileMetaData.CreatedBy);
             Assert.AreEqual(new Dictionary<string, string> {{"case", "Test"}, {"Awesome", "true"}}, fileMetaData.KeyValueMetadata);
             Assert.AreEqual(expectedColumns.Length, fileMetaData.NumColumns);
             Assert.AreEqual(numRows, fileMetaData.NumRows);
@@ -174,7 +174,7 @@ namespace ParquetSharp.Test
             // The parquet format only stores an integer file version (1 or 2) and
             // 2 gets mapped to the latest 2.x version.
             Assert.AreEqual(ParquetVersion.PARQUET_2_6, fileMetaData.Version);
-            Assert.AreEqual("parquet-cpp-arrow version 17.0.0", fileMetaData.WriterVersion.ToString());
+            Assert.AreEqual("parquet-cpp-arrow version 18.1.0", fileMetaData.WriterVersion.ToString());
 
             using var rowGroupReader = fileReader.RowGroup(0);
             var rowGroupMetaData = rowGroupReader.MetaData;

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -14,7 +14,7 @@ namespace ParquetSharp.Test
         {
             var p = WriterProperties.GetDefaultWriterProperties();
 
-            Assert.AreEqual("parquet-cpp-arrow version 17.0.0", p.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 18.1.0", p.CreatedBy);
             Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
             Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024 * 1024, p.DataPageSize);

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <VersionPrefix>17.0.0-beta1</VersionPrefix>
+    <VersionPrefix>18.1.0-beta1</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "parquetsharp",
   "version-string": "undefined",
-  "builtin-baseline": "e590c2b30c08caf1dd8d612ec602a003f9784b7d",
+  "builtin-baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
   "dependencies": [
     "arrow"
   ],

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,7 @@
   "overrides": [
     {
       "name": "arrow",
-      "version": "17.0.0"
+      "version": "18.1.0"
     }
   ]
 }


### PR DESCRIPTION
PR for upgrading the Arrow C++ version from 17.0.0 to 18.1.0, the latest stable version. This sets the groundwork for making the 18.1.0 ParquetSharp release, as requested by @adamreeve.

I rebuilt the project and executed the tests, which passed without problems. Please let me know if there are any extra things to consider, such as breaking changes that the tests might not have caught!