### PR TITLE
Support writing custom types that can represent nulls

### DIFF
--- a/csharp.test/TestCustomNullableType.cs
+++ b/csharp.test/TestCustomNullableType.cs
@@ -27,7 +27,6 @@ namespace ParquetSharp.Test
             {
                 using var writer = new ParquetFileWriter(outStream, schema, WriterProperties.GetDefaultWriterProperties());
                 writer.LogicalWriteConverterFactory = new ValueLogicalWriteConverterFactory();
-                writer.LogicalTypeFactory = new ValueLogicalTypeFactory();
 
                 using var rowGroup = writer.AppendRowGroup();
                 using var column = rowGroup.NextColumn();
@@ -41,7 +40,6 @@ namespace ParquetSharp.Test
             using var input = new BufferReader(buffer);
             using var fileReader = new ParquetFileReader(input);
             fileReader.LogicalReadConverterFactory = new ValueLogicalReadConverterFactory();
-            fileReader.LogicalTypeFactory = new ValueLogicalTypeFactory();
 
             using var groupReader = fileReader.RowGroup(0);
             using var columnReader = groupReader.Column(0).LogicalReaderOverride<Value>();
@@ -138,19 +136,6 @@ namespace ParquetSharp.Test
                 {
                     destination[i] = defLevels[i] != definedLevel ? default : new Value(source[src++]);
                 }
-            }
-        }
-
-        private class ValueLogicalTypeFactory : LogicalTypeFactory
-        {
-            public override bool IsNullable(Type type)
-            {
-                if (type == typeof(Value))
-                {
-                    return true;
-                }
-
-                return base.IsNullable(type);
             }
         }
     }

