### PR TITLE
Documentation Improvements: Arrow API

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,20 @@ devcontainer exec ./build_unix.sh
 devcontainer exec dotnet test csharp.test
 ```
 
+#### Code Formatting
+
+When formatting for the first time, you'll need to restore the formatter tool:
+
+```bash
+dotnet tool restore
+```
+
+Then, you can format any time with the following command which is also executed by the CI format checker:
+
+```bash
+dotnet jb cleanupcode "csharp" "csharp.test" "csharp.benchmark" --profile="Built-in: Reformat Code" --settings="ParquetSharp.DotSettings" --verbosity=WARN
+```
+
 ### Native
 
 Building ParquetSharp natively requires the following dependencies:

--- a/csharp/Arrow/ArrowReaderProperties.cs
+++ b/csharp/Arrow/ArrowReaderProperties.cs
@@ -4,10 +4,14 @@ using System.Runtime.InteropServices;
 namespace ParquetSharp.Arrow
 {
     /// <summary>
-    /// Configures Arrow specific options for reading Parquet files
+    /// Configures Arrow specific options for reading Parquet files.
     /// </summary>
     public sealed class ArrowReaderProperties : IDisposable
     {
+        /// <summary>
+        /// Create a new <see cref="ArrowReaderProperties"/> with default values.
+        /// </summary>
+        /// <returns></returns>
         public static ArrowReaderProperties GetDefault()
         {
             return new ArrowReaderProperties(ExceptionInfo.Return<IntPtr>(ArrowReaderProperties_GetDefault));

--- a/csharp/Arrow/ArrowWriterProperties.cs
+++ b/csharp/Arrow/ArrowWriterProperties.cs
@@ -17,6 +17,9 @@ namespace ParquetSharp.Arrow
             V2 = 1, // Full support for all nesting combinations
         }
 
+        /// <summary>
+        /// Create a new <see cref="ArrowWriterProperties"/> with default values.
+        /// </summary>
         public static ArrowWriterProperties GetDefault()
         {
             return new ArrowWriterProperties(ExceptionInfo.Return<IntPtr>(ArrowWriterProperties_GetDefault));

--- a/csharp/Arrow/FileReader.cs
+++ b/csharp/Arrow/FileReader.cs
@@ -122,9 +122,10 @@ namespace ParquetSharp.Arrow
 
         /// <summary>
         /// Get a record batch reader for the file data
+        /// </summary>
         /// <param name="rowGroups">The indices of row groups to read data from</param>
         /// <param name="columns">The indices of columns to read, based on the schema</param>
-        /// </summary>
+        /// <returns>An Arrow array stream reader</returns>
         public unsafe IArrowArrayStream GetRecordBatchReader(
             int[]? rowGroups = null,
             int[]? columns = null)

--- a/csharp/Arrow/FileWriter.cs
+++ b/csharp/Arrow/FileWriter.cs
@@ -185,7 +185,7 @@ namespace ParquetSharp.Arrow
         /// multiple record batches to be written to the same row group.
         ///
         /// New row groups are started if the data reaches the MaxRowGroupLength configured
-        /// in the WriterProperties.
+        /// in the <see cref="WriterProperties"/>.
         /// </summary>
         /// <param name="recordBatch">The record batch to write</param>
         public void WriteBufferedRecordBatch(RecordBatch recordBatch)

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -12,6 +12,13 @@ namespace ParquetSharp
     {
 #pragma warning disable RS0027
 
+        /// <summary>
+        /// Create a column with the given properties.
+        /// </summary>
+        /// <param name="logicalSystemType">The <see cref="Type"/> of the column.</param>
+        /// <param name="name">The name of the column.</param>
+        /// <param name="logicalTypeOverride">Optional override for the logical type of the column.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any of the arguments are null.</exception>
         public Column(Type logicalSystemType, string name, LogicalType? logicalTypeOverride = null)
             : this(logicalSystemType, name, logicalTypeOverride, GetTypeLength(logicalSystemType, logicalTypeOverride))
         {
@@ -19,6 +26,15 @@ namespace ParquetSharp
             Name = name ?? throw new ArgumentNullException(nameof(name));
         }
 
+        /// <summary>
+        /// Create a column with the given properties.
+        /// </summary>
+        /// <param name="logicalSystemType">The <see cref="Type"/> of the column.</param>
+        /// <param name="name">The name of the column.</param>
+        /// <param name="logicalTypeOverride">Optional override for the logical type of the column.</param>
+        /// <param name="length">The length of the column for decimal, Guid or Half types.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any of the arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown if the length is set with an incompatible type.</exception>
         public Column(Type logicalSystemType, string name, LogicalType? logicalTypeOverride, int length)
         {
             var isDecimal = logicalSystemType == typeof(decimal) || logicalSystemType == typeof(decimal?);

--- a/csharp/Column.cs
+++ b/csharp/Column.cs
@@ -33,7 +33,7 @@ namespace ParquetSharp
         /// <param name="name">The name of the column.</param>
         /// <param name="logicalTypeOverride">Optional override for the logical type of the column.</param>
         /// <param name="length">The length of the column for decimal, Guid or Half types.</param>
-        /// <exception cref="ArgumentNullException">Thrown if any of the arguments are null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if any of the required arguments are null.</exception>
         /// <exception cref="ArgumentException">Thrown if the length is set with an incompatible type.</exception>
         public Column(Type logicalSystemType, string name, LogicalType? logicalTypeOverride, int length)
         {

--- a/csharp/ColumnWriter.cs
+++ b/csharp/ColumnWriter.cs
@@ -87,6 +87,7 @@ namespace ParquetSharp
         /// Get the element <see cref="Type"/> of the data being written.
         /// </summary>
         public abstract Type ElementType { get; }
+
         /// <summary>
         /// Apply a visitor to the column writer.
         /// </summary>

--- a/csharp/ColumnWriter.cs
+++ b/csharp/ColumnWriter.cs
@@ -67,7 +67,7 @@ namespace ParquetSharp
         public LogicalWriteConverterFactory LogicalWriteConverterFactory => RowGroupWriter.ParquetFileWriter.LogicalWriteConverterFactory;
 
         /// <summary>
-        /// Get the <see cref="ParquetSharp.ColumnDescriptor"/> for the Parquet file writer.
+        /// Get the <see cref="ParquetSharp.ColumnDescriptor"/> for the column.
         /// </summary>
         public ColumnDescriptor ColumnDescriptor => new(ExceptionInfo.Return<IntPtr>(Handle, ColumnWriter_Descr));
         /// <summary>

--- a/csharp/FileDecryptionPropertiesBuilder.cs
+++ b/csharp/FileDecryptionPropertiesBuilder.cs
@@ -148,7 +148,7 @@ namespace ParquetSharp
         /// <summary>
         /// Build the <see cref="FileDecryptionProperties"/> object.
         /// </summary>
-        /// <returns>A new <see cref="FileDecryptionProperties"/> object with the configured decryption properties.</returns>
+        /// <returns>The configured <see cref="FileDecryptionProperties"/> object.</returns>
         public FileDecryptionProperties Build() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(_handle, FileDecryptionPropertiesBuilder_Build));
 
         [DllImport(ParquetDll.Name)]

--- a/csharp/FileMetaData.cs
+++ b/csharp/FileMetaData.cs
@@ -5,6 +5,9 @@ using AppVer = ParquetSharp.ApplicationVersion.CStruct;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Metadata for a Parquet file. Includes information about the schema, row groups, versions, etc.
+    /// </summary>
     public sealed class FileMetaData : IEquatable<FileMetaData>, IDisposable
     {
         internal FileMetaData(IntPtr handle)
@@ -17,8 +20,15 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
+        /// <summary>
+        /// Get the name of the entity that created the file.
+        /// </summary>
         public string CreatedBy => ExceptionInfo.ReturnString(_handle, FileMetaData_Created_By);
 
+        /// <summary>
+        /// Get the key-value metadata.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> containing the key-value metadata.</returns>
         public IReadOnlyDictionary<string, string> KeyValueMetadata
         {
             get
@@ -34,13 +44,38 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// Get the number of columns in the file.
+        /// </summary>
         public int NumColumns => ExceptionInfo.Return<int>(_handle, FileMetaData_Num_Columns);
+        /// <summary>
+        /// Get the number of rows in the file.
+        /// </summary>
         public long NumRows => ExceptionInfo.Return<long>(_handle, FileMetaData_Num_Rows);
+        /// <summary>
+        /// Get the number of row groups in the file.
+        /// </summary>
         public int NumRowGroups => ExceptionInfo.Return<int>(_handle, FileMetaData_Num_Row_Groups);
+        /// <summary>
+        /// Get the number of schema elements in the file.
+        /// </summary>
         public int NumSchemaElements => ExceptionInfo.Return<int>(_handle, FileMetaData_Num_Schema_Elements);
+        /// <summary>
+        /// Get the schema descriptor for the file.
+        /// </summary>
+        /// <returns>A <see cref="SchemaDescriptor"/> object that describes the schema of the file.</returns>
         public SchemaDescriptor Schema => _schema ??= new SchemaDescriptor(ExceptionInfo.Return<IntPtr>(_handle, FileMetaData_Schema));
+        /// <summary>
+        /// Get the total size of the file in bytes.
+        /// </summary>
         public int Size => ExceptionInfo.Return<int>(_handle, FileMetaData_Size);
+        /// <summary>
+        /// Get the version of the file.
+        /// </summary>
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(_handle, FileMetaData_Version);
+        /// <summary>
+        /// Get the version of the writer that created the file.
+        /// </summary>
         public ApplicationVersion WriterVersion => new ApplicationVersion(ExceptionInfo.Return<AppVer>(_handle, FileMetaData_Writer_Version));
 
         public bool Equals(FileMetaData? other)

--- a/csharp/FileMetaData.cs
+++ b/csharp/FileMetaData.cs
@@ -70,7 +70,7 @@ namespace ParquetSharp
         /// </summary>
         public int Size => ExceptionInfo.Return<int>(_handle, FileMetaData_Size);
         /// <summary>
-        /// Get the version of the file.
+        /// Get the Parquet format version of the file.
         /// </summary>
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(_handle, FileMetaData_Version);
         /// <summary>

--- a/csharp/LogicalColumnWriter.cs
+++ b/csharp/LogicalColumnWriter.cs
@@ -65,6 +65,12 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// Apply a visitor to this logical column writer.
+        /// </summary>
+        /// <typeparam name="TReturn">The return type of the visitor.</typeparam>
+        /// <param name="visitor">The visitor instance.</param>
+        /// <returns>The result of the visitor.</returns>
         public abstract TReturn Apply<TReturn>(ILogicalColumnWriterVisitor<TReturn> visitor);
 
         private sealed class Creator : IColumnDescriptorVisitor<LogicalColumnWriter>
@@ -85,6 +91,7 @@ namespace ParquetSharp
         }
     }
 
+    /// <inheritdoc />
     public sealed class LogicalColumnWriter<TElement> : LogicalColumnWriter
     {
         private LogicalColumnWriter(ColumnWriter columnWriter, int bufferLength, ByteBuffer? byteBuffer, ILogicalBatchWriter<TElement> batchWriter)
@@ -130,21 +137,36 @@ namespace ParquetSharp
             base.Dispose();
         }
 
+        /// <inheritdoc />
         public override TReturn Apply<TReturn>(ILogicalColumnWriterVisitor<TReturn> visitor)
         {
             return visitor.OnLogicalColumnWriter(this);
         }
 
+        /// <summary>
+        /// Write an array of values to the column.
+        /// </summary>
+        /// <param name="values">An array of values to write.</param>
         public void WriteBatch(TElement[] values)
         {
             WriteBatch(values.AsSpan());
         }
 
+        /// <summary>
+        /// Write a range of values to the column.
+        /// </summary>
+        /// <param name="values">An array of values to write.</param>
+        /// <param name="start">The index of the first value to write.</param>
+        /// <param name="length">The number of values to write.</param>
         public void WriteBatch(TElement[] values, int start, int length)
         {
             WriteBatch(values.AsSpan(start, length));
         }
 
+        /// <summary>
+        /// Write a span of values to the column.
+        /// </summary>
+        /// <param name="values">A <see cref="ReadOnlySpan{TElement}"/> of values to write.</param>
         public void WriteBatch(ReadOnlySpan<TElement> values)
         {
             _batchWriter.WriteBatch(values);

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -4,13 +4,23 @@ using System.Linq;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Defines the mapping between .NET types and Parquet logical types, allowing for custom type handling.
+    /// </summary>
     public class LogicalTypeFactory
     {
+        /// <summary>
+        /// Create a new LogicalTypeFactory with the default primitive mapping.
+        /// </summary>
         public LogicalTypeFactory()
             : this(DefaultPrimitiveMapping)
         {
         }
 
+        /// <summary>
+        /// Create a new LogicalTypeFactory with a custom primitive mapping.
+        /// </summary>
+        /// <param name="primitiveMapping">The mapping from .NET types to Parquet logical and physical types</param>
         public LogicalTypeFactory(IReadOnlyDictionary<Type, (LogicalType? logicalType, Repetition repetition, PhysicalType physicalType)> primitiveMapping)
         {
             _primitiveMapping = primitiveMapping;
@@ -317,6 +327,9 @@ namespace ParquetSharp
                 {PhysicalType.FixedLenByteArray, typeof(FixedLenByteArray)},
             };
 
+        /// <summary>
+        /// The default LogicalTypeFactory instance.
+        /// </summary>
         public static readonly LogicalTypeFactory Default = new();
 
         private readonly IReadOnlyDictionary<Type, (LogicalType? logicalType, Repetition repetition, PhysicalType physicalType)> _primitiveMapping;

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -12,7 +12,7 @@ namespace ParquetSharp
     {
 #pragma warning disable RS0026
 #pragma warning disable RS0027
-        
+
         /// <summary>
         /// Create a new ParquetFileReader for reading from a file at the specified path
         /// </summary>
@@ -150,12 +150,12 @@ namespace ParquetSharp
         /// The <see cref="ParquetSharp.LogicalTypeFactory"/> for handling custom types.
         /// </summary>
         public LogicalTypeFactory LogicalTypeFactory { get; set; } = LogicalTypeFactory.Default; // TODO make this init only at some point when C# 9 is more widespread
-        
+
         /// <summary>
         /// The <see cref="ParquetSharp.LogicalReadConverterFactory"/> for reading custom types.
         /// </summary>
         public LogicalReadConverterFactory LogicalReadConverterFactory { get; set; } = LogicalReadConverterFactory.Default; // TODO make this init only at some point when C# 9 is more widespread
-        
+
         /// <summary>
         /// Metadata associated with the Parquet file.
         /// </summary>

--- a/csharp/ParquetFileReader.cs
+++ b/csharp/ParquetFileReader.cs
@@ -5,16 +5,27 @@ using ParquetSharp.IO;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Opens and reads Parquet files.
+    /// </summary>
     public sealed class ParquetFileReader : IDisposable
     {
 #pragma warning disable RS0026
 #pragma warning disable RS0027
-
+        
+        /// <summary>
+        /// Create a new ParquetFileReader for reading from a file at the specified path
+        /// </summary>
+        /// <param name="path">Path to the Parquet file</param>
         public ParquetFileReader(string path)
             : this(path, null)
         {
         }
 
+        /// <summary>
+        /// Create a new ParquetFileReader for reading from a specified <see cref="RandomAccessFile"/>
+        /// </summary>
+        /// <param name="randomAccessFile">The file to read</param>
         public ParquetFileReader(RandomAccessFile randomAccessFile)
             : this(randomAccessFile, null)
         {
@@ -30,6 +41,12 @@ namespace ParquetSharp
         {
         }
 
+        /// <summary>
+        /// Create a new ParquetFileReader for reading from a file at the specified path
+        /// </summary>
+        /// <param name="path">Path to the Parquet file</param>
+        /// <param name="readerProperties">A <see cref="ReaderProperties"/> object that configures the reader</param>
+        /// <exception cref="ArgumentNullException">Thrown if the path is null</exception>
         public ParquetFileReader(string path, ReaderProperties? readerProperties)
         {
             if (path == null) throw new ArgumentNullException(nameof(path));
@@ -44,6 +61,12 @@ namespace ParquetSharp
             GC.KeepAlive(readerProperties);
         }
 
+        /// <summary>
+        /// Create a new ParquetFileReader for reading from a specified <see cref="RandomAccessFile"/>
+        /// </summary>
+        /// <param name="randomAccessFile">The file to read</param>
+        /// <param name="readerProperties">The <see cref="ReaderProperties"/> to use</param>  
+        /// <exception cref="ArgumentNullException">Thrown if the file or its handle are null</exception>
         public ParquetFileReader(RandomAccessFile randomAccessFile, ReaderProperties? readerProperties)
         {
             if (randomAccessFile == null) throw new ArgumentNullException(nameof(randomAccessFile));
@@ -123,10 +146,26 @@ namespace ParquetSharp
             GC.KeepAlive(_handle);
         }
 
+        /// <summary>
+        /// The <see cref="ParquetSharp.LogicalTypeFactory"/> for handling custom types.
+        /// </summary>
         public LogicalTypeFactory LogicalTypeFactory { get; set; } = LogicalTypeFactory.Default; // TODO make this init only at some point when C# 9 is more widespread
+        
+        /// <summary>
+        /// The <see cref="ParquetSharp.LogicalReadConverterFactory"/> for reading custom types.
+        /// </summary>
         public LogicalReadConverterFactory LogicalReadConverterFactory { get; set; } = LogicalReadConverterFactory.Default; // TODO make this init only at some point when C# 9 is more widespread
+        
+        /// <summary>
+        /// Metadata associated with the Parquet file.
+        /// </summary>
         public FileMetaData FileMetaData => _fileMetaData ??= new FileMetaData(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileReader_MetaData));
 
+        /// <summary>
+        /// Get a <see cref="RowGroupReader"/> for the specified row group index.
+        /// </summary>
+        /// <param name="i">The row group index</param>
+        /// <returns>A <see cref="RowGroupReader"/> for the specified row group index</returns>
         public RowGroupReader RowGroup(int i)
         {
             return new(ExceptionInfo.Return<int, IntPtr>(_handle, i, ParquetFileReader_RowGroup), this);

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -405,6 +405,8 @@ namespace ParquetSharp
 
         /// <summary>
         /// Creates and returns a new <see cref="RowGroupWriter"/> for writing a buffered row group.
+        /// Using a buffered writer allows writing to columns in any order, and writes to different columns
+        /// may be interleaved, but requires more memory.
         /// </summary>
         /// <returns>A new <see cref="RowGroupWriter"/> instance.</returns>
         public RowGroupWriter AppendBufferedRowGroup()

--- a/csharp/ParquetFileWriter.cs
+++ b/csharp/ParquetFileWriter.cs
@@ -9,6 +9,9 @@ using ParquetSharp.Schema;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Opens and writes Parquet files.
+    /// </summary>
     public sealed class ParquetFileWriter : IDisposable
     {
         /// <summary>
@@ -391,11 +394,19 @@ namespace ParquetSharp
             GC.KeepAlive(_handle);
         }
 
+        /// <summary>
+        /// Creates and returns a new <see cref="RowGroupWriter"/> for writing a row group to the file.
+        /// </summary>
+        /// <returns>A new <see cref="RowGroupWriter"/> instance.</returns>
         public RowGroupWriter AppendRowGroup()
         {
             return new(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileWriter_AppendRowGroup), this);
         }
 
+        /// <summary>
+        /// Creates and returns a new <see cref="RowGroupWriter"/> for writing a buffered row group.
+        /// </summary>
+        /// <returns>A new <see cref="RowGroupWriter"/> instance.</returns>
         public RowGroupWriter AppendBufferedRowGroup()
         {
             return new(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileWriter_AppendBufferedRowGroup), this);
@@ -405,10 +416,31 @@ namespace ParquetSharp
         internal long NumRows => ExceptionInfo.Return<long>(_handle, ParquetFileWriter_Num_Rows); // 2021-04-08: calling this results in a segfault when the writer has been closed
         internal int NumRowGroups => ExceptionInfo.Return<int>(_handle, ParquetFileWriter_Num_Row_Groups); // 2021-04-08: calling this results in a segfault when the writer has been closed
 
+        /// <summary>
+        /// The <see cref="ParquetSharp.LogicalTypeFactory"/> for handling custom types.
+        /// </summary>
         public LogicalTypeFactory LogicalTypeFactory { get; set; } = LogicalTypeFactory.Default; // TODO make this init only at some point when C# 9 is more widespread
+
+        /// <summary>
+        /// The <see cref="LogicalWriteConverterFactory"/> for writing custom types.
+        /// </summary>
         public LogicalWriteConverterFactory LogicalWriteConverterFactory { get; set; } = LogicalWriteConverterFactory.Default; // TODO make this init only at some point when C# 9 is more widespread
+
+        /// <summary>
+        /// The <see cref="ParquetSharp.WriterProperties"/> used to configure the writer.
+        /// </summary>
         public WriterProperties WriterProperties => _writerProperties ??= new WriterProperties(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileWriter_Properties));
+
+        /// <summary>
+        /// The schema of the file.
+        /// </summary>        
         public SchemaDescriptor Schema => new(ExceptionInfo.Return<IntPtr>(_handle, ParquetFileWriter_Schema));
+
+        /// <summary>
+        /// Get the <see cref="ParquetSharp.ColumnDescriptor"/> for the specified column index.
+        /// </summary>
+        /// <param name="i">The column index.</param>
+        /// <returns>A <see cref="ParquetSharp.ColumnDescriptor"/> instance for the specified column.</returns>
         public ColumnDescriptor ColumnDescriptor(int i) => new(ExceptionInfo.Return<int, IntPtr>(_handle, i, ParquetFileWriter_Descr));
 
         /// <summary>
@@ -432,6 +464,9 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// Returns the file metadata for the file.
+        /// </summary>
         public FileMetaData? FileMetaData
         {
             get

--- a/csharp/ReaderProperties.cs
+++ b/csharp/ReaderProperties.cs
@@ -3,8 +3,15 @@ using System.Runtime.InteropServices;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Configures options for reading Parquet files.
+    /// </summary>
     public sealed class ReaderProperties : IDisposable
     {
+        /// <summary>
+        /// Create a new <see cref="ReaderProperties"/> with default values.
+        /// </summary>
+        /// <returns>A new <see cref="ReaderProperties"/> object with default values.</returns>
         public static ReaderProperties GetDefaultReaderProperties()
         {
             return new ReaderProperties(ExceptionInfo.Return<IntPtr>(ReaderProperties_Get_Default_Reader_Properties));
@@ -20,8 +27,14 @@ namespace ParquetSharp
             Handle.Dispose();
         }
 
+        /// <summary>
+        /// Whether the buffered stream is enabled for reading.
+        /// </summary>
         public bool IsBufferedStreamEnabled => ExceptionInfo.Return<bool>(Handle, ReaderProperties_Is_Buffered_Stream_Enabled);
 
+        /// <summary>
+        /// The size of the buffer (in bytes) used for reading.
+        /// </summary>
         public long BufferSize
         {
             get => ExceptionInfo.Return<long>(Handle, ReaderProperties_Get_Buffer_Size);
@@ -32,6 +45,9 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// The <see cref="ParquetSharp.FileDecryptionProperties"/> used for reading encrypted files.
+        /// </summary>
         public FileDecryptionProperties? FileDecryptionProperties
         {
             get
@@ -47,12 +63,18 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// Enable buffered stream for reading.
+        /// </summary>
         public void EnableBufferedStream()
         {
             ExceptionInfo.Check(ReaderProperties_Enable_Buffered_Stream(Handle.IntPtr));
             GC.KeepAlive(Handle);
         }
 
+        /// <summary>
+        /// Disable buffered stream for reading.
+        /// </summary>
         public void DisableBufferedStream()
         {
             ExceptionInfo.Check(ReaderProperties_Disable_Buffered_Stream(Handle.IntPtr));
@@ -64,12 +86,18 @@ namespace ParquetSharp
         /// </summary>
         public bool PageChecksumVerification => ExceptionInfo.Return<bool>(Handle, ReaderProperties_Page_Checksum_Verification);
 
+        /// <summary>
+        /// Enable page checksum verification during reading to check for data corruption
+        /// </summary>
         public void EnablePageChecksumVerification()
         {
             ExceptionInfo.Check(ReaderProperties_Enable_Page_Checksum_Verification(Handle.IntPtr));
             GC.KeepAlive(Handle);
         }
 
+        /// <summary>
+        /// Disable page checksum verification during reading to check for data corruption
+        /// </summary>
         public void DisablePageChecksumVerification()
         {
             ExceptionInfo.Check(ReaderProperties_Disable_Page_Checksum_Verification(Handle.IntPtr));

--- a/csharp/RowGroupReader.cs
+++ b/csharp/RowGroupReader.cs
@@ -3,6 +3,9 @@ using System.Runtime.InteropServices;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Reads row groups in a Parquet file.
+    /// </summary>
     public sealed class RowGroupReader : IDisposable
     {
         internal RowGroupReader(IntPtr handle, ParquetFileReader parquetFileReader)
@@ -16,8 +19,16 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
+        /// <summary>
+        /// Get the metadata for this row group.
+        /// </summary>
         public RowGroupMetaData MetaData => _metaData ??= new RowGroupMetaData(ExceptionInfo.Return<IntPtr>(_handle, RowGroupReader_Metadata));
 
+        /// <summary>
+        /// Get the column reader for the specified column index.
+        /// </summary>
+        /// <param name="i">The column index</param>
+        /// <returns>A column reader for the specified column index</returns>
         public ColumnReader Column(int i) => ColumnReader.Create(
             ExceptionInfo.Return<int, IntPtr>(_handle, i, RowGroupReader_Column),
             this,

--- a/csharp/RowGroupWriter.cs
+++ b/csharp/RowGroupWriter.cs
@@ -46,6 +46,9 @@ namespace ParquetSharp
         /// <summary>
         /// Get the column writer for the next column.
         /// </summary>
+        /// <remarks>
+        /// This method is not valid when using a buffered row group writer.
+        /// </remarks>
         /// <returns>A <see cref="ColumnWriter"/> for the next column.</returns>
         public ColumnWriter NextColumn()
         {

--- a/csharp/RowGroupWriter.cs
+++ b/csharp/RowGroupWriter.cs
@@ -3,6 +3,10 @@ using System.Runtime.InteropServices;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Writes a row group to a Parquet file. Allows access to individual <see cref="ColumnWriter"/>
+    /// instances for each column in the row group.
+    /// </summary>
     public sealed class RowGroupWriter : IDisposable
     {
         internal RowGroupWriter(IntPtr handle, ParquetFileWriter parquetFileWriter)
@@ -29,11 +33,20 @@ namespace ParquetSharp
         public long TotalCompressedBytes => ExceptionInfo.Return<long>(_handle, RowGroupWriter_Total_Compressed_Bytes);
         public bool Buffered => ExceptionInfo.Return<bool>(_handle, RowGroupWriter_Buffered);
 
+        /// <summary>
+        /// Get the column writer for the i-th column.
+        /// </summary>
+        /// <param name="i">The index of the column.</param>
+        /// <returns>A <see cref="ColumnWriter"/> for the i-th column.</returns>
         public ColumnWriter Column(int i)
         {
             return ColumnWriter.Create(ExceptionInfo.Return<int, IntPtr>(_handle, i, RowGroupWriter_Column), this, i);
         }
 
+        /// <summary>
+        /// Get the column writer for the next column.
+        /// </summary>
+        /// <returns>A <see cref="ColumnWriter"/> for the next column.</returns>
         public ColumnWriter NextColumn()
         {
             return ColumnWriter.Create(ExceptionInfo.Return<IntPtr>(_handle, RowGroupWriter_NextColumn), this, CurrentColumn);

--- a/csharp/RowGroupWriter.cs
+++ b/csharp/RowGroupWriter.cs
@@ -36,6 +36,9 @@ namespace ParquetSharp
         /// <summary>
         /// Get the column writer for the i-th column.
         /// </summary>
+        /// <remarks>
+        /// This method may only be used with a buffered row group writer, created with <see cref="ParquetFileWriter.AppendBufferedRowGroup"/>.
+        /// </remarks>
         /// <param name="i">The index of the column.</param>
         /// <returns>A <see cref="ColumnWriter"/> for the i-th column.</returns>
         public ColumnWriter Column(int i)

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -4,8 +4,15 @@ using ParquetSharp.Schema;
 
 namespace ParquetSharp
 {
+    /// <summary>
+    /// Configures options for writing Parquet files.
+    /// </summary>
     public sealed class WriterProperties : IDisposable
     {
+        /// <summary>
+        /// Create a new <see cref="WriterProperties"/> with default values.
+        /// </summary>
+        /// <returns>A new <see cref="WriterProperties"/> object with default values.</returns>
         public static WriterProperties GetDefaultWriterProperties()
         {
             return new WriterProperties(ExceptionInfo.Return<IntPtr>(WriterProperties_Get_Default_Writer_Properties));
@@ -21,14 +28,41 @@ namespace ParquetSharp
             Handle.Dispose();
         }
 
+        /// <summary>
+        /// The entity that created the file.
+        /// </summary>
         public string CreatedBy => ExceptionInfo.ReturnString(Handle, WriterProperties_Created_By, WriterProperties_Created_By_Free);
+        /// <summary>
+        /// The size of the data pages in bytes.
+        /// </summary>
         public long DataPageSize => ExceptionInfo.Return<long>(Handle, WriterProperties_Data_Pagesize);
+        /// <summary>
+        /// The <see cref="ParquetSharp.Encoding"/> used for dictionary index encoding.
+        /// </summary>
         public Encoding DictionaryIndexEncoding => ExceptionInfo.Return<Encoding>(Handle, WriterProperties_Dictionary_Index_Encoding);
+        /// <summary>
+        /// The <see cref="ParquetSharp.Encoding"/> used for dictionary page encoding.
+        /// </summary>
         public Encoding DictionaryPageEncoding => ExceptionInfo.Return<Encoding>(Handle, WriterProperties_Dictionary_Page_Encoding);
+        /// <summary>
+        /// The maximum dictionary page size in bytes.
+        /// </summary>
         public long DictionaryPagesizeLimit => ExceptionInfo.Return<long>(Handle, WriterProperties_Dictionary_Pagesize_Limit);
+        /// <summary>
+        /// The <see cref="ParquetSharp.FileEncryptionProperties"/> used for writing encrypted files.
+        /// </summary>
         public FileEncryptionProperties FileEncryptionProperties => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, WriterProperties_File_Encryption_Properties));
+        /// <summary>
+        /// The maximum number of rows in a row group.
+        /// </summary>
         public long MaxRowGroupLength => ExceptionInfo.Return<long>(Handle, WriterProperties_Max_Row_Group_Length);
+        /// <summary>
+        /// The version of the Parquet format to write.
+        /// </summary>
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(Handle, WriterProperties_Version);
+        /// <summary>
+        /// The size of the write batch in bytes.
+        /// </summary>
         public long WriteBatchSize => ExceptionInfo.Return<long>(Handle, WriterProperties_Write_Batch_Size);
 
         /// <summary>
@@ -44,31 +78,61 @@ namespace ParquetSharp
             return ExceptionInfo.Return<bool>(Handle, path.Handle, WriterProperties_Page_Index_Enabled_For_Path);
         }
 
+        /// <summary>
+        /// Get the <see cref="ParquetSharp.Compression"/> type used for the specified column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column.</param>
+        /// <returns>The <see cref="ParquetSharp.Compression"/> type used for the specified column.</returns>
         public Compression Compression(ColumnPath path)
         {
             return ExceptionInfo.Return<Compression>(Handle, path.Handle, WriterProperties_Compression);
         }
 
+        /// <summary>
+        /// Get the compression level used for the specified column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column.</param>
+        /// <returns>The compression level used for the specified column.</returns>
         public int CompressionLevel(ColumnPath path)
         {
             return ExceptionInfo.Return<int>(Handle, path.Handle, WriterProperties_Compression_Level);
         }
 
+        /// <summary>
+        /// Whether dictionary encoding is enabled for the specified column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column.</param>
+        /// <returns>Whether dictionary encoding is enabled for the specified column.</returns>
         public bool DictionaryEnabled(ColumnPath path)
         {
             return ExceptionInfo.Return<bool>(Handle, path.Handle, WriterProperties_Dictionary_Enabled);
         }
 
+        /// <summary>
+        /// Get the <see cref="ParquetSharp.Encoding"/> used for the specified column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column.</param>
+        /// <returns>The <see cref="ParquetSharp.Encoding"/> used for the specified column.</returns>
         public Encoding Encoding(ColumnPath path)
         {
             return ExceptionInfo.Return<Encoding>(Handle, path.Handle, WriterProperties_Encoding);
         }
 
+        /// <summary>
+        /// Whether statistics are enabled for the specified column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column.</param>
+        /// <returns>Whether statistics are enabled for the specified column.</returns>
         public bool StatisticsEnabled(ColumnPath path)
         {
             return ExceptionInfo.Return<bool>(Handle, path.Handle, WriterProperties_Statistics_Enabled);
         }
 
+        /// <summary>
+        /// The maximum size of statistics for the specified column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column.</param>
+        /// <returns>The maximum size of statistics for the specified column.</returns>
         public ulong MaxStatisticsSize(ColumnPath path)
         {
             return ExceptionInfo.Return<ulong>(Handle, path.Handle, WriterProperties_Max_Statistics_Size);

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -61,7 +61,7 @@ namespace ParquetSharp
         /// </summary>
         public ParquetVersion Version => ExceptionInfo.Return<ParquetVersion>(Handle, WriterProperties_Version);
         /// <summary>
-        /// The size of the write batch in bytes.
+        /// The number of records to batch together when writing.
         /// </summary>
         public long WriteBatchSize => ExceptionInfo.Return<long>(Handle, WriterProperties_Write_Batch_Size);
 

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -6,10 +6,13 @@ using ParquetSharp.Schema;
 namespace ParquetSharp
 {
     /// <summary>
-    /// Builder pattern for WriterProperties.
+    /// Builder pattern for creating and configuring a <see cref="WriterProperties"/> object. 
     /// </summary>
     public sealed class WriterPropertiesBuilder : IDisposable
     {
+        /// <summary>
+        /// Create a new WriterPropertiesBuilder.
+        /// </summary>
         public WriterPropertiesBuilder()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Create(out var handle));
@@ -22,13 +25,19 @@ namespace ParquetSharp
             _handle.Dispose();
         }
 
+        /// <summary>
+        /// Build the <see cref="WriterProperties"/> from the current state of the builder.
+        /// </summary>
+        /// <returns>The configured <see cref="WriterProperties"/> object.</returns>
         public WriterProperties Build()
         {
             return new WriterProperties(ExceptionInfo.Return<IntPtr>(_handle, WriterPropertiesBuilder_Build));
         }
 
-        // Dictionary enable/disable
-
+        /// <summary>
+        /// Disable dictionary encoding for all columns.
+        /// </summary>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableDictionary()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary(_handle.IntPtr));
@@ -36,6 +45,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Disable dictionary encoding for a specific column.
+        /// </summary>
+        /// <param name="path">The path of the column to disable dictionary encoding for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableDictionary(string path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary_By_Path(_handle.IntPtr, path));
@@ -43,6 +57,10 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Disable dictionary encoding for a specific column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to disable dictionary encoding for.</param>
         public WriterPropertiesBuilder DisableDictionary(ColumnPath path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Dictionary_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
@@ -51,12 +69,21 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Enable dictionary encoding by default.
+        /// </summary>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableDictionary()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary(_handle.IntPtr));
             return this;
         }
 
+        /// <summary>
+        /// Enable dictionary encoding for a specific column.
+        /// </summary>
+        /// <param name="path">The path of the column to enable dictionary encoding for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableDictionary(string path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary_By_Path(_handle.IntPtr, path));
@@ -64,6 +91,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Enable dictionary encoding for a specific column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to enable dictionary encoding for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableDictionary(ColumnPath path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Dictionary_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
@@ -72,8 +104,10 @@ namespace ParquetSharp
             return this;
         }
 
-        // Statistics enable/disable
-
+        /// <summary>
+        /// Disable statistics by default.
+        /// </summary>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableStatistics()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics(_handle.IntPtr));
@@ -81,6 +115,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Disable statistics for a specific column.
+        /// </summary>
+        /// <param name="path">The path of the column to disable statistics for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableStatistics(string path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics_By_Path(_handle.IntPtr, path));
@@ -88,6 +127,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Disable statistics for a specific column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to disable statistics for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableStatistics(ColumnPath path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Statistics_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
@@ -96,6 +140,10 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Enable statistics by default.
+        /// </summary>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableStatistics()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics(_handle.IntPtr));
@@ -103,6 +151,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Enable statistics for a specific column.
+        /// </summary>
+        /// <param name="path">The path of the column to enable statistics for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableStatistics(string path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics_By_Path(_handle.IntPtr, path));
@@ -110,6 +163,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Enable statistics for a specific column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to enable statistics for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableStatistics(ColumnPath path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Statistics_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
@@ -118,8 +176,11 @@ namespace ParquetSharp
             return this;
         }
 
-        // Other properties
-
+        /// <summary>
+        /// Set the compression codec to use for all columns.
+        /// </summary>
+        /// <param name="codec">The <see cref="ParquetSharp.Compression"/> codec to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Compression(Compression codec)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Compression(_handle.IntPtr, codec));
@@ -127,6 +188,12 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the compression codec to use for a specific column.
+        /// </summary>
+        /// <param name="path">The path of the column to set the compression codec for.</param>
+        /// <param name="codec">The <see cref="ParquetSharp.Compression"/> codec to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Compression(string path, Compression codec)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Compression_By_Path(_handle.IntPtr, path, codec));
@@ -134,6 +201,12 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the compression codec to use for a specific column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to set the compression codec for.</param>
+        /// <param name="codec">The <see cref="ParquetSharp.Compression"/> codec to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Compression(ColumnPath path, Compression codec)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Compression_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr, codec));
@@ -142,6 +215,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the compression level to use for all columns.
+        /// </summary>
+        /// <param name="compressionLevel">The compression level to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder CompressionLevel(int compressionLevel)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Compression_Level(_handle.IntPtr, compressionLevel));
@@ -149,6 +227,12 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the compression level to use for a specific column.
+        /// </summary>
+        /// <param name="path">The path of the column to set the compression level for.</param>
+        /// <param name="compressionLevel">The compression level to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder CompressionLevel(string path, int compressionLevel)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Compression_Level_By_Path(_handle.IntPtr, path, compressionLevel));
@@ -156,6 +240,12 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the compression level to use for a specific column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to set the compression level for.</param>
+        /// <param name="compressionLevel">The compression level to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder CompressionLevel(ColumnPath path, int compressionLevel)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Compression_Level_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr, compressionLevel));
@@ -164,6 +254,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set an identifier for the entity that created the file.
+        /// </summary>
+        /// <param name="createdBy">The name of the entity that created the file.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder CreatedBy(string createdBy)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Created_By(_handle.IntPtr, createdBy));
@@ -171,6 +266,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the maximum size of a data page in bytes.
+        /// </summary>
+        /// <param name="pageSize">The maximum data page size to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DataPagesize(long pageSize)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Data_Pagesize(_handle.IntPtr, pageSize));
@@ -178,6 +278,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the maximum size of a dictionary page in bytes.
+        /// </summary>
+        /// <param name="dictionaryPagesizeLimit">The maximum dictionary page size to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DictionaryPagesizeLimit(long dictionaryPagesizeLimit)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Dictionary_Pagesize_Limit(_handle.IntPtr, dictionaryPagesizeLimit));
@@ -185,6 +290,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the encoding type to use for all columns.
+        /// </summary>
+        /// <param name="encoding">The <see cref="ParquetSharp.Encoding"/> to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Encoding(Encoding encoding)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Encoding(_handle.IntPtr, encoding));
@@ -192,6 +302,12 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the encoding type to use for a specific column.
+        /// </summary>
+        /// <param name="path">The path of the column to set the encoding for.</param>
+        /// <param name="encoding">The <see cref="ParquetSharp.Encoding"/> to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Encoding(string path, Encoding encoding)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Encoding_By_Path(_handle.IntPtr, path, encoding));
@@ -199,6 +315,12 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the encoding type to use for a specific column.
+        /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to set the encoding for.</param>
+        /// <param name="encoding">The <see cref="ParquetSharp.Encoding"/> to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Encoding(ColumnPath path, Encoding encoding)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Encoding_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr, encoding));
@@ -207,6 +329,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the encryption properties to use for the file.
+        /// </summary>
+        /// <param name="fileEncryptionProperties">The <see cref="FileEncryptionProperties"/> to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Encryption(FileEncryptionProperties? fileEncryptionProperties)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Encryption(_handle.IntPtr, fileEncryptionProperties?.Handle.IntPtr ?? IntPtr.Zero));
@@ -215,12 +342,22 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the maximum size of a row group in bytes.
+        /// </summary>
+        /// <param name="maxRowGroupLength">The maximum row group size to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder MaxRowGroupLength(long maxRowGroupLength)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Max_Row_Group_Length(_handle.IntPtr, maxRowGroupLength));
             return this;
         }
 
+        /// <summary>
+        /// Set the Parquet version to use for the file.
+        /// </summary>
+        /// <param name="version">The <see cref="ParquetVersion"/> to use.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder Version(ParquetVersion version)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Version(_handle.IntPtr, version));
@@ -228,6 +365,11 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Set the number of rows to write in a single batch.
+        /// </summary>
+        /// <param name="writeBatchSize">The number of rows to write in a single batch.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder WriteBatchSize(long writeBatchSize)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Write_Batch_Size(_handle.IntPtr, writeBatchSize));
@@ -251,8 +393,10 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Enable writing the page index for a specific column
+        /// Enable writing the page index for a specific column.
         /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to enable the page index for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableWritePageIndex(ColumnPath path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Write_Page_Index_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
@@ -262,8 +406,10 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Enable writing the page index for a specific column
+        /// Enable writing the page index for a specific column.
         /// </summary>
+        /// <param name="path">The path of the column to enable the page index for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnableWritePageIndex(string path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Write_Page_Index_By_Path(_handle.IntPtr, path));
@@ -272,8 +418,9 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Disable writing the page index by default
+        /// Disable writing the page index by default.
         /// </summary>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableWritePageIndex()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Write_Page_Index(_handle.IntPtr));
@@ -282,8 +429,10 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Disable writing the page index for a specific column
+        /// Disable writing the page index for a specific column.
         /// </summary>
+        /// <param name="path">The <see cref="ColumnPath"/> of the column to disable the page index for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableWritePageIndex(ColumnPath path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Write_Page_Index_By_ColumnPath(_handle.IntPtr, path.Handle.IntPtr));
@@ -293,8 +442,10 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Disable writing the page index for a specific column
+        /// Disable writing the page index for a specific column.
         /// </summary>
+        /// <param name="path">The path of the column to disable the page index for.</param>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisableWritePageIndex(string path)
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Write_Page_Index_By_Path(_handle.IntPtr, path));
@@ -303,8 +454,9 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Enable writing CRC checksums for data pages
+        /// Enable writing CRC checksums for data pages.
         /// </summary>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder EnablePageChecksum()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Enable_Page_Checksum(_handle.IntPtr));
@@ -313,8 +465,9 @@ namespace ParquetSharp
         }
 
         /// <summary>
-        /// Disable writing CRC checksums for data pages
+        /// Disable writing CRC checksums for data pages.
         /// </summary>
+        /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder DisablePageChecksum()
         {
             ExceptionInfo.Check(WriterPropertiesBuilder_Disable_Page_Checksum(_handle.IntPtr));


### PR DESCRIPTION
This PR adds a bunch of class and method descriptions for entities referenced in all the tests available at `csharp.test/Arrow`. Most of these are actually some of the core classes such as `ParquetFileReader/Writer`.

Feel free to amend any inaccuracies (I did some basic cross-referencing of existing docs/Parquet specification for these, but some might be off the mark).

Thank you!