### PR TITLE
Add ARM64 Support to ParquetSharp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,10 @@ if (MSVC)
 		endif()
 	endforeach()
 
-	add_compile_options("/MP") # Compile files in parallel.
+	if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+		add_compile_options(/MP) # Compile files in parallel with MSVC.
+	endif()
+
 	add_compile_options("/WX") # Threat warnings as errors.
 
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ endforeach()
 if (MSVC)
 
 	if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+		foreach (flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+			if (${flag_var} MATCHES "/MD")
+				string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+			endif()
+		endforeach()
+
 		add_compile_options(/MP) # Compile files in parallel with MSVC.
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,6 @@ endforeach()
 
 if (MSVC)
 
-	foreach (flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-		if (${flag_var} MATCHES "/MD")
-			string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-		endif()
-	endforeach()
-
 	if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 		add_compile_options(/MP) # Compile files in parallel with MSVC.
 	endif()

--- a/build_windows_arm.ps1
+++ b/build_windows_arm.ps1
@@ -1,0 +1,86 @@
+Set-StrictMode -Version 3
+$ErrorActionPreference = "Stop"
+
+# Find vcpkg or download it if required
+if ($null -ne $Env:VCPKG_INSTALLATION_ROOT) {
+  $vcpkgDir = $Env:VCPKG_INSTALLATION_ROOT
+  Write-Output "Using vcpkg at $vcpkgDir from VCPKG_INSTALLATION_ROOT"
+}
+elseif ($null -ne $Env:VCPKG_ROOT) {
+  $vcpkgDir = $Env:VCPKG_ROOT
+  Write-Output "Using vcpkg at $vcpkgDir from VCPKG_ROOT"
+}
+else {
+  $vcpkgDir = "$(Get-Location)/build/vcpkg"
+  Write-Output "Using local vcpkg at $vcpkgDir"
+  if (-not (Test-Path $vcpkgDir)) {
+    git clone https://github.com/microsoft/vcpkg.git $vcpkgDir
+    if (-not $?) { throw "git clone failed" }
+    & $vcpkgDir/bootstrap-vcpkg.bat
+    if (-not $?) { throw "bootstrap-vcpkg failed" }
+  }
+}
+
+$triplet = "arm64-windows"
+
+$build_types = @("Debug", "Release")
+
+if ($null -eq $env:ARROW_HOME) {
+    Write-Host "Error: ARROW_HOME environment variable not set." -ForegroundColor Red
+    Write-Host "Please set it to your Arrow installation directory, for example:" -ForegroundColor Yellow
+    Write-Host "    $env:ARROW_HOME = 'C:\path\to\arrow\install\$triplet'" -ForegroundColor Yellow
+    exit 1
+}
+
+$arrow_install_dir = $env:ARROW_HOME
+
+if (-not (Test-Path "$arrow_install_dir/release") -or -not (Test-Path "$arrow_install_dir/debug")) {
+    Write-Host "Error: ARROW_HOME directory doesn't contain expected 'debug' and 'release' subdirectories." -ForegroundColor Red
+    Write-Host "Please ensure your Arrow installation has both debug and release builds." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Using Arrow installation from: $arrow_install_dir" -ForegroundColor Green
+
+$options = @()
+if ($Env:GITHUB_ACTIONS -eq "true") {
+  $build_types = @("Release")
+  $customTripletsDir = "$(Get-Location)/build/custom-triplets"
+  New-Item -Path $customTripletsDir -ItemType "directory" -Force > $null
+  $sourceTripletFile = "$vcpkgDir/triplets/$triplet.cmake"
+  $customTripletFile = "$customTripletsDir/$triplet.cmake"
+  Copy-Item -Path $sourceTripletFile -Destination $customTripletFile
+  Add-Content -Path $customTripletFile -Value "set(VCPKG_BUILD_TYPE release)"
+
+  # Ensure vcpkg uses the same MSVC version to build dependencies as we use to build the ParquetSharp library.
+  # By default, vcpkg uses the most recent version it can find, which might not be the same as what msbuild uses.
+  $vsInstPath = & "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -property installationPath
+  Import-Module "$vsInstPath/Common7/Tools/Microsoft.VisualStudio.DevShell.dll"
+  Enter-VsDevShell -VsInstallPath $vsInstPath -SkipAutomaticLocation
+  $clPath = Get-Command cl.exe | Select -ExpandProperty "Source"
+  $toolsetVersion = $clPath.Split("\")[8]
+  if (-not $toolsetVersion.StartsWith("14.")) { throw "Couldn't get toolset version from path '$clPath'" }
+  Write-Output "Using platform toolset version = $toolsetVersion"
+  Add-Content -Path $customTripletFile -Value "set(VCPKG_PLATFORM_TOOLSET_VERSION $toolsetVersion)"
+
+  $options += "-D"
+  $options += "VCPKG_OVERLAY_TRIPLETS=$customTripletsDir"
+}
+
+cmake -B build/$triplet -S . `
+  -G "Ninja Multi-Config" `
+  -DCMAKE_C_COMPILER=clang-cl `
+  -DCMAKE_CXX_COMPILER=clang-cl `
+  -DCMAKE_TOOLCHAIN_FILE=C:/src/vcpkg/scripts/buildsystems/vcpkg.cmake `
+  -DCMAKE_MAKE_PROGRAM=ninja `
+  -DVCPKG_TARGET_TRIPLET="$triplet" `
+  -DARROW_ROOT_DEBUG="$arrow_install_dir/debug" `
+  -DARROW_ROOT_RELEASE="$arrow_install_dir/release" `
+  $options
+
+if (-not $?) { throw "cmake failed" }
+
+foreach ($build_type in $build_types) {
+  cmake --build build/$triplet --config $build_type --target ParquetSharpNative
+  if (-not $?) { throw "ninja build failed" }
+}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,10 +1,8 @@
 include(GenerateExportHeader)
 
-find_package(Arrow CONFIG REQUIRED)
 find_package(unofficial-brotli CONFIG REQUIRED)
 find_package(BZip2 REQUIRED)
 find_package(lz4 CONFIG REQUIRED)
-find_package(Parquet CONFIG REQUIRED)
 find_package(re2 CONFIG REQUIRED)
 find_package(Snappy CONFIG REQUIRED)
 find_package(Thrift CONFIG REQUIRED)
@@ -86,9 +84,19 @@ include_directories(
 	${PROJECT_BINARY_DIR}
 	${PARQUET_INCLUDE_DIRS})
 
+target_include_directories(ParquetSharpNative PRIVATE
+	"$<$<CONFIG:Debug>:${ARROW_ROOT_DEBUG}/include>"
+	"$<$<CONFIG:Release>:${ARROW_ROOT_RELEASE}/include>"
+)
+
+target_link_libraries(ParquetSharpNative PRIVATE 
+	debug ${ARROW_ROOT_DEBUG}/lib/arrow.lib
+	optimized ${ARROW_ROOT_RELEASE}/lib/arrow.lib
+	debug ${ARROW_ROOT_DEBUG}/lib/parquet.lib
+	optimized ${ARROW_ROOT_RELEASE}/lib/parquet.lib
+)
+
 target_link_libraries(ParquetSharpNative PRIVATE
-	Parquet::parquet_static
-	Arrow::arrow_static
 	unofficial::brotli::brotlidec unofficial::brotli::brotlienc unofficial::brotli::brotlicommon
 	BZip2::BZip2
 	lz4::lz4
@@ -97,7 +105,7 @@ target_link_libraries(ParquetSharpNative PRIVATE
 	thrift::thrift
 	utf8proc
 	ZLIB::ZLIB
-	zstd::libzstd_static
+	zstd::libzstd
 )
 
 add_definitions(-DARROW_STATIC)

--- a/cpp/arrow/FileWriter.cpp
+++ b/cpp/arrow/FileWriter.cpp
@@ -113,9 +113,9 @@ extern "C"
     )
   }
 
-  PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewRowGroup(FileWriter* writer, int64_t chunk_size)
+  PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewRowGroup(FileWriter* writer)
   {
-    TRYCATCH(PARQUET_THROW_NOT_OK(writer->NewRowGroup(chunk_size));)
+    TRYCATCH(PARQUET_THROW_NOT_OK(writer->NewRowGroup());)
   }
 
   PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewBufferedRowGroup(FileWriter* writer)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,58 @@
   "version-string": "undefined",
   "builtin-baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
   "dependencies": [
-    "arrow"
+    {
+      "name": "arrow",
+      "platform": "!arm"
+    },
+    {
+      "name": "brotli",
+      "platform": "arm"
+    },
+    {
+      "name": "bzip2",
+      "platform": "arm"
+    },
+    {
+      "name": "lz4",
+      "platform": "arm"
+    },
+    {
+      "name": "re2",
+      "platform": "arm"
+    },
+    {
+      "name": "abseil",
+      "platform": "arm"
+    },
+    {
+      "name": "snappy",
+      "platform": "arm"
+    },
+    {
+      "name": "thrift",
+      "platform": "arm"
+    },
+    {
+      "name": "zlib",
+      "platform": "arm"
+    },
+    {
+      "name": "libevent",
+      "platform": "arm"
+    },
+    {
+      "name": "utf8proc",
+      "platform": "arm"
+    },
+    {
+      "name": "zstd",
+      "platform": "arm"
+    },
+    {
+      "name": "openssl",
+      "platform": "arm"
+    }
   ],
   "overrides": [
     {


### PR DESCRIPTION
## Description
This PR adds support for building ParquetSharp on the ARM64 architecture. It includes modifications to the build system, dependency management, and resolves compatibility issues specific to ARM64 platforms.

## Checklist
- [x] Added new PowerShell build script specifically for ARM64 Windows
- [x] Updated `vcpkg.json` to include required dependencies for ARM64 builds.
- [x] Modified `CMakeLists.txt` to configure necessary dependencies for the ARM64 target.
- [x] Resolved all errors during the ARM64 build process.
- [x] Added build configuration to properly handle both Debug and Release builds on ARM64

## Related Issues
- ### Fixes #441 