--- a/csharp.test/TestCustomNullableType.cs
+++ b/csharp.test/TestCustomNullableType.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using ParquetSharp.IO;
+using ParquetSharp.Schema;
+
+namespace ParquetSharp.Test
+{
+    [TestFixture]
+    public static class TestCustomNullableType
+    {
+        /// <summary>
+        /// Test writing a custom type that has its own way to represent nullability,
+        /// which should be translated to nulls in Parquet.
+        /// </summary>
+        [Test]
+        public static void RoundTripCustomNullableType()
+        {
+            var inputData = new[] {new Value(1), default(Value), new Value(2), new Value(3)};
+
+            var columns = new[] {new PrimitiveNode("column", Repetition.Optional, LogicalType.None(), PhysicalType.Float)};
+            var schema = new GroupNode("schema", Repetition.Required, columns);
+
+            using var buffer = new ResizableBuffer();
+
+            using (var outStream = new BufferOutputStream(buffer))
+            {
+                using var writer = new ParquetFileWriter(outStream, schema, WriterProperties.GetDefaultWriterProperties());
+                writer.LogicalWriteConverterFactory = new ValueLogicalWriteConverterFactory();
+                writer.LogicalTypeFactory = new ValueLogicalTypeFactory();
+
+                using var rowGroup = writer.AppendRowGroup();
+                using var column = rowGroup.NextColumn();
+                using var logicalWriter = column.LogicalWriterOverride<Value>();
+
+                logicalWriter.WriteBatch(inputData);
+
+                writer.Close();
+            }
+
+            using var input = new BufferReader(buffer);
+            using var fileReader = new ParquetFileReader(input);
+            fileReader.LogicalReadConverterFactory = new ValueLogicalReadConverterFactory();
+            fileReader.LogicalTypeFactory = new ValueLogicalTypeFactory();
+
+            using var groupReader = fileReader.RowGroup(0);
+            using var columnReader = groupReader.Column(0).LogicalReaderOverride<Value>();
+
+            var roundTrippedData = columnReader.ReadAll(checked((int) groupReader.MetaData.NumRows));
+            Assert.AreEqual(inputData, roundTrippedData);
+        }
+
+        private enum TypeCode
+        {
+            Null,
+            Float,
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct Value
+        {
+            [FieldOffset(0)]
+            public TypeCode Type;
+
+            [FieldOffset(4)]
+            public float FloatValue;
+
+            public Value(float value)
+            {
+                Type = TypeCode.Float;
+                FloatValue = value;
+            }
+        }
+
+        private class ValueLogicalWriteConverterFactory : LogicalWriteConverterFactory
+        {
+            public override Delegate GetConverter<TLogical, TPhysical>(
+                ColumnDescriptor columnDescriptor,
+                ByteBuffer? byteBuffer)
+            {
+                if (typeof(TLogical) == typeof(Value))
+                {
+                    if (columnDescriptor.PhysicalType == PhysicalType.Float)
+                    {
+                        return (LogicalWrite<Value, float>.Converter) WriteFloat;
+                    }
+                }
+
+                return base.GetConverter<TLogical, TPhysical>(columnDescriptor, byteBuffer);
+            }
+
+            private static void WriteFloat(
+                ReadOnlySpan<Value> source,
+                Span<short> defLevels,
+                Span<float> destination,
+                short nullLevel)
+            {
+                int num = 0;
+                for (int index = 0; index < source.Length; ++index)
+                {
+                    var value = source[index];
+                    switch (value.Type)
+                    {
+                        case TypeCode.Null:
+                            defLevels[index] = nullLevel;
+                            break;
+
+                        case TypeCode.Float:
+                            destination[num++] = value.FloatValue;
+                            defLevels[index] = (short) (nullLevel + 1);
+                            break;
+
+                        default:
+                            throw new InvalidOperationException();
+                    }
+                }
+            }
+        }
+
+        private class ValueLogicalReadConverterFactory : LogicalReadConverterFactory
+        {
+            public override Delegate GetConverter<TLogical, TPhysical>(ColumnDescriptor columnDescriptor, ColumnChunkMetaData columnChunkMetaData)
+            {
+                if (typeof(TLogical) == typeof(Value))
+                {
+                    if (columnDescriptor.PhysicalType == PhysicalType.Float)
+                    {
+                        return (LogicalRead<Value, float>.Converter) ReadFloat;
+                    }
+                }
+                return base.GetConverter<TLogical, TPhysical>(columnDescriptor, columnChunkMetaData);
+            }
+
+            private static void ReadFloat(ReadOnlySpan<float> source, ReadOnlySpan<short> defLevels,
+                Span<Value> destination, short definedLevel)
+            {
+                for (int i = 0, src = 0; i < destination.Length; ++i)
+                {
+                    destination[i] = defLevels[i] != definedLevel ? default : new Value(source[src++]);
+                }
+            }
+        }
+
+        private class ValueLogicalTypeFactory : LogicalTypeFactory
+        {
+            public override bool IsNullable(Type type)
+            {
+                if (type == typeof(Value))
+                {
+                    return true;
+                }
+
+                return base.IsNullable(type);
+            }
+        }
+    }
+}

--- a/csharp.test/TestNode.cs
+++ b/csharp.test/TestNode.cs
@@ -99,6 +99,40 @@ namespace ParquetSharp.Test
             Assert.AreEqual(64, clonedPrimitiveNode.FieldId);
         }
 
+        [Test]
+        public static void TestPrimitiveNodeToString()
+        {
+            using var logicalType = LogicalType.Timestamp(true, TimeUnit.Micros);
+            using var node = new PrimitiveNode("timestamp", Repetition.Required, logicalType, PhysicalType.Int64);
+            using var group = new GroupNode("root", Repetition.Required, new[] {node});
+
+            var stringRepresentation = group.Fields[0].ToString();
+            Assert.AreEqual(
+                "PrimitiveNode {Path=\"timestamp\", PhysicalType=Int64, Repetition=Required, LogicalType=Timestamp}",
+                stringRepresentation);
+        }
+
+        [Test]
+        public static void TestGroupNodeToString()
+        {
+            using var noneType = LogicalType.None();
+            using var listType = LogicalType.List();
+
+            using var element = new PrimitiveNode("element", Repetition.Required, noneType, PhysicalType.Float);
+            using var list = new GroupNode("list", Repetition.Repeated, new[] {element});
+            using var values = new GroupNode("values", Repetition.Optional, new[] {list}, listType);
+            using var group = new GroupNode("root", Repetition.Required, new[] {values});
+
+            var stringRepresentation = group.Fields[0].ToString();
+            Assert.AreEqual(
+                "GroupNode {Path=\"values\", Repetition=Optional, LogicalType=List, Fields=[" +
+                "GroupNode {Path=\"values.list\", Repetition=Repeated, LogicalType=None, Fields=[" +
+                "PrimitiveNode {Path=\"values.list.element\", PhysicalType=Float, Repetition=Required, LogicalType=None}" +
+                "]}" +
+                "]}",
+                stringRepresentation);
+        }
+
         /// <summary>
         /// Verify that two nodes are not references to the same instance,
         /// and that none of their fields are.

