### PR TITLE
Build Arrow with support for mimalloc and jemalloc

### DIFF
--- a/csharp.test/TestMemoryPool.cs
+++ b/csharp.test/TestMemoryPool.cs
@@ -12,8 +12,7 @@ namespace ParquetSharp.Test
             var pool = MemoryPool.GetDefaultMemoryPool();
 
             Assert.AreEqual(0, pool.BytesAllocated);
-            Assert.Greater(pool.MaxMemory, 0);
-            Assert.AreEqual("system", pool.BackendName);
+            Assert.IsNotEmpty(pool.BackendName);
 
             using (var buffer = new ResizableBuffer())
             {

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -12,7 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <VersionPrefix>20.0.0-beta1</VersionPrefix>
+    <VersionPrefix>20.0.0-beta2</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,10 @@
     {
       "name": "arrow",
       "features": [
-        "mimalloc",
+        {
+          "name": "mimalloc",
+          "platform": "linux | !arm64"
+        },
         {
           "name": "jemalloc",
           "platform": "!windows&!arm64"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,13 @@
   "dependencies": [
     {
       "name": "arrow",
-      "features": ["jemalloc", "mimalloc"]
+      "features": [
+        "mimalloc",
+        {
+          "name": "jemalloc",
+          "platform": "!windows&!arm64"
+        }
+      ]
     }
   ],
   "overrides": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,14 +2,17 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "parquetsharp",
   "version-string": "undefined",
-  "builtin-baseline": "d9ccd77bb554e67137f3f754a2e2f11f4188c82c",
+  "builtin-baseline": "e08b7bd89ae162f8579df2f8d39a1ae94107c8fd",
   "dependencies": [
-    "arrow"
+    {
+      "name": "arrow",
+      "features": ["jemalloc", "mimalloc"]
+    }
   ],
   "overrides": [
     {
       "name": "arrow",
-      "version": "20.0.0"
+      "version": "20.0.0#1"
     }
   ]
 }


### PR DESCRIPTION
* Enables building Arrow with mimalloc on all x64 platforms and Linux arm64
* Enables building Arrow with jemalloc on Linux and x64 macOS

This means the default allocator will now be mimalloc, matching upstream Arrow on platforms where we enable it. Users can switch allocators with the `ARROW_DEFAULT_MEMORY_POOL` environment variable.

Mimalloc and jemalloc should work on arm64, but it appears that these don't build correctly when cross-compiling on an x64 host as part of the Arrow build. Arrow doesn't use mimalloc or jemalloc from vcpkg but always builds its own version, so this probably needs some fixes to the upstream Arrow build scripts.