### PR TITLE
Allow specifying the native allocator in code

### DIFF
--- a/cpp/BufferOutputStream.cpp
+++ b/cpp/BufferOutputStream.cpp
@@ -7,13 +7,16 @@
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* BufferOutputStream_Create(std::shared_ptr<arrow::io::BufferOutputStream>** output_stream)
+	PARQUETSHARP_EXPORT ExceptionInfo* BufferOutputStream_Create(::arrow::MemoryPool* pool, std::shared_ptr<arrow::io::BufferOutputStream>** output_stream)
 	{
 		TRYCATCH
 		(
+			if (pool == nullptr) {
+				pool = ::arrow::default_memory_pool();
+			}
 			PARQUET_ASSIGN_OR_THROW(
 				const std::shared_ptr<arrow::io::BufferOutputStream> output,
-				arrow::io::BufferOutputStream::Create(1024, arrow::default_memory_pool()));
+				arrow::io::BufferOutputStream::Create(1024, pool));
 
 			*output_stream = new std::shared_ptr<arrow::io::BufferOutputStream>(output);
 		)

--- a/cpp/MemoryPool.cpp
+++ b/cpp/MemoryPool.cpp
@@ -11,7 +11,28 @@ extern "C"
 	{
 		TRYCATCH(*memory_pool = arrow::default_memory_pool();)
 	}
