### PR TITLE
CI: fix Linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Compile native ParquetSharp library (Linux)
       if: runner.os == 'Linux'
       run: |
-        docker exec -w $PWD -e GITHUB_ACTIONS -e VCPKG_INSTALLATION_ROOT centos \
+        docker exec -w $PWD -e GITHUB_ACTIONS -e VCPKG_INSTALLATION_ROOT -e VCPKG_FORCE_SYSTEM_BINARIES=1 centos \
           scl enable devtoolset-10 rh-git227 httpd24 -- \
           sh -c 'PATH=$(uv tool dir --bin):$PATH ./build_unix.sh'
     - name: Compile native ParquetSharp library (macOS)


### PR DESCRIPTION
Force the use of the installed `cmake` and `ninja` on Linux. It worked until now because the version of `ninja` that `vcpkg` wanted to install was less or equal to the one we (currently) install with `uv`. This version will quite likely be updated later, but it's probably best to just force `vcpkg` to use it. The version of `cmake` currently shipped with the `manylinux` image is very recent (`4.1.0`) so this is not a concern.

Fixes #574