### PR TITLE
Workaround for breaking vcpkg changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,10 @@ jobs:
 
     # Method 3: Using printenv
     - name: Display All Environment Variables
-      run: printenv | sort
       shell: bash
+      run: |
+      printenv | sort
+      cmake --version
 
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
     - name: Compile native ParquetSharp library (Windows)
       if: runner.os == 'Windows'
       run: ./build_windows.ps1
-      env:
+    - name: Upload vcpkg arrow logs
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    # Method 3: Using printenv
+    - name: Display All Environment Variables
+      run: printenv | sort
+      shell: bash
+
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root
       id: vcpkg-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    # Method 3: Using printenv
-    - name: Display All Environment Variables
-      shell: bash
-      run: |
-        printenv | sort
-        cmake --version
-        make --help
-
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root
       id: vcpkg-info
@@ -98,6 +90,14 @@ jobs:
       run: echo "version=$(cmake --version | head -n1 | awk '{print $3}')" >> $GITHUB_OUTPUT
       shell: bash
 
+    # Ensure vcpkg builtin registry is up-to-date
+    - name: Update vcpkg builtin registry
+      working-directory: ${{ steps.vcpkg-info.outputs.root }}
+      run: |
+        git reset --hard
+        git pull
+        git checkout d320630b28aeb59b24424eb2a7ef3905314107a1
+        git status
 
     # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.
     - name: Start CentOS container and install toolchain
@@ -142,10 +142,13 @@ jobs:
           exec="docker exec -w $PWD -e GITHUB_ACTIONS -e ACTIONS_CACHE_URL -e ACTIONS_RUNTIME_TOKEN -e VCPKG_BINARY_SOURCES -e VCPKG_INSTALLATION_ROOT centos scl enable devtoolset-7 rh-git227 httpd24 --"
         fi
         $exec ./build_unix.sh ${{ matrix.arch }}
-
+      env:
+        VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
     - name: Compile native ParquetSharp library (Windows)
       if: runner.os == 'Windows'
       run: ./build_windows.ps1
+      env:
+        VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
     - name: Upload vcpkg arrow logs
       if: success() || failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,6 @@ jobs:
       run: echo "version=$(cmake --version | head -n1 | awk '{print $3}')" >> $GITHUB_OUTPUT
       shell: bash
 
-    # Ensure vcpkg builtin registry is up-to-date
-    - name: Update vcpkg builtin registry
-      working-directory: ${{ steps.vcpkg-info.outputs.root }}
-      run: |
-        git reset --hard
-        git pull
 
     # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.
     - name: Start CentOS container and install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
       run: |
         printenv | sort
         cmake --version
+        make --help
 
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
       run: |
         git reset --hard
         git pull
-        git checkout 66248ff4dbafdff577df74e4d9a8e948389fab09
+        # Workaround for breaking changes ("Migrate tool metadata from XML to JSON format")
+        git checkout 358f3893843c9d0d1b2e594183481fb68e3aa963~1
         git status
 
     # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       run: |
         git reset --hard
         git pull
-        git checkout e590c2b30c08caf1dd8d612ec602a003f9784b7d
+        git checkout 66248ff4dbafdff577df74e4d9a8e948389fab09
         git status
 
     # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
         $exec ./build_unix.sh ${{ matrix.arch }}
       env:
         VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+        CMAKE_MAKE_PROGRAM : make
     - name: Compile native ParquetSharp library (Windows)
       if: runner.os == 'Windows'
       run: ./build_windows.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,15 +148,11 @@ jobs:
           exec="docker exec -w $PWD -e GITHUB_ACTIONS -e ACTIONS_CACHE_URL -e ACTIONS_RUNTIME_TOKEN -e VCPKG_BINARY_SOURCES -e VCPKG_INSTALLATION_ROOT centos scl enable devtoolset-7 rh-git227 httpd24 --"
         fi
         $exec ./build_unix.sh ${{ matrix.arch }}
-      env:
-        VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
-        CMAKE_MAKE_PROGRAM: make
+
     - name: Compile native ParquetSharp library (Windows)
       if: runner.os == 'Windows'
       run: ./build_windows.ps1
       env:
-        VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
-    - name: Upload vcpkg arrow logs
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
     - name: Display All Environment Variables
       shell: bash
       run: |
-      printenv | sort
-      cmake --version
+        printenv | sort
+        cmake --version
 
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       run: |
         git reset --hard
         git pull
-        git checkout d320630b28aeb59b24424eb2a7ef3905314107a1
+        git checkout e590c2b30c08caf1dd8d612ec602a003f9784b7d
         git status
 
     # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         $exec ./build_unix.sh ${{ matrix.arch }}
       env:
         VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
-        CMAKE_MAKE_PROGRAM : make
+        CMAKE_MAKE_PROGRAM: make
     - name: Compile native ParquetSharp library (Windows)
       if: runner.os == 'Windows'
       run: ./build_windows.ps1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,9 @@ jobs:
         cd $VCPKG_INSTALLATION_ROOT
         git reset --hard
         git pull
+        # Workaround for breaking changes ("Migrate tool metadata from XML to JSON format")
+        git checkout 358f3893843c9d0d1b2e594183481fb68e3aa963~1
+        git status
 
     - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -12,6 +12,7 @@ jobs:
     environment: nudge
     steps:
       - name: Send notification
-        uses: pavlovic-ivan/octo-nudge@v2
+        uses: pavlovic-ivan/octo-nudge@v3
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}
+          conclusions: failure,cancelled

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -12,7 +12,6 @@ jobs:
     environment: nudge
     steps:
       - name: Send notification
-        uses: pavlovic-ivan/octo-nudge@v3
+        uses: pavlovic-ivan/octo-nudge@v2
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}
-          conclusions: failure,cancelled


### PR DESCRIPTION
There is an ongoing process for reorganizing vcpkg, but it broke our CI:
- https://github.com/microsoft/vcpkg/commit/358f3893843c9d0d1b2e594183481fb68e3aa963
- https://github.com/microsoft/vcpkg-tool/pull/1553

I'm unsure how to fix it properly, but with this change, we at least make sure that we use vcpkg repo prior to the `vcpkgTools.xml` related changes and unblock our CI.