### PR TITLE
Update ParquetSharp to Reflect changes in Arrow APIs and Type Defintions

### DIFF
--- a/cpp/ColumnDecryptionProperties.cpp
+++ b/cpp/ColumnDecryptionProperties.cpp
@@ -11,7 +11,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* ColumnDecryptionProperties_Deep_Clone(const std::shared_ptr<ColumnDecryptionProperties>* properties, std::shared_ptr<ColumnDecryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 	
     PARQUETSHARP_EXPORT void ColumnDecryptionProperties_Free(const std::shared_ptr<const ColumnDecryptionProperties>* properties)

--- a/cpp/ColumnEncryptionProperties.cpp
+++ b/cpp/ColumnEncryptionProperties.cpp
@@ -11,7 +11,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* ColumnEncryptionProperties_Deep_Clone(const std::shared_ptr<ColumnEncryptionProperties>* properties, std::shared_ptr<ColumnEncryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 	
     PARQUETSHARP_EXPORT void ColumnEncryptionProperties_Free(const std::shared_ptr<const ColumnEncryptionProperties>* properties)

--- a/cpp/Enums.cpp
+++ b/cpp/Enums.cpp
@@ -53,7 +53,8 @@ namespace
 		static_assert(LogicalType::Type::BSON == 13);
 		static_assert(LogicalType::Type::UUID == 14);
 		static_assert(LogicalType::Type::FLOAT16 == 15);
-		static_assert(LogicalType::Type::NONE == 16);
+		static_assert(LogicalType::Type::VARIANT == 16);
+		static_assert(LogicalType::Type::NONE == 17);
 
 		static_assert(ParquetCipher::AES_GCM_V1 == 0);
 		static_assert(ParquetCipher::AES_GCM_CTR_V1 == 1);

--- a/cpp/Enums.cpp
+++ b/cpp/Enums.cpp
@@ -59,12 +59,9 @@ namespace
 		static_assert(ParquetCipher::AES_GCM_CTR_V1 == 1);
 
 		static_assert(ParquetVersion::PARQUET_1_0 == 0);
-		ARROW_SUPPRESS_DEPRECATION_WARNING
-		static_assert(ParquetVersion::PARQUET_2_0 == 1);
-		ARROW_UNSUPPRESS_DEPRECATION_WARNING
-		static_assert(ParquetVersion::PARQUET_2_4 == 2);
-		static_assert(ParquetVersion::PARQUET_2_6 == 3);
-		static_assert(ParquetVersion::PARQUET_2_LATEST == 3);
+		static_assert(ParquetVersion::PARQUET_2_4 == 1);
+		static_assert(ParquetVersion::PARQUET_2_6 == 2);
+		static_assert(ParquetVersion::PARQUET_2_LATEST == 2);
 
 		static_assert(Type::BOOLEAN == 0);
 		static_assert(Type::INT32 == 1);

--- a/cpp/FileDecryptionProperties.cpp
+++ b/cpp/FileDecryptionProperties.cpp
@@ -13,7 +13,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* FileDecryptionProperties_Deep_Clone(const std::shared_ptr<FileDecryptionProperties>* properties, std::shared_ptr<FileDecryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 
     PARQUETSHARP_EXPORT void FileDecryptionProperties_Free(const std::shared_ptr<const FileDecryptionProperties>* properties)

--- a/cpp/FileEncryptionProperties.cpp
+++ b/cpp/FileEncryptionProperties.cpp
@@ -11,7 +11,7 @@ extern "C"
 {
     PARQUETSHARP_EXPORT ExceptionInfo* FileEncryptionProperties_Deep_Clone(const std::shared_ptr<FileEncryptionProperties>* properties, std::shared_ptr<FileEncryptionProperties>** clone)
     {
-        TRYCATCH(*clone = new std::shared_ptr((*properties)->DeepClone());)
+        TRYCATCH(*clone = new std::shared_ptr((*properties));)
     }
 
     PARQUETSHARP_EXPORT void FileEncryptionProperties_Free(const std::shared_ptr<const FileEncryptionProperties>* properties)

--- a/cpp/arrow/FileReader.cpp
+++ b/cpp/arrow/FileReader.cpp
@@ -93,13 +93,13 @@ extern "C"
       }
       if (columns == nullptr)
       {
-        PARQUET_THROW_NOT_OK(reader->GetRecordBatchReader(row_groups_vec, &batch_reader));
+        PARQUET_ASSIGN_OR_THROW(batch_reader, reader->GetRecordBatchReader(row_groups_vec));
       }
       else
       {
         std::vector<int> columns_vec(columns_count);
         std::copy(columns, columns + columns_count, columns_vec.begin());
-        PARQUET_THROW_NOT_OK(reader->GetRecordBatchReader(row_groups_vec, columns_vec, &batch_reader));
+        PARQUET_ASSIGN_OR_THROW(batch_reader, reader->GetRecordBatchReader(row_groups_vec, columns_vec));
       }
       PARQUET_THROW_NOT_OK(arrow::ExportRecordBatchReader(batch_reader, stream_out));
     )

--- a/csharp.test/TestNode.cs
+++ b/csharp.test/TestNode.cs
@@ -8,17 +8,6 @@ namespace ParquetSharp.Test
     internal static class TestNode
     {
         [Test]
-        public static void TestDeepClone()
-        {
-            using var node = new ExampleSchemaBuilder().Build();
-            using var cloned = node.DeepClone();
-
-            Assert.AreEqual(node, cloned);
-
-            DeepAssertNotReferenceEqual(node, cloned);
-        }
-
-        [Test]
         public static void TestEquality()
         {
             using var exampleSchema = new ExampleSchemaBuilder().Build();
@@ -90,13 +79,8 @@ namespace ParquetSharp.Test
             using var logicalType = LogicalType.Int(32, true);
             using var primitiveNode = new PrimitiveNode("primitive", Repetition.Required, logicalType, PhysicalType.Int32, fieldId: 64);
 
-            using var clonedGroupNode = groupNode.DeepClone();
-            using var clonedPrimitiveNode = primitiveNode.DeepClone();
-
             Assert.AreEqual(42, groupNode.FieldId);
-            Assert.AreEqual(42, clonedGroupNode.FieldId);
             Assert.AreEqual(64, primitiveNode.FieldId);
-            Assert.AreEqual(64, clonedPrimitiveNode.FieldId);
         }
 
         /// <summary>

--- a/csharp/ColumnDecryptionProperties.cs
+++ b/csharp/ColumnDecryptionProperties.cs
@@ -27,8 +27,6 @@ namespace ParquetSharp
         /// </summary>
         public byte[] Key => ExceptionInfo.Return<AesKey>(Handle, ColumnDecryptionProperties_Key).ToBytes();
 
-        public ColumnDecryptionProperties DeepClone() => new ColumnDecryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnDecryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/ColumnEncryptionProperties.cs
+++ b/csharp/ColumnEncryptionProperties.cs
@@ -24,8 +24,6 @@ namespace ParquetSharp
         public byte[] Key => ExceptionInfo.Return<AesKey>(Handle, ColumnEncryptionProperties_Key).ToBytes();
         public string KeyMetadata => ExceptionInfo.ReturnString(Handle, ColumnEncryptionProperties_Key_Metadata, ColumnEncryptionProperties_Key_Metadata_Free);
 
-        public ColumnEncryptionProperties DeepClone() => new ColumnEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, ColumnEncryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/FileDecryptionProperties.cs
+++ b/csharp/FileDecryptionProperties.cs
@@ -42,8 +42,6 @@ namespace ParquetSharp
             }
         }
 
-        public FileDecryptionProperties DeepClone() => new FileDecryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, FileDecryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileDecryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/FileEncryptionProperties.cs
+++ b/csharp/FileEncryptionProperties.cs
@@ -51,11 +51,6 @@ namespace ParquetSharp
             return columnHandle == IntPtr.Zero ? null : new ColumnEncryptionProperties(columnHandle);
         }
 
