### PR TITLE
Improved workaround for breaking vcpkg changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
             triplet+="windows-static"
             ;;
         esac
-        echo "VCPKG_INSTALLATION_ROOT=$VCPKG_INSTALLATION_ROOT"
         echo "triplet=$triplet" >> $GITHUB_OUTPUT
         echo "root=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_OUTPUT
       shell: bash
@@ -97,6 +96,19 @@ jobs:
       run: |
         git reset --hard
         git pull
+
+    # We may need to re-bootstrap vcpkg after updating
+    - name: Bootstrap vcpkg (Unix)
+      if: runner.os != 'Windows'
+      working-directory: ${{ steps.vcpkg-info.outputs.root }}
+      run: |
+        ./bootstrap-vcpkg.sh
+
+    - name: Bootstrap vcpkg (Windows)
+      if: runner.os == 'Windows'
+      working-directory: ${{ steps.vcpkg-info.outputs.root }}
+      run: |
+        ./bootstrap-vcpkg.bat
 
     # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.
     - name: Start CentOS container and install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,6 @@ jobs:
       run: |
         git reset --hard
         git pull
-        # Workaround for breaking changes ("Migrate tool metadata from XML to JSON format")
-        git checkout 358f3893843c9d0d1b2e594183481fb68e3aa963~1
-        git status
 
     # Setup a CentOS 7 container to build on Linux x64 for backwards compatibility.
     - name: Start CentOS container and install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
             triplet+="windows-static"
             ;;
         esac
+        echo "VCPKG_INSTALLATION_ROOT=$VCPKG_INSTALLATION_ROOT"
         echo "triplet=$triplet" >> $GITHUB_OUTPUT
         echo "root=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,9 +28,6 @@ jobs:
         cd $VCPKG_INSTALLATION_ROOT
         git reset --hard
         git pull
-        # Workaround for breaking changes ("Migrate tool metadata from XML to JSON format")
-        git checkout 358f3893843c9d0d1b2e594183481fb68e3aa963~1
-        git status
 
     - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,11 @@ jobs:
         git reset --hard
         git pull
 
+    - name: Bootstrap vcpkg
+      run: |
+        cd $VCPKG_INSTALLATION_ROOT
+        ./bootstrap-vcpkg.sh
+
     - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
Rather than checking out an older version of vcpkg, we can run bootstrap-vcpkg to update the vcpkg tools.