--- a/csharp/ColumnDescriptor.cs
+++ b/csharp/ColumnDescriptor.cs
@@ -33,18 +33,24 @@ namespace ParquetSharp
 
         public TReturn Apply<TReturn>(LogicalTypeFactory typeFactory, IColumnDescriptorVisitor<TReturn> visitor)
         {
-            return Apply(typeFactory, null, false, visitor);
+            return Apply(typeFactory, null, null, false, visitor);
         }
 
         public TReturn Apply<TReturn>(LogicalTypeFactory typeFactory, Type? columnLogicalTypeOverride, IColumnDescriptorVisitor<TReturn> visitor)
         {
-            return Apply(typeFactory, columnLogicalTypeOverride, false, visitor);
+            return Apply(typeFactory, null, columnLogicalTypeOverride, false, visitor);
         }
 
         public TReturn Apply<TReturn>(LogicalTypeFactory typeFactory, Type? columnLogicalTypeOverride, bool useNesting, IColumnDescriptorVisitor<TReturn> visitor)
         {
+            return Apply(typeFactory, null, columnLogicalTypeOverride, useNesting, visitor);
+        }
+
+        public TReturn Apply<TReturn>(LogicalTypeFactory typeFactory, Type? elementTypeOverride, Type? columnLogicalTypeOverride, bool useNesting, IColumnDescriptorVisitor<TReturn> visitor)
+        {
             var types = GetSystemTypes(typeFactory, columnLogicalTypeOverride, useNesting);
-            var visitorApply = VisitorCache.GetOrAdd((types.physicalType, types.logicalType, types.elementType, typeof(TReturn)), t =>
+            var elementType = elementTypeOverride ?? types.elementType;
+            var visitorApply = VisitorCache.GetOrAdd((types.physicalType, types.logicalType, elementType, typeof(TReturn)), t =>
             {
 
                 var iface = typeof(IColumnDescriptorVisitor<TReturn>);
@@ -122,7 +128,8 @@ namespace ParquetSharp
                     }
 
                     if (node.Repetition == Repetition.Optional &&
-                        !typeFactory.IsNullable(elementType))
+                        elementType.IsValueType &&
+                        !TypeUtils.IsNullable(elementType, out _))
                     {
                         // Node is optional and the element type is not already a nullable type
                         elementType = typeof(Nullable<>).MakeGenericType(elementType);

--- a/csharp/ColumnDescriptor.cs
+++ b/csharp/ColumnDescriptor.cs
@@ -122,8 +122,7 @@ namespace ParquetSharp
                     }
 
                     if (node.Repetition == Repetition.Optional &&
-                        elementType.IsValueType &&
-                        !TypeUtils.IsNullable(elementType, out _))
+                        !typeFactory.IsNullable(elementType))
                     {
                         // Node is optional and the element type is not already a nullable type
                         elementType = typeof(Nullable<>).MakeGenericType(elementType);

--- a/csharp/ColumnDescriptor.cs
+++ b/csharp/ColumnDescriptor.cs
@@ -46,7 +46,7 @@ namespace ParquetSharp
             return Apply(typeFactory, null, columnLogicalTypeOverride, useNesting, visitor);
         }
 
-        public TReturn Apply<TReturn>(LogicalTypeFactory typeFactory, Type? elementTypeOverride, Type? columnLogicalTypeOverride, bool useNesting, IColumnDescriptorVisitor<TReturn> visitor)
+        internal TReturn Apply<TReturn>(LogicalTypeFactory typeFactory, Type? elementTypeOverride, Type? columnLogicalTypeOverride, bool useNesting, IColumnDescriptorVisitor<TReturn> visitor)
         {
             var types = GetSystemTypes(typeFactory, columnLogicalTypeOverride, useNesting);
             var elementType = elementTypeOverride ?? types.elementType;

--- a/csharp/LogicalBatchWriter/LogicalBatchWriterFactory.cs
+++ b/csharp/LogicalBatchWriter/LogicalBatchWriterFactory.cs
@@ -53,7 +53,7 @@ namespace ParquetSharp.LogicalBatchWriter
             {
                 if (schemaNodes.Length != 1)
                 {
-                    throw new Exception("Expected only a single schema node for the leaf element writer");
+                    throw new Exception($"Expected a primitive schema node for element type {typeof(TElement)}. Got schema {schemaNodes[0]}.");
                 }
 
                 var optional = schemaNodes[0].Repetition == Repetition.Optional;
@@ -92,7 +92,8 @@ namespace ParquetSharp.LogicalBatchWriter
                 return MakeArrayWriter<TElement>(schemaNodes, definitionLevel, repetitionLevel, firstRepetitionLevel);
             }
 
-            throw new Exception($"Failed to create a batch writer for type {typeof(TElement)}");
+            throw new Exception(
+                $"Failed to create a batch writer for type {typeof(TElement)} from schema {schemaNodes[0]}");
         }
 
         /// <summary>

--- a/csharp/LogicalColumnReader.cs
+++ b/csharp/LogicalColumnReader.cs
@@ -27,6 +27,7 @@ namespace ParquetSharp
 
             return columnReader.ColumnDescriptor.Apply(
                 columnReader.LogicalTypeFactory,
+                elementTypeOverride,
                 columnLogicalTypeOverride,
                 useNesting,
                 new Creator(columnReader, bufferLength));

--- a/csharp/LogicalColumnWriter.cs
+++ b/csharp/LogicalColumnWriter.cs
@@ -28,6 +28,7 @@ namespace ParquetSharp
 
             return columnWriter.ColumnDescriptor.Apply(
                 columnWriter.LogicalTypeFactory,
+                elementTypeOverride,
                 columnLogicalTypeOverride,
                 useNesting,
                 new Creator(columnWriter, bufferLength));

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -84,6 +84,15 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// Returns whether the specified type can represent null values.
+        /// If this returns false, then optional values are wrapped in the `System.Nullable`
+        /// type so that nulls can be represented.
+        /// </summary>
+        public virtual bool IsNullable(Type type)
+        {
+            return !type.IsValueType || TypeUtils.IsNullable(type, out _);
+        }
 
         /// <summary>
         /// Get the mapping from a column descriptor to the actual C# physical and logical element types.

--- a/csharp/LogicalTypeFactory.cs
+++ b/csharp/LogicalTypeFactory.cs
@@ -84,15 +84,6 @@ namespace ParquetSharp
             }
         }
 