-        /// <summary>
-        /// Create a deep clone of the file encryption properties object.
-        /// </summary>
-        public FileEncryptionProperties DeepClone() => new FileEncryptionProperties(ExceptionInfo.Return<IntPtr>(Handle, FileEncryptionProperties_Deep_Clone));
-
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr FileEncryptionProperties_Deep_Clone(IntPtr properties, out IntPtr clone);
 

--- a/csharp/PublicAPI/net6/PublicAPI.Shipped.txt
+++ b/csharp/PublicAPI/net6/PublicAPI.Shipped.txt
@@ -10,7 +10,6 @@ abstract ParquetSharp.LogicalColumnReader.Apply<TReturn>(ParquetSharp.ILogicalCo
 abstract ParquetSharp.LogicalColumnReader.HasNext.get -> bool
 abstract ParquetSharp.LogicalColumnReader.Skip(long numRowsToSkip) -> long
 abstract ParquetSharp.LogicalColumnWriter.Apply<TReturn>(ParquetSharp.ILogicalColumnWriterVisitor<TReturn>! visitor) -> TReturn
-abstract ParquetSharp.Schema.Node.DeepClone() -> ParquetSharp.Schema.Node!
 abstract ParquetSharp.Statistics.MaxUntyped.get -> object!
 abstract ParquetSharp.Statistics.MinUntyped.get -> object!
 const ParquetSharp.LogicalRead.DateTimeOffset = 621355968000000000 -> long
@@ -41,8 +40,6 @@ override ParquetSharp.LogicalColumnWriter<TElement>.Apply<TReturn>(ParquetSharp.
 override ParquetSharp.LogicalColumnWriter<TElement>.Dispose() -> void
 override ParquetSharp.LogicalType.ToString() -> string!
 override ParquetSharp.Schema.ColumnPath.ToString() -> string!
-override ParquetSharp.Schema.GroupNode.DeepClone() -> ParquetSharp.Schema.Node!
-override ParquetSharp.Schema.PrimitiveNode.DeepClone() -> ParquetSharp.Schema.Node!
 override ParquetSharp.Statistics<TValue>.MaxUntyped.get -> object!
 override ParquetSharp.Statistics<TValue>.MinUntyped.get -> object!
 override ParquetSharp.TimeSpanNanos.ToString() -> string!
@@ -161,7 +158,6 @@ ParquetSharp.ColumnCryptoMetaData.EncryptedWithFooterKey.get -> bool
 ParquetSharp.ColumnCryptoMetaData.KeyMetadata.get -> string!
 ParquetSharp.ColumnDecryptionProperties
 ParquetSharp.ColumnDecryptionProperties.ColumnPath.get -> string!
-ParquetSharp.ColumnDecryptionProperties.DeepClone() -> ParquetSharp.ColumnDecryptionProperties!
 ParquetSharp.ColumnDecryptionProperties.Dispose() -> void
 ParquetSharp.ColumnDecryptionProperties.Key.get -> byte[]!
 ParquetSharp.ColumnDecryptionPropertiesBuilder
@@ -190,7 +186,6 @@ ParquetSharp.ColumnDescriptor.TypePrecision.get -> int
 ParquetSharp.ColumnDescriptor.TypeScale.get -> int
 ParquetSharp.ColumnEncryptionProperties
 ParquetSharp.ColumnEncryptionProperties.ColumnPath.get -> string!
-ParquetSharp.ColumnEncryptionProperties.DeepClone() -> ParquetSharp.ColumnEncryptionProperties!
 ParquetSharp.ColumnEncryptionProperties.Dispose() -> void
 ParquetSharp.ColumnEncryptionProperties.IsEncrypted.get -> bool
 ParquetSharp.ColumnEncryptionProperties.IsEncryptedWithFooterKey.get -> bool
@@ -347,7 +342,6 @@ ParquetSharp.FileDecryptionProperties.AadPrefix.get -> string!
 ParquetSharp.FileDecryptionProperties.AadPrefixVerifier.get -> ParquetSharp.AadPrefixVerifier?
 ParquetSharp.FileDecryptionProperties.CheckPlaintextFooterIntegrity.get -> bool
 ParquetSharp.FileDecryptionProperties.ColumnKey(string! columPath) -> byte[]!
-ParquetSharp.FileDecryptionProperties.DeepClone() -> ParquetSharp.FileDecryptionProperties!
 ParquetSharp.FileDecryptionProperties.Dispose() -> void
 ParquetSharp.FileDecryptionProperties.FooterKey.get -> byte[]!
 ParquetSharp.FileDecryptionProperties.KeyRetriever.get -> ParquetSharp.DecryptionKeyRetriever?
@@ -365,7 +359,6 @@ ParquetSharp.FileDecryptionPropertiesBuilder.KeyRetriever(ParquetSharp.Decryptio
 ParquetSharp.FileDecryptionPropertiesBuilder.PlaintextFilesAllowed() -> ParquetSharp.FileDecryptionPropertiesBuilder!
 ParquetSharp.FileEncryptionProperties
 ParquetSharp.FileEncryptionProperties.ColumnEncryptionProperties(string! columnPath) -> ParquetSharp.ColumnEncryptionProperties?
-ParquetSharp.FileEncryptionProperties.DeepClone() -> ParquetSharp.FileEncryptionProperties!
 ParquetSharp.FileEncryptionProperties.Dispose() -> void
 ParquetSharp.FileEncryptionProperties.EncryptedFooter.get -> bool
 ParquetSharp.FileEncryptionProperties.FileAad.get -> string!

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -40,29 +40,6 @@ namespace ParquetSharp.Schema
             return ExceptionInfo.Return<int>(Handle, node.Handle, GroupNode_Field_Index_By_Node);
         }
 
-        public override Node DeepClone()
-        {
-            using var logicalType = LogicalType;
-            var fields = Fields;
-            var clonedFields = fields.Select(f => f.DeepClone()).ToArray();
-            try
-            {
-                return new GroupNode(
-                    Name,
-                    Repetition,
-                    clonedFields,
-                    logicalType is NoneLogicalType ? null : logicalType,
-                    FieldId);
-            }
-            finally
-            {
-                foreach (var field in fields.Concat(clonedFields))
-                {
-                    field.Dispose();
-                }
-            }
-        }
-
         private static unsafe IntPtr Make(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType? logicalType, int fieldId)
         {
             var handles = fields.Select(f => f.Handle.IntPtr).ToArray();

--- a/csharp/Schema/Node.cs
+++ b/csharp/Schema/Node.cs
@@ -29,11 +29,6 @@ namespace ParquetSharp.Schema
         public ColumnPath Path => new(ExceptionInfo.Return<IntPtr>(Handle, Node_Path));
         public Repetition Repetition => ExceptionInfo.Return<Repetition>(Handle, Node_Repetition);
 
-        /// <summary>
-        /// Deep cloning of the node. If the node is a group node, its children will be deep cloned as well.
-        /// </summary>
-        public abstract Node DeepClone();
-
         public bool Equals(Node? other)
         {
             return other != null && ExceptionInfo.Return<bool>(Handle, other.Handle, Node_Equals);

--- a/csharp/Schema/PrimitiveNode.cs
+++ b/csharp/Schema/PrimitiveNode.cs
@@ -40,18 +40,6 @@ namespace ParquetSharp.Schema
         public PhysicalType PhysicalType => ExceptionInfo.Return<PhysicalType>(Handle, PrimitiveNode_Physical_Type);
         public int TypeLength => ExceptionInfo.Return<int>(Handle, PrimitiveNode_Type_Length);
 
-        public override Node DeepClone()
-        {
-            using var logicalType = LogicalType;
-            return new PrimitiveNode(
-                Name,
-                Repetition,
-                logicalType,
-                PhysicalType,
-                TypeLength,
-                FieldId);
-        }
-
         private static IntPtr Make(
             string name,
             Repetition repetition,


### PR DESCRIPTION
## Description
This PR updates ParquetSharp to maintain compatibility with recent changes introduced in Arrow. The deprecated overloads of `GetRecordBatchReader` and the `PARQUET_2_0` enum value have been removed in Arrow 19+, along with some other modifications (apache/arrow#44990, apache/arrow#45849, apache/arrow#45375 and apache/arrow#46132).

## Checklist
- [x] Migrated to arrow::Result-based APIs (PARQUET_ASSIGN_OR_THROW) as the old Status-based methods were removed.
- [x] Refactored usage of `GetRecordBatchReader` to align with Arrow's updated method definitions.
- [x] Updated enums and added Variant `LogicalType`.

## Related Issues
- ### Fixes #522
