### PR TITLE
ci: macos-13 runners are deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,17 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
-        arch: [x64, arm64]
-        exclude:
-        - os: windows-2022
+        include:
+        - os: ubuntu-22.04-arm
           arch: arm64
+        - os: ubuntu-22.04
+          arch: x64
+        - os: macos-14
+          arch: arm64
+        - os: macos-15-intel
+          arch: x64
+        - os: windows-2022
+          arch: x64
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -231,10 +237,21 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-13, macos-14, windows-2022]
+        os:
+        - ubuntu-22.04
+        - ubuntu-22.04-arm
+        - ubuntu-24.04
+        - ubuntu-24.04-arm
+        - macos-14
+        - macos-15
+        - macos-15-intel
+        - windows-2022
+        - windows-2025
         dotnet: [net6.0, net8.0, net9.0]
         include:
         - os: windows-2022
+          dotnet: net472
+        - os: windows-2025
           dotnet: net472
       fail-fast: false
     name: Test NuGet package (${{ matrix.dotnet }} on ${{ matrix.os }})

--- a/csharp.test/TestMemoryPool.cs
+++ b/csharp.test/TestMemoryPool.cs
@@ -27,10 +27,7 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestJemallocMemoryPool()
         {
-            var expectJemalloc = IsRunningInCi() &&
-                                 (
-                                     !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                                     RuntimeInformation.ProcessArchitecture != Architecture.Arm64);
+            var expectJemalloc = IsRunningInCi() && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             MemoryPool pool;
             try
             {
@@ -58,10 +55,7 @@ namespace ParquetSharp.Test
         [Test]
         public static void TestMimallocMemoryPool()
         {
-            var expectMimalloc = IsRunningInCi() &&
-                                 (
-                                     RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-                                     (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture != Architecture.Arm64));
+            var expectMimalloc = IsRunningInCi() && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             MemoryPool pool;
             try
             {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,11 +9,11 @@
       "features": [
         {
           "name": "mimalloc",
-          "platform": "linux | (!staticcrt & !arm64)"
+          "platform": "linux | !staticcrt"
         },
         {
           "name": "jemalloc",
-          "platform": "!windows&!arm64"
+          "platform": "!windows"
         }
       ]
     }


### PR DESCRIPTION
- use the minimum non-deprecated macOS runner to build
- avoid cross-compilation because arrow-vendored
  jemalloc/mimalloc builds currently use the host architecture instead
  of the target - this needs to be fixed upstream in arrow
- enable jemalloc/mimalloc for arm64 architectures
- test against all stable free runner images

note: `macos-15-intel` is used to build macOS/x64, but the build is still compatible with older versions, as seen in [this run where tests were executed on `macos-13`](https://github.com/G-Research/ParquetSharp/actions/runs/18278992855/job/52039859098).