### PR TITLE
Update ParquetSharp to Reflect changes in Arrow APIs and Type Defintions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,10 @@ if (MSVC)
 		endif()
 	endforeach()
 
-	add_compile_options("/MP") # Compile files in parallel.
+	if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+		add_compile_options(/MP) # Compile files in parallel with MSVC.
+	endif()
+
 	add_compile_options("/WX") # Threat warnings as errors.
 
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ endforeach()
 if (MSVC)
 
 	if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+		foreach (flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+			if (${flag_var} MATCHES "/MD")
+				string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+			endif()
+		endforeach()
+
 		add_compile_options(/MP) # Compile files in parallel with MSVC.
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,6 @@ endforeach()
 
 if (MSVC)
 
-	foreach (flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-		if (${flag_var} MATCHES "/MD")
-			string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-		endif()
-	endforeach()
-
 	if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 		add_compile_options(/MP) # Compile files in parallel with MSVC.
 	endif()

--- a/build_windows_arm.ps1
+++ b/build_windows_arm.ps1
@@ -1,0 +1,86 @@
+Set-StrictMode -Version 3
+$ErrorActionPreference = "Stop"
+
+# Find vcpkg or download it if required
+if ($null -ne $Env:VCPKG_INSTALLATION_ROOT) {
+  $vcpkgDir = $Env:VCPKG_INSTALLATION_ROOT
+  Write-Output "Using vcpkg at $vcpkgDir from VCPKG_INSTALLATION_ROOT"
+}
+elseif ($null -ne $Env:VCPKG_ROOT) {
+  $vcpkgDir = $Env:VCPKG_ROOT
+  Write-Output "Using vcpkg at $vcpkgDir from VCPKG_ROOT"
+}
+else {
+  $vcpkgDir = "$(Get-Location)/build/vcpkg"
+  Write-Output "Using local vcpkg at $vcpkgDir"
+  if (-not (Test-Path $vcpkgDir)) {
+    git clone https://github.com/microsoft/vcpkg.git $vcpkgDir
+    if (-not $?) { throw "git clone failed" }
+    & $vcpkgDir/bootstrap-vcpkg.bat
+    if (-not $?) { throw "bootstrap-vcpkg failed" }
+  }
+}
+
+$triplet = "arm64-windows"
+
+$build_types = @("Debug", "Release")
+
+if ($null -eq $env:ARROW_HOME) {
+    Write-Host "Error: ARROW_HOME environment variable not set." -ForegroundColor Red
+    Write-Host "Please set it to your Arrow installation directory, for example:" -ForegroundColor Yellow
+    Write-Host "    $env:ARROW_HOME = 'C:\path\to\arrow\install\$triplet'" -ForegroundColor Yellow
+    exit 1
+}
+
+$arrow_install_dir = $env:ARROW_HOME
+
+if (-not (Test-Path "$arrow_install_dir/release") -or -not (Test-Path "$arrow_install_dir/debug")) {
+    Write-Host "Error: ARROW_HOME directory doesn't contain expected 'debug' and 'release' subdirectories." -ForegroundColor Red
+    Write-Host "Please ensure your Arrow installation has both debug and release builds." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Using Arrow installation from: $arrow_install_dir" -ForegroundColor Green
+
+$options = @()
+if ($Env:GITHUB_ACTIONS -eq "true") {
+  $build_types = @("Release")
+  $customTripletsDir = "$(Get-Location)/build/custom-triplets"
+  New-Item -Path $customTripletsDir -ItemType "directory" -Force > $null
+  $sourceTripletFile = "$vcpkgDir/triplets/$triplet.cmake"
+  $customTripletFile = "$customTripletsDir/$triplet.cmake"
+  Copy-Item -Path $sourceTripletFile -Destination $customTripletFile
+  Add-Content -Path $customTripletFile -Value "set(VCPKG_BUILD_TYPE release)"
+
+  # Ensure vcpkg uses the same MSVC version to build dependencies as we use to build the ParquetSharp library.
+  # By default, vcpkg uses the most recent version it can find, which might not be the same as what msbuild uses.
+  $vsInstPath = & "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -property installationPath
+  Import-Module "$vsInstPath/Common7/Tools/Microsoft.VisualStudio.DevShell.dll"
+  Enter-VsDevShell -VsInstallPath $vsInstPath -SkipAutomaticLocation
+  $clPath = Get-Command cl.exe | Select -ExpandProperty "Source"
+  $toolsetVersion = $clPath.Split("\")[8]
+  if (-not $toolsetVersion.StartsWith("14.")) { throw "Couldn't get toolset version from path '$clPath'" }
+  Write-Output "Using platform toolset version = $toolsetVersion"
+  Add-Content -Path $customTripletFile -Value "set(VCPKG_PLATFORM_TOOLSET_VERSION $toolsetVersion)"
+
+  $options += "-D"
+  $options += "VCPKG_OVERLAY_TRIPLETS=$customTripletsDir"
+}
+
+cmake -B build/$triplet -S . `
+  -G "Ninja Multi-Config" `
+  -DCMAKE_C_COMPILER=clang-cl `
+  -DCMAKE_CXX_COMPILER=clang-cl `
+  -DCMAKE_TOOLCHAIN_FILE=C:/src/vcpkg/scripts/buildsystems/vcpkg.cmake `
+  -DCMAKE_MAKE_PROGRAM=ninja `
+  -DVCPKG_TARGET_TRIPLET="$triplet" `
+  -DARROW_ROOT_DEBUG="$arrow_install_dir/debug" `
+  -DARROW_ROOT_RELEASE="$arrow_install_dir/release" `
+  $options
+
+if (-not $?) { throw "cmake failed" }
+
+foreach ($build_type in $build_types) {
+  cmake --build build/$triplet --config $build_type --target ParquetSharpNative
+  if (-not $?) { throw "ninja build failed" }
+}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,10 +1,8 @@
 include(GenerateExportHeader)
 
-find_package(Arrow CONFIG REQUIRED)
 find_package(unofficial-brotli CONFIG REQUIRED)
 find_package(BZip2 REQUIRED)
 find_package(lz4 CONFIG REQUIRED)
-find_package(Parquet CONFIG REQUIRED)
 find_package(re2 CONFIG REQUIRED)
 find_package(Snappy CONFIG REQUIRED)
 find_package(Thrift CONFIG REQUIRED)
@@ -86,9 +84,19 @@ include_directories(
 	${PROJECT_BINARY_DIR}
 	${PARQUET_INCLUDE_DIRS})
 
+target_include_directories(ParquetSharpNative PRIVATE
+	"$<$<CONFIG:Debug>:${ARROW_ROOT_DEBUG}/include>"
+	"$<$<CONFIG:Release>:${ARROW_ROOT_RELEASE}/include>"
+)
+
+target_link_libraries(ParquetSharpNative PRIVATE 
+	debug ${ARROW_ROOT_DEBUG}/lib/arrow.lib
+	optimized ${ARROW_ROOT_RELEASE}/lib/arrow.lib
+	debug ${ARROW_ROOT_DEBUG}/lib/parquet.lib
+	optimized ${ARROW_ROOT_RELEASE}/lib/parquet.lib
+)
+
 target_link_libraries(ParquetSharpNative PRIVATE
-	Parquet::parquet_static
-	Arrow::arrow_static
 	unofficial::brotli::brotlidec unofficial::brotli::brotlienc unofficial::brotli::brotlicommon
 	BZip2::BZip2
 	lz4::lz4
@@ -97,7 +105,7 @@ target_link_libraries(ParquetSharpNative PRIVATE
 	thrift::thrift
 	utf8proc
 	ZLIB::ZLIB
-	zstd::libzstd_static
+	zstd::libzstd
 )
 
 add_definitions(-DARROW_STATIC)

--- a/cpp/ColumnDecryptionProperties.cpp
+++ b/cpp/ColumnDecryptionProperties.cpp
@@ -11,7 +11,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionProperties_Deep_Clone(const std::shared_ptr<ColumnDecryptionProperties>* properties, std::shared_ptr<ColumnDecryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 	
     PARQUETSHARP_EXPORT void ColumnDecryptionProperties_Free(const std::shared_ptr<const ColumnDecryptionProperties>* properties)

--- a/cpp/ColumnEncryptionProperties.cpp
+++ b/cpp/ColumnEncryptionProperties.cpp
@@ -11,7 +11,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Deep_Clone(const std::shared_ptr<ColumnEncryptionProperties>* properties, std::shared_ptr<ColumnEncryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 	
     PARQUETSHARP_EXPORT void ColumnEncryptionProperties_Free(const std::shared_ptr<const ColumnEncryptionProperties>* properties)

--- a/cpp/Enums.cpp
+++ b/cpp/Enums.cpp
@@ -53,7 +53,8 @@ namespace
 		static_assert(LogicalType::Type::BSON == 13);
 		static_assert(LogicalType::Type::UUID == 14);
 		static_assert(LogicalType::Type::FLOAT16 == 15);
-		static_assert(LogicalType::Type::NONE == 16);
+		static_assert(LogicalType::Type::VARIANT == 16);
+		static_assert(LogicalType::Type::NONE == 17);
 
 		static_assert(ParquetCipher::AES_GCM_V1 == 0);
 		static_assert(ParquetCipher::AES_GCM_CTR_V1 == 1);

--- a/cpp/Enums.cpp
+++ b/cpp/Enums.cpp
@@ -59,12 +59,9 @@ namespace
 		static_assert(ParquetCipher::AES_GCM_CTR_V1 == 1);
 
 		static_assert(ParquetVersion::PARQUET_1_0 == 0);
-		ARROW_SUPPRESS_DEPRECATION_WARNING
-		static_assert(ParquetVersion::PARQUET_2_0 == 1);
-		ARROW_UNSUPPRESS_DEPRECATION_WARNING
-		static_assert(ParquetVersion::PARQUET_2_4 == 2);
-		static_assert(ParquetVersion::PARQUET_2_6 == 3);
-		static_assert(ParquetVersion::PARQUET_2_LATEST == 3);
+		static_assert(ParquetVersion::PARQUET_2_4 == 1);
+		static_assert(ParquetVersion::PARQUET_2_6 == 2);
+		static_assert(ParquetVersion::PARQUET_2_LATEST == 2);
 
 		static_assert(Type::BOOLEAN == 0);
 		static_assert(Type::INT32 == 1);

--- a/cpp/FileDecryptionProperties.cpp
+++ b/cpp/FileDecryptionProperties.cpp
@@ -13,7 +13,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Deep_Clone(const std::shared_ptr<FileDecryptionProperties>* properties, std::shared_ptr<FileDecryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 
     PARQUETSHARP_EXPORT void FileDecryptionProperties_Free(const std::shared_ptr<const FileDecryptionProperties>* properties)

--- a/cpp/FileEncryptionProperties.cpp
+++ b/cpp/FileEncryptionProperties.cpp
@@ -11,7 +11,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Deep_Clone(const std::shared_ptr<FileEncryptionProperties>* properties, std::shared_ptr<FileEncryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 
     PARQUETSHARP_EXPORT void FileEncryptionProperties_Free(const std::shared_ptr<const FileEncryptionProperties>* properties)

--- a/cpp/arrow/FileReader.cpp
+++ b/cpp/arrow/FileReader.cpp
@@ -93,13 +93,13 @@ extern "C"
       }
       if (columns == nullptr)
       {
-        PARQUET_THROW_NOT_OK(reader->GetRecordBatchReader(row_groups_vec, &batch_reader));
+        PARQUET_ASSIGN_OR_THROW(batch_reader, reader->GetRecordBatchReader(row_groups_vec));
       }
       else
       {
         std::vector<int> columns_vec(columns_count);
         std::copy(columns, columns + columns_count, columns_vec.begin());
-        PARQUET_THROW_NOT_OK(reader->GetRecordBatchReader(row_groups_vec, columns_vec, &batch_reader));
+        PARQUET_ASSIGN_OR_THROW(batch_reader, reader->GetRecordBatchReader(row_groups_vec, columns_vec));
       }
       PARQUET_THROW_NOT_OK(arrow::ExportRecordBatchReader(batch_reader, stream_out));
     )

--- a/cpp/arrow/FileWriter.cpp
+++ b/cpp/arrow/FileWriter.cpp
@@ -113,9 +113,9 @@ extern "C"
     )
   }
 
-  PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewRowGroup(FileWriter* writer, int64_t chunk_size)
+  PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewRowGroup(FileWriter* writer)
   {
-    TRYCATCH(PARQUET_THROW_NOT_OK(writer->NewRowGroup(chunk_size));)
+    TRYCATCH(PARQUET_THROW_NOT_OK(writer->NewRowGroup());)
   }
 
   PARQUETSHARP_EXPORT ExceptionInfo* FileWriter_NewBufferedRowGroup(FileWriter* writer)

--- a/csharp.test/TestNode.cs
+++ b/csharp.test/TestNode.cs
@@ -8,17 +8,6 @@ namespace ParquetSharp.Test
     internal static class TestNode
     {
         [Test]
-        public static void TestDeepClone()
-        {
-            using var node = new ExampleSchemaBuilder().Build();
-            using var cloned = node.DeepClone();
-
-            Assert.AreEqual(node, cloned);
-
-            DeepAssertNotReferenceEqual(node, cloned);
-        }
-
-        [Test]
         public static void TestEquality()
         {
             using var exampleSchema = new ExampleSchemaBuilder().Build();
@@ -90,13 +79,8 @@ namespace ParquetSharp.Test
             using var logicalType = LogicalType.Int(32, true);
             using var primitiveNode = new PrimitiveNode("primitive", Repetition.Required, logicalType, PhysicalType.Int32, fieldId: 64);
 
-            using var clonedGroupNode = groupNode.DeepClone();
-            using var clonedPrimitiveNode = primitiveNode.DeepClone();
-
             Assert.AreEqual(42, groupNode.FieldId);
-            Assert.AreEqual(42, clonedGroupNode.FieldId);
             Assert.AreEqual(64, primitiveNode.FieldId);
-            Assert.AreEqual(64, clonedPrimitiveNode.FieldId);
         }
 
         /// <summary>

--- a/csharp/ColumnDecryptionProperties.cs
+++ b/csharp/ColumnDecryptionProperties.cs
@@ -27,8 +27,6 @@ namespace ParquetSharp
         /// </summary>
         public byte[] Key => ExceptionInfo.Return<AesKey>(Handle, ColumnDecryptionProperties_Key).ToBytes();
 
-        public ColumnDecryptionProperties DeepClone() => new ColumnDecryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnDecryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/ColumnEncryptionProperties.cs
+++ b/csharp/ColumnEncryptionProperties.cs
@@ -24,8 +24,6 @@ namespace ParquetSharp
         public byte[] Key => ExceptionInfo.Return<AesKey>(Handle, ColumnEncryptionProperties_Key).ToBytes();
         public string KeyMetadata => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Key_Metadata, ColumnEncryptionProperties_Key_Metadata_Free);
 
-        public ColumnEncryptionProperties DeepClone() => new ColumnEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnEncryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -42,8 +42,6 @@ namespace ParquetSharp
             }
         }
 
-        public FileDecryptionProperties DeepClone() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, FileDecryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/FileEncryptionProperties.cs
+++ b/csharp/FileEncryptionProperties.cs
@@ -51,11 +51,6 @@ namespace ParquetSharp
             return columnHandle == IntPtr.Zero ? null : new ColumnEncryptionProperties(columnHandle);
         }
 
-        /// <summary>
-        /// Create a deep clone of the file encryption properties object.
-        /// </summary>
-        public FileEncryptionProperties DeepClone() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, FileEncryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -40,29 +40,6 @@ namespace ParquetSharp.Schema
             return ExceptionInfo.Return<int>(Handle, node.Handle, GroupNode_Field_Index_By_Node);
         }
 
-        public override Node DeepClone()
-        {
-            using var logicalType = LogicalType;
-            var fields = Fields;
-            var clonedFields = fields.Select(f => f.DeepClone()).ToArray();
-            try
-            {
-                return new GroupNode(
-                    Name,
-                    Repetition,
-                    clonedFields,
-                    logicalType is NoneLogicalType ? null : logicalType,
-                    FieldId);
-            }
-            finally
-            {
-                foreach (var field in fields.Concat(clonedFields))
-                {
-                    field.Dispose();
-                }
-            }
-        }
-
         private static unsafe IntPtr Make(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType? logicalType, int fieldId)
         {
             var handles = fields.Select(f => f.Handle.IntPtr).ToArray();

--- a/csharp/Schema/Node.cs
+++ b/csharp/Schema/Node.cs
@@ -29,11 +29,6 @@ namespace ParquetSharp.Schema
         public ColumnPath Path => new(ExceptionInfo.Return<IntPtr>(Handle, Node_Path));
         public Repetition Repetition => ExceptionInfo.Return<Repetition>(Handle, Node_Repetition);
 
-        /// <summary>
-        /// Deep cloning of the node. If the node is a group node, its children will be deep cloned as well.
-        /// </summary>
-        public abstract Node DeepClone();
-
         public bool Equals(Node? other)
         {
             return other != null && ExceptionInfo.Return<bool>(Handle, other.Handle, Node_Equals);

--- a/csharp/Schema/PrimitiveNode.cs
+++ b/csharp/Schema/PrimitiveNode.cs
@@ -40,18 +40,6 @@ namespace ParquetSharp.Schema
         public PhysicalType PhysicalType => ExceptionInfo.Return<PhysicalType>(Handle, PrimitiveNode_Physical_Type);
         public int TypeLength => ExceptionInfo.Return<int>(Handle, PrimitiveNode_Type_Length);
 
-        public override Node DeepClone()
-        {
-            using var logicalType = LogicalType;
-            return new PrimitiveNode(
-                Name,
-                Repetition,
-                logicalType,
-                PhysicalType,
-                TypeLength,
-                FieldId);
-        }
-
         private static IntPtr Make(
             string name,
             Repetition repetition,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,58 @@
   "version-string": "undefined",
   "builtin-baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
   "dependencies": [
-    "arrow"
+    {
+      "name": "arrow",
+      "platform": "!arm"
+    },
+    {
+      "name": "brotli",
+      "platform": "arm"
+    },
+    {
+      "name": "bzip2",
+      "platform": "arm"
+    },
+    {
+      "name": "lz4",
+      "platform": "arm"
+    },
+    {
+      "name": "re2",
+      "platform": "arm"
+    },
+    {
+      "name": "abseil",
+      "platform": "arm"
+    },
+    {
+      "name": "snappy",
+      "platform": "arm"
+    },
+    {
+      "name": "thrift",
+      "platform": "arm"
+    },
+    {
+      "name": "zlib",
+      "platform": "arm"
+    },
+    {
+      "name": "libevent",
+      "platform": "arm"
+    },
+    {
+      "name": "utf8proc",
+      "platform": "arm"
+    },
+    {
+      "name": "zstd",
+      "platform": "arm"
+    },
+    {
+      "name": "openssl",
+      "platform": "arm"
+    }
   ],
   "overrides": [
     {


### PR DESCRIPTION
## Description
This PR updates ParquetSharp to maintain compatibility with recent changes introduced in Arrow. Several deprecated overloads of GetRecordBatchReader and the `PARQUET_2_0` enum value have been removed in Arrow 19+ (apache/arrow#44990, apache/arrow#45849, apache/arrow#45375 and apache/arrow#46132).

## Checklist

- [x] Migrated to arrow::Result-based APIs (PARQUET_ASSIGN_OR_THROW) as the old Status-based methods were removed.
- [x] Refactored usage of `GetRecordBatchReader` to align with Arrow's updated method definitions.
- [x] Updated enums and added Variant `LogicalType`.

## Related Issues
- ### Fixes #522