-        /// <summary>
-        /// Returns whether the specified type can represent null values.
-        /// If this returns false, then optional values are wrapped in the `System.Nullable`
-        /// type so that nulls can be represented.
-        /// </summary>
-        public virtual bool IsNullable(Type type)
-        {
-            return !type.IsValueType || TypeUtils.IsNullable(type, out _);
-        }
 
         /// <summary>
         /// Get the mapping from a column descriptor to the actual C# physical and logical element types.

--- a/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual ParquetSharp.LogicalTypeFactory.IsNullable(System.Type! type) -> bool

--- a/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-virtual ParquetSharp.LogicalTypeFactory.IsNullable(System.Type! type) -> bool
+ParquetSharp.ColumnDescriptor.Apply<TReturn>(ParquetSharp.LogicalTypeFactory! typeFactory, System.Type? elementTypeOverride, System.Type? columnLogicalTypeOverride, bool useNesting, ParquetSharp.IColumnDescriptorVisitor<TReturn>! visitor) -> TReturn

--- a/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-ParquetSharp.ColumnDescriptor.Apply<TReturn>(ParquetSharp.LogicalTypeFactory! typeFactory, System.Type? elementTypeOverride, System.Type? columnLogicalTypeOverride, bool useNesting, ParquetSharp.IColumnDescriptorVisitor<TReturn>! visitor) -> TReturn

