### PR TITLE
Read dense for nullable (ReaderProperties)

### DIFF
--- a/cpp/ReaderProperties.cpp
+++ b/cpp/ReaderProperties.cpp
@@ -8,80 +8,91 @@ using namespace parquet;
 
 extern "C"
 {
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_Default_Reader_Properties(ReaderProperties** reader_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Get_Default_Reader_Properties(ReaderProperties **reader_properties)
 	{
 		TRYCATCH(*reader_properties = new ReaderProperties(default_reader_properties());)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_With_Memory_Pool(::arrow::MemoryPool* memory_pool, ReaderProperties** reader_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_With_Memory_Pool(::arrow::MemoryPool *memory_pool, ReaderProperties **reader_properties)
 	{
 		TRYCATCH(*reader_properties = new ReaderProperties(memory_pool);)
 	}
 
-	PARQUETSHARP_EXPORT void ReaderProperties_Free(ReaderProperties* reader_properties)
+	PARQUETSHARP_EXPORT void ReaderProperties_Free(ReaderProperties *reader_properties)
 	{
 		delete reader_properties;
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Is_Buffered_Stream_Enabled(const ReaderProperties* reader_properties, bool* is_buffered_stream_enabled)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Is_Buffered_Stream_Enabled(const ReaderProperties *reader_properties, bool *is_buffered_stream_enabled)
 	{
 		TRYCATCH(*is_buffered_stream_enabled = reader_properties->is_buffered_stream_enabled();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Enable_Buffered_Stream(ReaderProperties* reader_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Enable_Buffered_Stream(ReaderProperties *reader_properties)
 	{
 		TRYCATCH(reader_properties->enable_buffered_stream();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Disable_Buffered_Stream(ReaderProperties* reader_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Disable_Buffered_Stream(ReaderProperties *reader_properties)
 	{
 		TRYCATCH(reader_properties->disable_buffered_stream();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Set_Buffer_Size(ReaderProperties* reader_properties, int64_t buffer_size)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Set_Buffer_Size(ReaderProperties *reader_properties, int64_t buffer_size)
 	{
 		TRYCATCH(reader_properties->set_buffer_size(buffer_size);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_Buffer_Size(const ReaderProperties* reader_properties, int64_t* buffer_size)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Get_Buffer_Size(const ReaderProperties *reader_properties, int64_t *buffer_size)
 	{
 		TRYCATCH(*buffer_size = reader_properties->buffer_size();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Set_File_Decryption_Properties(ReaderProperties* reader_properties, const std::shared_ptr<FileDecryptionProperties>* file_decryption_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Set_File_Decryption_Properties(ReaderProperties *reader_properties, const std::shared_ptr<FileDecryptionProperties> *file_decryption_properties)
 	{
 		TRYCATCH(reader_properties->file_decryption_properties(file_decryption_properties ? *file_decryption_properties : nullptr);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_File_Decryption_Properties(ReaderProperties* reader_properties, std::shared_ptr<FileDecryptionProperties>** file_decryption_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Get_File_Decryption_Properties(ReaderProperties *reader_properties, std::shared_ptr<FileDecryptionProperties> **file_decryption_properties)
 	{
-		TRYCATCH
-		(
-			const auto& p = reader_properties->file_decryption_properties();
-			*file_decryption_properties = p ? new std::shared_ptr(p) : nullptr;
-		)
+		TRYCATCH(
+			const auto &p = reader_properties->file_decryption_properties();
+			*file_decryption_properties = p ? new std::shared_ptr(p) : nullptr;)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Page_Checksum_Verification(const ReaderProperties* reader_properties, bool* verification_enabled)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Page_Checksum_Verification(const ReaderProperties *reader_properties, bool *verification_enabled)
 	{
 		TRYCATCH(*verification_enabled = reader_properties->page_checksum_verification();)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Enable_Page_Checksum_Verification(ReaderProperties* reader_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Enable_Page_Checksum_Verification(ReaderProperties *reader_properties)
 	{
 		TRYCATCH(reader_properties->set_page_checksum_verification(true);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Disable_Page_Checksum_Verification(ReaderProperties* reader_properties)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Disable_Page_Checksum_Verification(ReaderProperties *reader_properties)
 	{
 		TRYCATCH(reader_properties->set_page_checksum_verification(false);)
 	}
 
-	PARQUETSHARP_EXPORT ExceptionInfo* ReaderProperties_Get_Memory_Pool(const ReaderProperties* reader_properties, ::arrow::MemoryPool** memory_pool)
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Get_Memory_Pool(const ReaderProperties *reader_properties, ::arrow::MemoryPool **memory_pool)
 	{
-		TRYCATCH
-		(
-			*memory_pool = reader_properties->memory_pool();
-		)
+		TRYCATCH(
+				*memory_pool = reader_properties->memory_pool();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Read_Dense_For_Nullable(const ReaderProperties *reader_properties, bool *enabled)
+	{
+		TRYCATCH(*enabled = reader_properties->read_dense_for_nullable();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Enable_Read_Dense_For_Nullable(ReaderProperties *reader_properties)
+	{
+		TRYCATCH(reader_properties->enable_read_dense_for_nullable();)
+	}
+
+	PARQUETSHARP_EXPORT ExceptionInfo *ReaderProperties_Disable_Read_Dense_For_Nullable(ReaderProperties *reader_properties)
+	{
+		TRYCATCH(reader_properties->disable_read_dense_for_nullable();)
 	}
 }

--- a/csharp.test/TestReaderProperties.cs
+++ b/csharp.test/TestReaderProperties.cs
@@ -37,6 +37,16 @@ namespace ParquetSharp.Test
             Assert.That(p.IsBufferedStreamEnabled, Is.False);
         }
 
+        [Test]
+        public static void TestReadDenseForNullableToggle()
+        {
+            using var p = ReaderProperties.GetDefaultReaderProperties();
+            p.EnableReadDenseForNullable();
+            Assert.That(p.ReadDenseForNullable, Is.True);
+            p.DisableReadDenseForNullable();
+            Assert.That(p.ReadDenseForNullable, Is.False);
+        }
+
         [TestCaseSource(typeof(MemoryPools), nameof(MemoryPools.NonNullTestCases))]
         public static void TestSetMemoryPool(MemoryPools.TestCase pool)
         {

--- a/csharp/PublicAPI.Shipped.txt
+++ b/csharp/PublicAPI.Shipped.txt
@@ -584,13 +584,16 @@ ParquetSharp.ReaderProperties.BufferSize.get -> long
 ParquetSharp.ReaderProperties.BufferSize.set -> void
 ParquetSharp.ReaderProperties.DisableBufferedStream() -> void
 ParquetSharp.ReaderProperties.DisablePageChecksumVerification() -> void
+ParquetSharp.ReaderProperties.DisableReadDenseForNullable() -> void
 ParquetSharp.ReaderProperties.Dispose() -> void
 ParquetSharp.ReaderProperties.EnableBufferedStream() -> void
 ParquetSharp.ReaderProperties.EnablePageChecksumVerification() -> void
+ParquetSharp.ReaderProperties.EnableReadDenseForNullable() -> void
 ParquetSharp.ReaderProperties.FileDecryptionProperties.get -> ParquetSharp.FileDecryptionProperties?
 ParquetSharp.ReaderProperties.FileDecryptionProperties.set -> void
 ParquetSharp.ReaderProperties.IsBufferedStreamEnabled.get -> bool
 ParquetSharp.ReaderProperties.PageChecksumVerification.get -> bool
+ParquetSharp.ReaderProperties.ReadDenseForNullable.get -> bool
 ParquetSharp.Repetition
 ParquetSharp.Repetition.Optional = 1 -> ParquetSharp.Repetition
 ParquetSharp.Repetition.Repeated = 2 -> ParquetSharp.Repetition

--- a/csharp/ReaderProperties.cs
+++ b/csharp/ReaderProperties.cs
@@ -137,6 +137,29 @@ namespace ParquetSharp
             }
         }
 
+        /// <summary>
+        /// Whether to read dense data for nullable columns.
+        /// </summary>
+        public bool ReadDenseForNullable => ExceptionInfo.Return<bool>(Handle, ReaderProperties_Read_Dense_For_Nullable);
+
+        /// <summary>
+        /// Enable reading dense data for nullable columns.
+        /// </summary>
+        public void EnableReadDenseForNullable()
+        {
+            ExceptionInfo.Check(ReaderProperties_Enable_Read_Dense_For_Nullable(Handle.IntPtr));
+            GC.KeepAlive(Handle);
+        }
+
+        /// <summary>
+        /// Disable reading dense data for nullable columns.
+        /// </summary>
+        public void DisableReadDenseForNullable()
+        {
+            ExceptionInfo.Check(ReaderProperties_Disable_Read_Dense_For_Nullable(Handle.IntPtr));
+            GC.KeepAlive(Handle);
+        }
+
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ReaderProperties_Get_Default_Reader_Properties(out IntPtr readerProperties);
 
@@ -178,6 +201,15 @@ namespace ParquetSharp
 
         [DllImport(ParquetDll.Name)]
         private static extern IntPtr ReaderProperties_Get_Memory_Pool(IntPtr readerProperties, out IntPtr memoryPool);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Read_Dense_For_Nullable(IntPtr readerProperties, [MarshalAs(UnmanagedType.I1)] out bool enabled);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Enable_Read_Dense_For_Nullable(IntPtr readerProperties);
+
+        [DllImport(ParquetDll.Name)]
+        private static extern IntPtr ReaderProperties_Disable_Read_Dense_For_Nullable(IntPtr readerProperties);
 
         internal readonly ParquetHandle Handle;
     }


### PR DESCRIPTION
This PR adds the option to specify reader property `read_dense_for_nullable` (mentioned in issue #556) 