### PR TITLE
Hide docs for protected static extern members

### DIFF
--- a/csharp/ColumnReader.cs
+++ b/csharp/ColumnReader.cs
@@ -121,66 +121,82 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnReader_Type(IntPtr columnReader, out PhysicalType type);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_Bool(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, bool* values,
             out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_Int32(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, int* values,
             out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_Int64(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, long* values,
             out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_Int96(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, Int96* values,
             out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_Float(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, float* values,
             out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_Double(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, double* values,
             out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_ByteArray(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, ByteArray* values,
             out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnReader_ReadBatch_FixedLenByteArray(
             IntPtr columnReader, long batchSize, short* defLevels, short* repLevels, FixedLenByteArray* values, out long valuesRead, out long levelsRead);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_Bool(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_Int32(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_Int64(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_Int96(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_Float(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_Double(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_ByteArray(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedColumnReader_Skip_FixedLenByteArray(IntPtr columnReader, long numRowsToSkip, out long levelsSkipped);
 

--- a/csharp/ColumnWriter.cs
+++ b/csharp/ColumnWriter.cs
@@ -143,66 +143,82 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ColumnWriter_Type(IntPtr columnWriter, out PhysicalType type);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_Bool(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, bool* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_Int32(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, int* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_Int64(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, long* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_Int96(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, Int96* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_Float(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, float* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_Double(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, double* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_ByteArray(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, ByteArray* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatch_FixedLenByteArray(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, FixedLenByteArray* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_Bool(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, bool* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_Int32(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, int* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_Int64(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, long* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_Int96(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, Int96* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_Float(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, float* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_Double(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, double* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_ByteArray(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, ByteArray* values);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern unsafe IntPtr TypedColumnWriter_WriteBatchSpaced_FixedLenByteArray(
             IntPtr columnWriter, long numValues, short* defLevels, short* repLevels, byte* validBits, long validBitsOffset, FixedLenByteArray* values);

--- a/csharp/Statistics.cs
+++ b/csharp/Statistics.cs
@@ -76,51 +76,67 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr Statistics_Physical_Type(IntPtr statistics, out PhysicalType physicalType);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_Bool(IntPtr statistics, [MarshalAs(UnmanagedType.I1)] out bool min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_Int32(IntPtr statistics, out int min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_Int64(IntPtr statistics, out long min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_Int96(IntPtr statistics, out Int96 min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_Float(IntPtr statistics, out float min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_Double(IntPtr statistics, out double min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_ByteArray(IntPtr statistics, out ByteArray min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Min_FLBA(IntPtr statistics, out FixedLenByteArray min);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_Bool(IntPtr statistics, [MarshalAs(UnmanagedType.I1)] out bool max);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_Int32(IntPtr statistics, out int max);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_Int64(IntPtr statistics, out long max);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_Int96(IntPtr statistics, out Int96 max);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_Float(IntPtr statistics, out float max);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_Double(IntPtr statistics, out double max);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_ByteArray(IntPtr statistics, out ByteArray max);
 
+        /// <exclude />
         [DllImport(ParquetDll.Name)]
         protected static extern IntPtr TypedStatistics_Max_FLBA(IntPtr statistics, out FixedLenByteArray max);
 


### PR DESCRIPTION
These aren't intended to be used by users and shouldn't be possible to call directly due to these classes having internal constructors and the derived classes are all sealed. 

Partly addresses #513