--- a/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+override ParquetSharp.Schema.GroupNode.ToString() -> string!
+override ParquetSharp.Schema.PrimitiveNode.ToString() -> string!

--- a/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual ParquetSharp.LogicalTypeFactory.IsNullable(System.Type! type) -> bool

--- a/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-virtual ParquetSharp.LogicalTypeFactory.IsNullable(System.Type! type) -> bool
+ParquetSharp.ColumnDescriptor.Apply<TReturn>(ParquetSharp.LogicalTypeFactory! typeFactory, System.Type? elementTypeOverride, System.Type? columnLogicalTypeOverride, bool useNesting, ParquetSharp.IColumnDescriptorVisitor<TReturn>! visitor) -> TReturn

--- a/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-ParquetSharp.ColumnDescriptor.Apply<TReturn>(ParquetSharp.LogicalTypeFactory! typeFactory, System.Type? elementTypeOverride, System.Type? columnLogicalTypeOverride, bool useNesting, ParquetSharp.IColumnDescriptorVisitor<TReturn>! visitor) -> TReturn

--- a/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/net6/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+override ParquetSharp.Schema.GroupNode.ToString() -> string!
+override ParquetSharp.Schema.PrimitiveNode.ToString() -> string!

--- a/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual ParquetSharp.LogicalTypeFactory.IsNullable(System.Type! type) -> bool

--- a/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-virtual ParquetSharp.LogicalTypeFactory.IsNullable(System.Type! type) -> bool
+ParquetSharp.ColumnDescriptor.Apply<TReturn>(ParquetSharp.LogicalTypeFactory! typeFactory, System.Type? elementTypeOverride, System.Type? columnLogicalTypeOverride, bool useNesting, ParquetSharp.IColumnDescriptorVisitor<TReturn>! visitor) -> TReturn

--- a/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-ParquetSharp.ColumnDescriptor.Apply<TReturn>(ParquetSharp.LogicalTypeFactory! typeFactory, System.Type? elementTypeOverride, System.Type? columnLogicalTypeOverride, bool useNesting, ParquetSharp.IColumnDescriptorVisitor<TReturn>! visitor) -> TReturn

--- a/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+override ParquetSharp.Schema.GroupNode.ToString() -> string!
+override ParquetSharp.Schema.PrimitiveNode.ToString() -> string!

--- a/csharp/Schema/GroupNode.cs
+++ b/csharp/Schema/GroupNode.cs
@@ -63,6 +63,14 @@ namespace ParquetSharp.Schema
             }
         }
 
+        public override string ToString()
+        {
+            using var path = Path;
+            using var logicalType = LogicalType;
+            var fields = string.Join(", ", Fields.Select(f => f.ToString()));
+            return $"GroupNode {{Path=\"{path.ToDotString()}\", Repetition={Repetition}, LogicalType={logicalType.Type}, Fields=[{fields}]}}";
+        }
+
         private static unsafe IntPtr Make(string name, Repetition repetition, IReadOnlyList<Node> fields, LogicalType? logicalType, int fieldId)
         {
             var handles = fields.Select(f => f.Handle.IntPtr).ToArray();

--- a/csharp/Schema/PrimitiveNode.cs
+++ b/csharp/Schema/PrimitiveNode.cs
@@ -52,6 +52,13 @@ namespace ParquetSharp.Schema
                 FieldId);
         }
 
+        public override string ToString()
+        {
+            using var path = Path;
+            using var logicalType = LogicalType;
+            return $"PrimitiveNode {{Path=\"{path.ToDotString()}\", PhysicalType={PhysicalType}, Repetition={Repetition}, LogicalType={logicalType.Type}}}";
+        }
+
         private static IntPtr Make(
             string name,
             Repetition repetition,


### PR DESCRIPTION
Fixes #525

I'm not 100% sure about this approach and whether we want to catch any discrepancies between the element type returned by `GetSystemTypes` and what the user has provided as an override. Eg. what should happen if the schema represents a list but the element type override doesn't use an array?

I also tried an alternative approach in 46eddf24ee34261b2c993c39a1fbea3645525565 that would require the user to specify whether a type can represent nulls in the `LogicalTypeFactory`.