-	
+
+	PARQUETSHARP_EXPORT ExceptionInfo* MemoryPool_System_Memory_Pool(const arrow::MemoryPool** memory_pool)
+	{
+		TRYCATCH(*memory_pool = arrow::system_memory_pool();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* MemoryPool_Jemalloc_Memory_Pool(arrow::MemoryPool** memory_pool)
+	{
+		TRYCATCH(
+			auto status = arrow::jemalloc_memory_pool(memory_pool);
+			PARQUET_THROW_NOT_OK(status);
+		)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* MemoryPool_Mimalloc_Memory_Pool(arrow::MemoryPool** memory_pool)
+	{
+		TRYCATCH(
+			auto status = arrow::mimalloc_memory_pool(memory_pool);
+			PARQUET_THROW_NOT_OK(status);
+		)
+	}
+
 	PARQUETSHARP_EXPORT ExceptionInfo* MemoryPool_Bytes_Allocated(const arrow::MemoryPool* memory_pool, int64_t* bytes_allocated)
 	{
 		TRYCATCH(*bytes_allocated = memory_pool->bytes_allocated();)

--- a/cpp/ReaderProperties.cpp
+++ b/cpp/ReaderProperties.cpp
@@ -13,6 +13,11 @@ extern "C"
 		TRYCATCH(*reader_properties = new ReaderProperties(default_reader_properties());)
 	}
 
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_With_Memory_Pool(::arrow::MemoryPool* memory_pool, ReaderProperties** reader_properties)
+	{
+		TRYCATCH(*reader_properties = new ReaderProperties(memory_pool);)
+	}
+
 	PARQUETSHARP_EXPORT void ReaderProperties_Free(ReaderProperties* reader_properties)
 	{
 		delete reader_properties;
@@ -70,5 +75,13 @@ extern "C"
 	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Disable_Page_Checksum_Verification(ReaderProperties* reader_properties)
 	{
 		TRYCATCH(reader_properties->set_page_checksum_verification(false);)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_Memory_Pool(const ReaderProperties* reader_properties, ::arrow::MemoryPool** memory_pool)
+	{
+		TRYCATCH
+		(
+			*memory_pool = reader_properties->memory_pool();
+		)
 	}
 }

--- a/cpp/ResizableBuffer.cpp
+++ b/cpp/ResizableBuffer.cpp
@@ -8,10 +8,10 @@
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* ResizableBuffer_Create(const int64_t initialSize, std::shared_ptr<arrow::ResizableBuffer>** buffer)
+	PARQUETSHARP_EXPORT ExceptionInfo* ResizableBuffer_Create(const int64_t initialSize, ::arrow::MemoryPool* memory_pool, std::shared_ptr<arrow::ResizableBuffer>** buffer)
 	{
 		TRYCATCH(
-			auto pBuffer = arrow::AllocateResizableBuffer(initialSize);
+			auto pBuffer = arrow::AllocateResizableBuffer(initialSize, memory_pool);
 			*buffer = new std::shared_ptr<arrow::ResizableBuffer>(pBuffer.ValueOrDie().release());
 		)
 	}

--- a/cpp/WriterProperties.cpp
+++ b/cpp/WriterProperties.cpp
@@ -157,4 +157,9 @@ extern "C"
 		delete[] descending;
 		delete[] nulls_first;
 	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterProperties_Memory_Pool(const std::shared_ptr<WriterProperties>* writer_properties, ::arrow::MemoryPool** memory_pool)
+	{
+		TRYCATCH(*memory_pool = (*writer_properties)->memory_pool();)
+	}
 }

--- a/cpp/WriterPropertiesBuilder.cpp
+++ b/cpp/WriterPropertiesBuilder.cpp
@@ -226,4 +226,9 @@ extern "C"
 		
 		TRYCATCH(builder->set_sorting_columns(sorting_columns);)
 	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo* WriterPropertiesBuilder_Memory_Pool(WriterProperties::Builder* builder, ::arrow::MemoryPool* pool)
+	{
+		TRYCATCH(builder->memory_pool(pool);)
+	}
 }

--- a/cpp/arrow/FileReader.cpp
+++ b/cpp/arrow/FileReader.cpp
@@ -21,7 +21,9 @@ extern "C"
   {
     TRYCATCH
     (
-      arrow::MemoryPool* pool = arrow::default_memory_pool();
+      arrow::MemoryPool* pool = reader_properties == nullptr
+          ? arrow::default_memory_pool()
+          : reader_properties->memory_pool();
       std::shared_ptr<arrow::io::ReadableFile> input_file;
       std::unique_ptr<FileReader> reader_ptr;
       PARQUET_ASSIGN_OR_THROW(input_file, arrow::io::ReadableFile::Open(path, pool));

--- a/cpp/arrow/FileReader.cpp
+++ b/cpp/arrow/FileReader.cpp
@@ -28,6 +28,7 @@ extern "C"
       std::unique_ptr<FileReader> reader_ptr;
       PARQUET_ASSIGN_OR_THROW(input_file, arrow::io::ReadableFile::Open(path, pool));
       FileReaderBuilder builder;
+      builder.memory_pool(pool);
       PARQUET_THROW_NOT_OK(builder.Open(input_file, *reader_properties));
       if (arrow_reader_properties != nullptr) {
         builder.properties(*arrow_reader_properties);
@@ -47,6 +48,10 @@ extern "C"
     (
       std::unique_ptr<FileReader> reader_ptr;
       FileReaderBuilder builder;
+      arrow::MemoryPool* pool = reader_properties == nullptr
+          ? arrow::default_memory_pool()
+          : reader_properties->memory_pool();
+      builder.memory_pool(pool);
       PARQUET_THROW_NOT_OK(builder.Open(*readable_file_interface, *reader_properties));
       if (arrow_reader_properties != nullptr) {
         builder.properties(*arrow_reader_properties);

--- a/cpp/arrow/FileWriter.cpp
+++ b/cpp/arrow/FileWriter.cpp
@@ -21,7 +21,9 @@ extern "C"
   {
     TRYCATCH
     (
-      arrow::MemoryPool* pool = arrow::default_memory_pool();
+      arrow::MemoryPool* pool = writer_properties == nullptr
+          ? arrow::default_memory_pool()
+          : (*writer_properties)->memory_pool();
 
       std::shared_ptr<::arrow::io::OutputStream> output_stream;
       PARQUET_ASSIGN_OR_THROW(output_stream, ::arrow::io::FileOutputStream::Open(path));
@@ -54,7 +56,9 @@ extern "C"
   {
     TRYCATCH
     (
-      arrow::MemoryPool* pool = arrow::default_memory_pool();
+      arrow::MemoryPool* pool = writer_properties == nullptr
+          ? arrow::default_memory_pool()
+          : (*writer_properties)->memory_pool();
 
       std::shared_ptr<parquet::WriterProperties> properties = writer_properties == nullptr
           ? parquet::default_writer_properties()

--- a/csharp.test/MemoryPools.cs
+++ b/csharp.test/MemoryPools.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ParquetSharp.Test
+{
+    public class MemoryPools
+    {
+        /// <summary>
+        /// Used as an Nunit TestCaseSource to test methods with different memory pools.
+        /// </summary>
+        /// <returns></returns>
+        public static TestCase[] TestCases()
+        {
+            var pools = new List<MemoryPool?>()
+            {
+                null,
+                MemoryPool.SystemMemoryPool(),
+            };
+
+            try
+            {
+                pools.Add(MemoryPool.MimallocMemoryPool());
+            }
+            catch (ParquetException)
+            {
+                // Mimalloc not available
+            }
+
+            try
+            {
+                pools.Add(MemoryPool.JemallocMemoryPool());
+            }
+            catch (ParquetException)
+            {
+                // Jemalloc not available
+            }
+
+            return pools.Select(p => new TestCase(p)).ToArray();
+        }
+
+        public class TestCase
+        {
+            public TestCase(MemoryPool? memoryPool)
+            {
+                Pool = memoryPool;
+            }
+
+            public MemoryPool? Pool { get; }
+
+            public override string ToString()
+            {
+                return Pool?.BackendName ?? "null";
+            }
+        }
+    }
+}

--- a/csharp.test/MemoryPools.cs
+++ b/csharp.test/MemoryPools.cs
@@ -8,7 +8,6 @@ namespace ParquetSharp.Test
         /// <summary>
         /// Used as an Nunit TestCaseSource to test methods with different memory pools.
         /// </summary>
-        /// <returns></returns>
         public static TestCase[] TestCases()
         {
             var pools = new List<MemoryPool?>()
@@ -36,6 +35,15 @@ namespace ParquetSharp.Test
             }
 
             return pools.Select(p => new TestCase(p)).ToArray();
+        }
+
+        /// <summary>
+        /// Used as an Nunit TestCaseSource to test methods with different memory pools.
+        /// Excludes the null pool.
+        /// </summary>
+        public static TestCase[] NonNullTestCases()
+        {
+            return TestCases().Where(t => t.Pool != null).ToArray();
         }
 
         public class TestCase

--- a/csharp.test/TestBuffer.cs
+++ b/csharp.test/TestBuffer.cs
@@ -58,11 +58,13 @@ namespace ParquetSharp.Test
             }
         }
 
-        [Test]
-        public static void TestBufferOutputStreamFinish()
+        [TestCaseSource(typeof(MemoryPools), nameof(MemoryPools.TestCases))]
+        public static void TestBufferOutputStreamFinish(MemoryPools.TestCase memoryPool)
         {
             var expected = Enumerable.Range(0, 100).ToArray();
-            using var outStream = new BufferOutputStream();
+            using var outStream = memoryPool.Pool == null
+                ? new BufferOutputStream()
+                : new BufferOutputStream(memoryPool.Pool);
 
             // Write out a single column
             using (var fileWriter = new ParquetFileWriter(outStream, new Column[] {new Column<int>("int_field")}))
@@ -86,10 +88,10 @@ namespace ParquetSharp.Test
             Assert.AreEqual(expected, allData);
         }
 
-        [Test]
-        public static void TestResizeBuffer()
+        [TestCaseSource(typeof(MemoryPools), nameof(MemoryPools.TestCases))]
+        public static void TestResizeBuffer(MemoryPools.TestCase memoryPool)
         {
-            using var buffer = new ResizableBuffer(initialSize: 128);
+            using var buffer = new ResizableBuffer(initialSize: 128, memoryPool: memoryPool.Pool);
             const int newLength = 256;
             buffer.Resize(newLength);
             var values = Enumerable.Range(0, newLength).Select(i => (byte) i).ToArray();

--- a/csharp.test/TestMemoryPool.cs
+++ b/csharp.test/TestMemoryPool.cs
@@ -90,7 +90,7 @@ namespace ParquetSharp.Test
         {
             Assert.AreEqual(0, pool.BytesAllocated);
 
-            using (var buffer = new ResizableBuffer())
+            using (var buffer = new ResizableBuffer(memoryPool: pool))
             {
                 using var stream = new BufferOutputStream(buffer);
                 using var writerPropertiesBuilder = new WriterPropertiesBuilder();

--- a/csharp.test/TestMemoryPool.cs
+++ b/csharp.test/TestMemoryPool.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
 using ParquetSharp.IO;
 
 namespace ParquetSharp.Test
@@ -10,9 +12,83 @@ namespace ParquetSharp.Test
         public static void TestDefaultMemoryPool()
         {
             var pool = MemoryPool.GetDefaultMemoryPool();
+            Assert.That(new[] {"system", "mimalloc", "jemalloc"}, Does.Contain(pool.BackendName));
+            TestMemoryPoolInstance(pool);
+        }
 
+        [Test]
+        public static void TestSystemMemoryPool()
+        {
+            var pool = MemoryPool.SystemMemoryPool();
+            Assert.That(pool.BackendName, Is.EqualTo("system"));
+            // TODO: TestMemoryPoolInstance(pool);
+        }
+
+        [Test]
+        public static void TestJemallocMemoryPool()
+        {
+            var expectJemalloc = IsRunningInCi() &&
+                                 (
+                                     !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                                     RuntimeInformation.ProcessArchitecture != Architecture.Arm64);
+            MemoryPool pool;
+            try
+            {
+                pool = MemoryPool.JemallocMemoryPool();
+            }
+            catch (ParquetException)
+            {
+                if (expectJemalloc)
+                {
+                    throw;
+                }
+                Assert.Ignore("jemalloc not available");
+                return;
+            }
+
+            if (!expectJemalloc && IsRunningInCi())
+            {
+                throw new Exception("Expected jemalloc to be unavailable, but it was available.");
+            }
+
+            Assert.That(pool.BackendName, Is.EqualTo("jemalloc"));
+            // TODO: TestMemoryPoolInstance(pool);
+        }
+
+        [Test]
+        public static void TestMimallocMemoryPool()
+        {
+            var expectMimalloc = IsRunningInCi() &&
+                                 (
+                                     RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                                     (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture != Architecture.Arm64));
+            MemoryPool pool;
+            try
+            {
+                pool = MemoryPool.MimallocMemoryPool();
+            }
+            catch (ParquetException)
+            {
+                if (expectMimalloc)
+                {
+                    throw;
+                }
+                Assert.Ignore("Mimalloc not available");
+                return;
+            }
+
+            if (!expectMimalloc && IsRunningInCi())
+            {
+                throw new Exception("Expected Mimalloc to be unavailable, but it was available.");
+            }
+
+            Assert.That(pool.BackendName, Is.EqualTo("mimalloc"));
+            // TODO: TestMemoryPoolInstance(pool);
+        }
+
+        private static void TestMemoryPoolInstance(MemoryPool pool)
+        {
             Assert.AreEqual(0, pool.BytesAllocated);
-            Assert.IsNotEmpty(pool.BackendName);
 
             using (var buffer = new ResizableBuffer())
             {
@@ -25,6 +101,11 @@ namespace ParquetSharp.Test
 
             Assert.AreEqual(0, pool.BytesAllocated);
             Assert.Greater(pool.MaxMemory, 0);
+        }
+
+        private static bool IsRunningInCi()
+        {
+            return Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
         }
     }
 }

--- a/csharp.test/TestMemoryPool.cs
+++ b/csharp.test/TestMemoryPool.cs
@@ -21,7 +21,7 @@ namespace ParquetSharp.Test
         {
             var pool = MemoryPool.SystemMemoryPool();
             Assert.That(pool.BackendName, Is.EqualTo("system"));
-            // TODO: TestMemoryPoolInstance(pool);
+            TestMemoryPoolInstance(pool);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace ParquetSharp.Test
             }
 
             Assert.That(pool.BackendName, Is.EqualTo("jemalloc"));
-            // TODO: TestMemoryPoolInstance(pool);
+            TestMemoryPoolInstance(pool);
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace ParquetSharp.Test
             }
 
             Assert.That(pool.BackendName, Is.EqualTo("mimalloc"));
-            // TODO: TestMemoryPoolInstance(pool);
+            TestMemoryPoolInstance(pool);
         }
 
         private static void TestMemoryPoolInstance(MemoryPool pool)
@@ -93,10 +93,15 @@ namespace ParquetSharp.Test
             using (var buffer = new ResizableBuffer())
             {
                 using var stream = new BufferOutputStream(buffer);
-                using var fileWriter = new ParquetFileWriter(stream, new Column[] {new Column<int>("Index")});
+                using var writerPropertiesBuilder = new WriterPropertiesBuilder();
+                writerPropertiesBuilder.MemoryPool(pool);
+                using var writerProperties = writerPropertiesBuilder.Build();
+                using var fileWriter = new ParquetFileWriter(stream, new Column[] {new Column<int>("Index")}, writerProperties);
 
                 Assert.Greater(pool.BytesAllocated, 0);
                 Assert.Greater(pool.MaxMemory, 0);
+
+                fileWriter.Close();
             }
 
             Assert.AreEqual(0, pool.BytesAllocated);

--- a/csharp.test/TestReaderProperties.cs
+++ b/csharp.test/TestReaderProperties.cs
@@ -1,14 +1,10 @@
-﻿using System.Linq;
-using NUnit.Framework;
-using ParquetSharp.IO;
-using ParquetSharp.Schema;
+﻿using NUnit.Framework;
 
 namespace ParquetSharp.Test
 {
     [TestFixture]
     internal static class TestReaderProperties
     {
-
         [Test]
         public static void TestDefaultProperties()
         {
@@ -17,6 +13,9 @@ namespace ParquetSharp.Test
             Assert.That(p.BufferSize, Is.EqualTo(1 << 14));
             Assert.That(p.IsBufferedStreamEnabled, Is.False);
             Assert.That(p.PageChecksumVerification, Is.False);
+
+            var memoryPool = p.MemoryPool;
+            Assert.That(memoryPool.BackendName, Is.Not.Empty);
         }
 
         [Test]
@@ -36,6 +35,13 @@ namespace ParquetSharp.Test
             Assert.That(p.IsBufferedStreamEnabled, Is.True);
             p.DisableBufferedStream();
             Assert.That(p.IsBufferedStreamEnabled, Is.False);
+        }
+
+        [TestCaseSource(typeof(MemoryPools), nameof(MemoryPools.NonNullTestCases))]
+        public static void TestSetMemoryPool(MemoryPools.TestCase pool)
+        {
+            using var p = ReaderProperties.WithMemoryPool(pool.Pool!);
+            Assert.That(p.MemoryPool.BackendName, Is.EqualTo(pool.ToString()));
         }
     }
 }

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -26,6 +26,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(1024, p.WriteBatchSize);
             Assert.True(p.WritePageIndex);
             Assert.False(p.PageChecksumEnabled);
+            Assert.That(p.MemoryPool.BackendName, Is.Not.Empty);
         }
 
         [Test]
@@ -44,6 +45,7 @@ namespace ParquetSharp.Test
                 .EnableWritePageIndex()
                 .DisableWritePageIndex()
                 .EnablePageChecksum()
+                .MemoryPool(MemoryPool.SystemMemoryPool())
                 .Build();
 
             Assert.AreEqual("Meeeee!!!", p.CreatedBy);
@@ -58,6 +60,7 @@ namespace ParquetSharp.Test
             Assert.AreEqual(666, p.WriteBatchSize);
             Assert.False(p.WritePageIndex);
             Assert.True(p.PageChecksumEnabled);
+            Assert.AreEqual("system", p.MemoryPool.BackendName);
         }
 
         [Test]

--- a/csharp/IO/BufferOutputStream.cs
+++ b/csharp/IO/BufferOutputStream.cs
@@ -12,7 +12,15 @@ namespace ParquetSharp.IO
         /// Create a new buffer output stream.
         /// </summary>
         public BufferOutputStream()
-            : base(ExceptionInfo.Return<IntPtr>(BufferOutputStream_Create))
+            : base(ExceptionInfo.Return<IntPtr, IntPtr>(IntPtr.Zero, BufferOutputStream_Create))
+        {
+        }
+
+        /// <summary>
+        /// Create a new buffer output stream using the specified memory pool.
+        /// </summary>
+        public BufferOutputStream(MemoryPool memoryPool)
+            : base(ExceptionInfo.Return<IntPtr, IntPtr>(memoryPool.Handle, BufferOutputStream_Create))
         {
         }
 
@@ -35,7 +43,7 @@ namespace ParquetSharp.IO
         }
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr BufferOutputStream_Create(out IntPtr outputStream);
+        private static extern IntPtr BufferOutputStream_Create(IntPtr memoryPool, out IntPtr outputStream);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr BufferOutputStream_Create_From_ResizableBuffer(IntPtr resizableBuffer, out IntPtr outputStream);

--- a/csharp/IO/ResizableBuffer.cs
+++ b/csharp/IO/ResizableBuffer.cs
@@ -12,8 +12,16 @@ namespace ParquetSharp.IO
         /// Create a new resizable buffer with the given initial size.
         /// </summary>
         /// <param name="initialSize">The initial size of the buffer in bytes.</param>
-        public ResizableBuffer(long initialSize = 128L)
-            : base(ExceptionInfo.Return<long, IntPtr>(initialSize, ResizableBuffer_Create))
+        /// <param name="memoryPool">The memory pool to use to allocate the buffer.</param>
+        public ResizableBuffer(long initialSize = 128L, MemoryPool? memoryPool = null)
+            : base(ExceptionInfo.Return<long, IntPtr, IntPtr>(initialSize, memoryPool?.Handle ?? IntPtr.Zero, ResizableBuffer_Create))
+        {
+        }
+
+        // Backward compatibility overload
+        /// <exclude />
+        public ResizableBuffer(long initialSize)
+            : this(initialSize, null)
         {
         }
 
@@ -40,7 +48,7 @@ namespace ParquetSharp.IO
         }
 
         [DllImport(ParquetDll.Name)]
-        private static extern IntPtr ResizableBuffer_Create(long initialSize, out IntPtr resizableBuffer);
+        private static extern IntPtr ResizableBuffer_Create(long initialSize, IntPtr memoryPool, out IntPtr resizableBuffer);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ResizableBuffer_Resize(IntPtr resizableBuffer, long newSize);

--- a/csharp/MemoryPool.cs
+++ b/csharp/MemoryPool.cs
@@ -8,13 +8,59 @@ namespace ParquetSharp
     /// </summary>
     public sealed class MemoryPool
     {
+        /// <summary>
+        /// Get the default memory pool for native allocations.
+        /// This can be configured by setting the "ARROW_DEFAULT_MEMORY_POOL" environment variable.
+        /// Possible values are "system", "jemalloc", "mimalloc".
+        /// </summary>
+        /// <returns>The default memory pool instance</returns>
         public static MemoryPool GetDefaultMemoryPool()
         {
             return new MemoryPool(ExceptionInfo.Return<IntPtr>(MemoryPool_Default_Memory_Pool));
         }
 
+        /// <summary>
+        /// Get a memory pool that uses the system allocator.
+        /// </summary>
+        /// <returns>The system memory pool</returns>
+        public static MemoryPool SystemMemoryPool()
+        {
+            return new MemoryPool(ExceptionInfo.Return<IntPtr>(MemoryPool_System_Memory_Pool));
+        }
+
+        /// <summary>
+        /// Get a memory pool that uses the jemalloc allocator.
+        /// </summary>
+        /// <returns>A jemalloc memory pool</returns>
+        /// <exception cref="ParquetException">Thrown if ParquetSharp was not built with Jemalloc enabled.</exception>
+        public static MemoryPool JemallocMemoryPool()
+        {
+            return new MemoryPool(ExceptionInfo.Return<IntPtr>(MemoryPool_Jemalloc_Memory_Pool));
+        }
+
+        /// <summary>
+        /// Get a memory pool that uses the mimalloc allocator.
+        /// </summary>
+        /// <returns>A mimalloc memory pool</returns>
+        /// <exception cref="ParquetException">Thrown if ParquetSharp was not built with Mimalloc enabled.</exception>
+        public static MemoryPool MimallocMemoryPool()
+        {
+            return new MemoryPool(ExceptionInfo.Return<IntPtr>(MemoryPool_Mimalloc_Memory_Pool));
+        }
+
+        /// <summary>
+        /// The number of bytes currently allocated by this memory pool and not yet freed.
+        /// </summary>
         public long BytesAllocated => ExceptionInfo.Return<long>(_handle, MemoryPool_Bytes_Allocated);
+
+        /// <summary>
+        /// The peak number of bytes allocated by this memory pool.
+        /// </summary>
         public long MaxMemory => ExceptionInfo.Return<long>(_handle, MemoryPool_Max_Memory);
+
+        /// <summary>
+        /// The name of the backend used by this memory pool.
+        /// </summary>
         public string BackendName => ExceptionInfo.ReturnString(_handle, MemoryPool_Backend_Name, MemoryPool_Backend_Name_Free);
 
         private MemoryPool(IntPtr handle)
@@ -24,6 +70,15 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr MemoryPool_Default_Memory_Pool(out IntPtr memoryPool);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr MemoryPool_System_Memory_Pool(out IntPtr memoryPool);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr MemoryPool_Jemalloc_Memory_Pool(out IntPtr memoryPool);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr MemoryPool_Mimalloc_Memory_Pool(out IntPtr memoryPool);
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr MemoryPool_Bytes_Allocated(IntPtr memoryPool, out long bytesAllocated);

--- a/csharp/MemoryPool.cs
+++ b/csharp/MemoryPool.cs
@@ -63,7 +63,7 @@ namespace ParquetSharp
         /// </summary>
         public string BackendName => ExceptionInfo.ReturnString(Handle, MemoryPool_Backend_Name, MemoryPool_Backend_Name_Free);
 
-        private MemoryPool(IntPtr handle)
+        internal MemoryPool(IntPtr handle)
         {
             Handle = handle;
         }

--- a/csharp/MemoryPool.cs
+++ b/csharp/MemoryPool.cs
@@ -51,21 +51,21 @@ namespace ParquetSharp
         /// <summary>
         /// The number of bytes currently allocated by this memory pool and not yet freed.
         /// </summary>
-        public long BytesAllocated => ExceptionInfo.Return<long>(_handle, MemoryPool_Bytes_Allocated);
+        public long BytesAllocated => ExceptionInfo.Return<long>(Handle, MemoryPool_Bytes_Allocated);
 
         /// <summary>
         /// The peak number of bytes allocated by this memory pool.
         /// </summary>
-        public long MaxMemory => ExceptionInfo.Return<long>(_handle, MemoryPool_Max_Memory);
+        public long MaxMemory => ExceptionInfo.Return<long>(Handle, MemoryPool_Max_Memory);
 
         /// <summary>
         /// The name of the backend used by this memory pool.
         /// </summary>
-        public string BackendName => ExceptionInfo.ReturnString(_handle, MemoryPool_Backend_Name, MemoryPool_Backend_Name_Free);
+        public string BackendName => ExceptionInfo.ReturnString(Handle, MemoryPool_Backend_Name, MemoryPool_Backend_Name_Free);
 
         private MemoryPool(IntPtr handle)
         {
-            _handle = handle;
+            Handle = handle;
         }
 
         [DllImport(ParquetDll.Name)]
@@ -92,6 +92,6 @@ namespace ParquetSharp
         [DllImport(ParquetDll.Name)]
         private static extern void MemoryPool_Backend_Name_Free(IntPtr backendName);
 
-        private readonly IntPtr _handle;
+        internal readonly IntPtr Handle;
     }
 }

--- a/csharp/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI.Unshipped.txt
@@ -19,3 +19,4 @@ ParquetSharp.LogicalTypeEnum.Variant = 19 -> ParquetSharp.LogicalTypeEnum
 static ParquetSharp.MemoryPool.JemallocMemoryPool() -> ParquetSharp.MemoryPool!
 static ParquetSharp.MemoryPool.MimallocMemoryPool() -> ParquetSharp.MemoryPool!
 static ParquetSharp.MemoryPool.SystemMemoryPool() -> ParquetSharp.MemoryPool!
+ParquetSharp.WriterPropertiesBuilder.MemoryPool(ParquetSharp.MemoryPool! memoryPool) -> ParquetSharp.WriterPropertiesBuilder!

--- a/csharp/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI.Unshipped.txt
@@ -20,3 +20,7 @@ static ParquetSharp.MemoryPool.JemallocMemoryPool() -> ParquetSharp.MemoryPool!
 static ParquetSharp.MemoryPool.MimallocMemoryPool() -> ParquetSharp.MemoryPool!
 static ParquetSharp.MemoryPool.SystemMemoryPool() -> ParquetSharp.MemoryPool!
 ParquetSharp.WriterPropertiesBuilder.MemoryPool(ParquetSharp.MemoryPool! memoryPool) -> ParquetSharp.WriterPropertiesBuilder!
+ParquetSharp.IO.BufferOutputStream.BufferOutputStream(ParquetSharp.MemoryPool! memoryPool) -> void
+ParquetSharp.IO.ResizableBuffer.ResizableBuffer(long initialSize = 128, ParquetSharp.MemoryPool? memoryPool = null) -> void
+ParquetSharp.IO.ResizableBuffer.ResizableBuffer(long initialSize) -> void
+*REMOVED*ParquetSharp.IO.ResizableBuffer.ResizableBuffer(long initialSize = 128) -> void

--- a/csharp/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI.Unshipped.txt
@@ -16,3 +16,6 @@ ParquetSharp.RowGroupMetaData.SortingColumns() -> ParquetSharp.WriterProperties.
 ParquetSharp.LogicalTypeEnum.Geography = 18 -> ParquetSharp.LogicalTypeEnum
 ParquetSharp.LogicalTypeEnum.Geometry = 17 -> ParquetSharp.LogicalTypeEnum
 ParquetSharp.LogicalTypeEnum.Variant = 19 -> ParquetSharp.LogicalTypeEnum
+static ParquetSharp.MemoryPool.JemallocMemoryPool() -> ParquetSharp.MemoryPool!
+static ParquetSharp.MemoryPool.MimallocMemoryPool() -> ParquetSharp.MemoryPool!
+static ParquetSharp.MemoryPool.SystemMemoryPool() -> ParquetSharp.MemoryPool!

--- a/csharp/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI.Unshipped.txt
@@ -19,6 +19,7 @@ ParquetSharp.LogicalTypeEnum.Variant = 19 -> ParquetSharp.LogicalTypeEnum
 static ParquetSharp.MemoryPool.JemallocMemoryPool() -> ParquetSharp.MemoryPool!
 static ParquetSharp.MemoryPool.MimallocMemoryPool() -> ParquetSharp.MemoryPool!
 static ParquetSharp.MemoryPool.SystemMemoryPool() -> ParquetSharp.MemoryPool!
+ParquetSharp.WriterProperties.MemoryPool.get -> ParquetSharp.MemoryPool!
 ParquetSharp.WriterPropertiesBuilder.MemoryPool(ParquetSharp.MemoryPool! memoryPool) -> ParquetSharp.WriterPropertiesBuilder!
 ParquetSharp.IO.BufferOutputStream.BufferOutputStream(ParquetSharp.MemoryPool! memoryPool) -> void
 ParquetSharp.IO.ResizableBuffer.ResizableBuffer(long initialSize = 128, ParquetSharp.MemoryPool? memoryPool = null) -> void

--- a/csharp/PublicAPI.Unshipped.txt
+++ b/csharp/PublicAPI.Unshipped.txt
@@ -24,3 +24,5 @@ ParquetSharp.IO.BufferOutputStream.BufferOutputStream(ParquetSharp.MemoryPool! m
 ParquetSharp.IO.ResizableBuffer.ResizableBuffer(long initialSize = 128, ParquetSharp.MemoryPool? memoryPool = null) -> void
 ParquetSharp.IO.ResizableBuffer.ResizableBuffer(long initialSize) -> void
 *REMOVED*ParquetSharp.IO.ResizableBuffer.ResizableBuffer(long initialSize = 128) -> void
+static ParquetSharp.ReaderProperties.WithMemoryPool(ParquetSharp.MemoryPool! memoryPool) -> ParquetSharp.ReaderProperties!
+ParquetSharp.ReaderProperties.MemoryPool.get -> ParquetSharp.MemoryPool!

--- a/csharp/ReaderProperties.cs
+++ b/csharp/ReaderProperties.cs
@@ -17,6 +17,15 @@ namespace ParquetSharp
             return new ReaderProperties(ExceptionInfo.Return<IntPtr>(ReaderProperties_Get_Default_Reader_Properties));
         }
 
+        /// <summary>
+        /// Create a new <see cref="ReaderProperties"/> that uses the specified memory pool for allocations in the reader.
+        /// </summary>
+        /// <returns>A new <see cref="ReaderProperties"/> object.</returns>
+        public static ReaderProperties WithMemoryPool(MemoryPool memoryPool)
+        {
+            return new ReaderProperties(ExceptionInfo.Return<IntPtr, IntPtr>(memoryPool.Handle, ReaderProperties_With_Memory_Pool));
+        }
+
         internal ReaderProperties(IntPtr handle)
         {
             Handle = new ParquetHandle(handle, ReaderProperties_Free);
@@ -114,8 +123,25 @@ namespace ParquetSharp
             GC.KeepAlive(Handle);
         }
 
+        /// <summary>
+        /// Get the memory pool that will be used for allocations in the reader.
+        ///
+        /// This can be set when creating the reader properties with <see cref="WithMemoryPool" />.
+        /// </summary>
+        public MemoryPool MemoryPool
+        {
+            get
+            {
+                var poolPtr = ExceptionInfo.Return<IntPtr>(Handle, ReaderProperties_Get_Memory_Pool);
+                return new MemoryPool(poolPtr);
+            }
+        }
+
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ReaderProperties_Get_Default_Reader_Properties(out IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_With_Memory_Pool(IntPtr memoryPool, out IntPtr readerProperties);
 
         [DllImport(ParquetDll.Name)]
         private static extern void ReaderProperties_Free(IntPtr readerProperties);
@@ -149,6 +175,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ReaderProperties_Disable_Page_Checksum_Verification(IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Get_Memory_Pool(IntPtr readerProperties, out IntPtr memoryPool);
 
         internal readonly ParquetHandle Handle;
     }

--- a/csharp/WriterProperties.cs
+++ b/csharp/WriterProperties.cs
@@ -259,6 +259,11 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// The memory pool that will be used by allocations in the writer.
+        /// </summary>
+        public MemoryPool MemoryPool => new MemoryPool(ExceptionInfo.Return<IntPtr>(Handle, WriterProperties_Memory_Pool));
+
         internal readonly ParquetHandle Handle;
 
         [DllImport(ParquetDll.Name)]
@@ -332,5 +337,8 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern void WriterProperties_Sorting_Columns_Free(IntPtr columnIndices, IntPtr descending, IntPtr nullsFirst);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterProperties_Memory_Pool(IntPtr writerProperties, out IntPtr memoryPool);
     }
 }

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -543,7 +543,7 @@ namespace ParquetSharp
         /// <returns>This builder instance.</returns>
         public WriterPropertiesBuilder MemoryPool(MemoryPool memoryPool)
         {
-            WriterPropertiesBuilder_Memory_Pool(_handle.IntPtr, memoryPool.Handle);
+            ExceptionInfo.Check(WriterPropertiesBuilder_Memory_Pool(_handle.IntPtr, memoryPool.Handle));
 
             GC.KeepAlive(_handle);
             return this;

--- a/csharp/WriterPropertiesBuilder.cs
+++ b/csharp/WriterPropertiesBuilder.cs
@@ -536,6 +536,19 @@ namespace ParquetSharp
             return this;
         }
 
+        /// <summary>
+        /// Specify the native memory pool to use for allocations in the writer.
+        /// </summary>
+        /// <param name="memoryPool">The memory pool to use</param>
+        /// <returns>This builder instance.</returns>
+        public WriterPropertiesBuilder MemoryPool(MemoryPool memoryPool)
+        {
+            WriterPropertiesBuilder_Memory_Pool(_handle.IntPtr, memoryPool.Handle);
+
+            GC.KeepAlive(_handle);
+            return this;
+        }
+
         private void ApplyDefaults()
         {
             OnDefaultProperty(DefaultWriterProperties.EnableDictionary, enabled =>
@@ -749,6 +762,9 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr WriterPropertiesBuilder_Sorting_Columns(IntPtr builder, IntPtr columnIndices, IntPtr isDescending, IntPtr nullsFirst, int numColumns);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr WriterPropertiesBuilder_Memory_Pool(IntPtr builder, IntPtr memoryPool);
 
         private readonly ParquetHandle _handle;
     }


### PR DESCRIPTION
Fixes #545

Adds new `MemoryPool` methods to get the system, Jemalloc and Mimalloc memory pools.

Allows specifying the native MemoryPool / Allocator for:
* `ResizableBuffer`
* `BufferOutputStream`
* `WriterProperties`
* `ReaderProperties`