### PR TITLE
Add github link to navbar (as text)

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -31,7 +31,7 @@ items:
   - uid: Writing
     name: Writing
     href: docs/Writing.md
-- uid:
+- uid: API Reference
   name: API Reference
   type: Namespace
   items:
@@ -53,3 +53,6 @@ items:
   - uid: ParquetSharp.Schema
     name: ParquetSharp.Schema
     href: api/ParquetSharp.Schema.html
+- uid: GitHub
+  name: GitHub
+  href: https://github.com/G-Research/ParquetSharp


### PR DESCRIPTION
This is a tiny PR for adding the GitHub link as text to the navbar. I tried adding it as a right-aligned icon, but following the docs and [discussions](https://github.com/dotnet/docfx/discussions/9644) didn't work for me. I looked at other repos built with DocFX, and apparently, they just add the link as text, such as [this one](https://ovasquez.github.io/docfx-material/).

This will help improve the site's page rank since users can easily navigate to and from GitHub.

I've looked at how https://g-research.github.io works, and it seems to fetch the value from the repo's "homepage," namely `gh_repo.homepage`. We should set it up in this repo's config so it gets auto-updated soon. I don't think we need to change the main page's config.

Thank you!