### PR TITLE
Enable Control Flow Guard for windows builds

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -104,6 +104,10 @@ add_definitions(-DARROW_STATIC)
 add_definitions(-DARROW_NO_DEPRECATED_API)
 add_definitions(-DPARQUET_STATIC)
 
+if (MSVC AND (MSVC_VERSION GREATER 1900))
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /guard:cf")
+endif()
+
 if (UNIX AND CMAKE_BUILD_TYPE STREQUAL Release)
 	if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
 		set(STRIP_OPTIONS -x)


### PR DESCRIPTION
Enable control flow guard when building with msvc as ParquetSharpNative.dll is reporting [BA2008](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard) from BinSkim.

Verified that after this change that binskim no longer reports BA2008.

More details for /guard command can be found [here](https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard?view=msvc-170).