### PR TITLE
Bump version of Ubuntu used in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   check-format:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Check format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2022]
+        os: [ubuntu-22.04, macos-13, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
@@ -231,7 +231,7 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04-arm64, macos-13, macos-14, windows-2022]
+        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-13, macos-14, windows-2022]
         dotnet: [netcoreapp3.1, net6.0, net7.0, net8.0]
         include:
         - os: windows-2022


### PR DESCRIPTION
The Ubuntu 20.04 GitHub actions runner is being deprecated (https://github.com/actions/runner-images/issues/11101).

This bumps the Ubuntu version to either `ubuntu-latest` or `ubuntu-22.04`. I've used Ubuntu 22.04 for the `build-native` job rather than `ubuntu-latest` so that the arm64 library will be usable on Ubuntu 22.04 (for the x64 build we use a manylinux CentOS image for more compatibility).