### PR TITLE
Bump versions of .NET used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install bison
 
-    # .NET Core Setup (and also MSBuild for Windows).
+    # .NET Setup (and also MSBuild for Windows).
     - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4
       with:
@@ -232,15 +232,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-13, macos-14, windows-2022]
-        dotnet: [netcoreapp3.1, net6.0, net7.0, net8.0]
+        dotnet: [net6.0, net8.0, net9.0]
         include:
         - os: windows-2022
           dotnet: net472
-        exclude:
-        - os: ubuntu-22.04-arm64
-          dotnet: netcoreapp3.1
-        - os: macos-14
-          dotnet: netcoreapp3.1
       fail-fast: false
     name: Test NuGet package (${{ matrix.dotnet }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -253,25 +248,20 @@ jobs:
       with:
         name: nuget-package
         path: nuget
-    - name: Setup .NET Core SDK v3.1.x
-      if: matrix.dotnet == 'netcoreapp3.1'
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 3.1.x
     - name: Setup .NET SDK v6.0.x
       if: matrix.dotnet == 'net6.0'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
-    - name: Setup .NET SDK v7.0.x
-      if: matrix.dotnet == 'net7.0'
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 7.0.x
     - name: Setup .NET SDK v8.0.x
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+    - name: Setup .NET SDK v9.0.x
+      if: matrix.dotnet == 'net9.0'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
     - name: Add local NuGet feed
       run: |
         dotnet new nugetconfig


### PR DESCRIPTION
Installing dotnet core 3.1 has started failing on MacOS 13 runners (image version 20250526.1184 worked but 20250602.1211 is now failing): https://github.com/G-Research/ParquetSharp/actions/runs/15455632889/job/43508150360

```
/Users/runner/work/_actions/actions/setup-dotnet/v4/externals/install-dotnet.sh: line 1440: link_types[$link_index]: unbound variable
```

Rather than try to figure out what's broken, I've updated the .NET versions used in CI as dotnet core 3.1 is out of support since December 2022. I've kept .NET 6 for now as this was an LTS version that only just went out of support in November 2024. I've also kept using 8.0 by default as this is an LTS release and 9.0 isn't, and 8.0 is what we specify in our global.json.