### PR TITLE
Add support for Windows Arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
           arch: x64
         - os: windows-2022
           arch: x64
+        - os: windows-11-arm
+          arch: arm64
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -113,7 +115,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         docker run -d --name centos --entrypoint tail -v $PWD:$PWD -v $VCPKG_INSTALLATION_ROOT:$VCPKG_INSTALLATION_ROOT quay.io/pypa/manylinux2014_$(uname -m) -f /dev/null
-        docker exec centos sh -c "yum install -y devtoolset-10 rh-git227 httpd24-curl flex bison perl-Data-Dumper perl-IPC-Cmd && \
+        docker exec centos sh -c "yum install -y devtoolset-10 rh-git227 httpd24-curl flex bison perl-Data-Dumper perl-IPC-Cmd perl-Time-Piece && \
                                   uv tool install ninja"
 
     # Install vcpkg dependencies
@@ -224,11 +226,14 @@ jobs:
         - macos-15-intel
         - windows-2022
         - windows-2025
+        - windows-11-arm
         dotnet: [net6.0, net8.0, net9.0]
         include:
         - os: windows-2022
           dotnet: net472
         - os: windows-2025
+          dotnet: net472
+        - os: windows-11-arm
           dotnet: net472
       fail-fast: false
     name: Test NuGet package (${{ matrix.dotnet }} on ${{ matrix.os }})

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -21,7 +21,13 @@ else {
   }
 }
 
-$triplet = "x64-windows-static"
+switch -Regex ($env:PROCESSOR_ARCHITECTURE) {
+  "AMD64" { $arch = "x64" }
+  "ARM64" { $arch = "arm64" }
+  default { throw "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE" }
+}
+
+$triplet = "$arch-windows-static"
 
 $build_types = @("Debug", "Release")
 
@@ -30,27 +36,30 @@ if ($Env:GITHUB_ACTIONS -eq "true") {
   $build_types = @("Release")
   $customTripletsDir = "$(Get-Location)/build/custom-triplets"
   New-Item -Path $customTripletsDir -ItemType "directory" -Force > $null
-  $sourceTripletFile = "$vcpkgDir/triplets/$triplet.cmake"
-  $customTripletFile = "$customTripletsDir/$triplet.cmake"
-  Copy-Item -Path $sourceTripletFile -Destination $customTripletFile
-  Add-Content -Path $customTripletFile -Value "set(VCPKG_BUILD_TYPE release)"
+  foreach ($subdir in @("", "community")) {
+    $sourceTripletFile = "$vcpkgDir/triplets/$subdir/$triplet.cmake"
+    if (Test-Path $sourceTripletFile) {
+      $customTripletFile = "$customTripletsDir/$triplet.cmake"
+      Copy-Item -Path $sourceTripletFile -Destination $customTripletFile
+      Add-Content -Path $customTripletFile -Value "set(VCPKG_BUILD_TYPE release)"
 
-  # Ensure vcpkg uses the same MSVC version to build dependencies as we use to build the ParquetSharp library.
-  # By default, vcpkg uses the most recent version it can find, which might not be the same as what msbuild uses.
-  $vsInstPath = & "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -property installationPath
-  Import-Module "$vsInstPath/Common7/Tools/Microsoft.VisualStudio.DevShell.dll"
-  Enter-VsDevShell -VsInstallPath $vsInstPath -SkipAutomaticLocation
-  $clPath = Get-Command cl.exe | Select -ExpandProperty "Source"
-  $toolsetVersion = $clPath.Split("\")[8]
-  if (-not $toolsetVersion.StartsWith("14.")) { throw "Couldn't get toolset version from path '$clPath'" }
-  Write-Output "Using platform toolset version = $toolsetVersion"
-  Add-Content -Path $customTripletFile -Value "set(VCPKG_PLATFORM_TOOLSET_VERSION $toolsetVersion)"
-
+      # Ensure vcpkg uses the same MSVC version to build dependencies as we use to build the ParquetSharp library.
+      # By default, vcpkg uses the most recent version it can find, which might not be the same as what msbuild uses.
+      $vsInstPath = & "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -property installationPath
+      Import-Module "$vsInstPath/Common7/Tools/Microsoft.VisualStudio.DevShell.dll"
+      Enter-VsDevShell -VsInstallPath $vsInstPath -SkipAutomaticLocation
+      $clPath = Get-Command cl.exe | Select -ExpandProperty "Source"
+      $toolsetVersion = $clPath.Split("\")[8]
+      if (-not $toolsetVersion.StartsWith("14.")) { throw "Couldn't get toolset version from path '$clPath'" }
+      Write-Output "Using platform toolset version = $toolsetVersion"
+      Add-Content -Path $customTripletFile -Value "set(VCPKG_PLATFORM_TOOLSET_VERSION $toolsetVersion)"
+    }
+  }
   $options += "-D"
   $options += "VCPKG_OVERLAY_TRIPLETS=$customTripletsDir"
 }
 
-cmake -B build/$triplet -S . -D VCPKG_TARGET_TRIPLET=$triplet -D CMAKE_TOOLCHAIN_FILE=$vcpkgDir/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 17 2022" -A "x64" $options
+cmake -B build/$triplet -S . -D VCPKG_TARGET_TRIPLET=$triplet -D CMAKE_TOOLCHAIN_FILE=$vcpkgDir/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 17 2022" -A $arch $options
 if (-not $?) { throw "cmake failed" }
 
 foreach ($build_type in $build_types) {

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -10,7 +10,6 @@
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp.Test</AssemblyName>
     <RootNamespace>ParquetSharp.Test</RootNamespace>
-    <PlatformTarget Condition="'$(TargetFramework)'=='net472'">x64</PlatformTarget>
     <GenerateProgramFile>false</GenerateProgramFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp</AssemblyName>
     <RootNamespace>ParquetSharp</RootNamespace>
-    <PlatformTarget Condition="'$(TargetFramework)'=='net471'">x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -38,13 +37,22 @@
   </PropertyGroup>
 
   <ItemGroup Label="Native Library">
-    <Content Include="..\bin\x64-windows-static\ParquetSharpNatived.dll" Link="ParquetSharpNatived.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsWindows)'=='true' OR Exists('..\bin\x64-windows-static\ParquetSharpNatived.dll'))">
+    <Content Include="..\bin\x64-windows-static\ParquetSharpNatived.dll" Link="ParquetSharpNatived.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND (('$(IsWindows)'=='true' AND '$(OSArchitecture)'=='X64') OR Exists('..\bin\x64-windows-static\ParquetSharpNatived.dll'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\bin\x64-windows-static\ParquetSharpNatived.pdb" Link="ParquetSharpNatived.pdb" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND ('$(IsWindows)'=='true' OR Exists('..\bin\x64-windows-static\ParquetSharpNatived.pdb'))">
+    <Content Include="..\bin\x64-windows-static\ParquetSharpNatived.pdb" Link="ParquetSharpNatived.pdb" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Debug' AND (('$(IsWindows)'=='true' AND '$(OSArchitecture)'=='X64') OR Exists('..\bin\x64-windows-static\ParquetSharpNatived.pdb'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\bin\x64-windows-static\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Release' AND ('$(IsWindows)'=='true' OR Exists('..\bin\x64-windows-static\ParquetSharpNative.dll'))">
+    <Content Include="..\bin\x64-windows-static\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-x64/native" Condition="'$(Configuration)'=='Release' AND (('$(IsWindows)'=='true' AND '$(OSArchitecture)'=='X64') OR Exists('..\bin\x64-windows-static\ParquetSharpNative.dll'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\arm64-windows-static\ParquetSharpNatived.dll" Link="ParquetSharpNatived.dll" PackagePath="runtimes/win-arm64/native" Condition="'$(Configuration)'=='Debug' AND (('$(IsWindows)'=='true' AND '$(OSArchitecture)'=='Arm64') OR Exists('..\bin\arm64-windows-static\ParquetSharpNatived.dll'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\arm64-windows-static\ParquetSharpNatived.pdb" Link="ParquetSharpNatived.pdb" PackagePath="runtimes/win-arm64/native" Condition="'$(Configuration)'=='Debug' AND (('$(IsWindows)'=='true' AND '$(OSArchitecture)'=='Arm64') OR Exists('..\bin\arm64-windows-static\ParquetSharpNatived.pdb'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\bin\arm64-windows-static\ParquetSharpNative.dll" Link="ParquetSharpNative.dll" PackagePath="runtimes/win-arm64/native" Condition="'$(Configuration)'=='Release' AND (('$(IsWindows)'=='true' AND '$(OSArchitecture)'=='Arm64') OR Exists('..\bin\arm64-windows-static\ParquetSharpNative.dll'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\bin\x64-linux\ParquetSharpNatived.so" Link="ParquetSharpNatived.so" PackagePath="runtimes/linux-x64/native" Condition="'$(Configuration)'=='Debug' AND (('$(IsLinux)'=='true' AND '$(OSArchitecture)'=='X64') OR Exists('..\bin\x64-linux\ParquetSharpNatived.so'))">

--- a/csharp/ParquetSharp.targets
+++ b/csharp/ParquetSharp.targets
@@ -2,8 +2,16 @@
 
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Inspired by https://stackoverflow.com/questions/40104838/automatic-native-and-managed-dlls-extracting-from-nuget-package -->
-  <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\ParquetSharpNative.dll" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
+  <PropertyGroup>
+    <OSArchitecture Condition="'$(OSArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</OSArchitecture>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\ParquetSharpNative.dll" Condition="'$(OSArchitecture)'=='X64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>ParquetSharpNative.dll</Link>
+      <Visible>False</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\ParquetSharpNative.dll" Condition="'$(OSArchitecture)'=='Arm64'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>ParquetSharpNative.dll</Link>
       <Visible>False</Visible>

--- a/fsharp.test/ParquetSharp.Test.FSharp.fsproj
+++ b/fsharp.test/ParquetSharp.Test.FSharp.fsproj
@@ -6,7 +6,6 @@
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
     <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);net6.0;net9.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
-    <PlatformTarget Condition="'$(TargetFramework)'=='net472'">x64</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "parquetsharp",
   "version-string": "undefined",
-  "builtin-baseline": "8485f14efb70fc778b96b3d3681b285e3f10b104",
+  "builtin-baseline": "71f123418c6cdc00258964629b0ede4317ba1a36",
   "dependencies": [
     {
       "name": "arrow",
@@ -21,7 +21,7 @@
   "overrides": [
     {
       "name": "arrow",
-      "version": "21.0.0"
+      "version": "21.0.0#1"
     }
   ]
 }


### PR DESCRIPTION
- Build and test on Windows 11 arm64 runners
- Update vcpkg baseline and arrow port to the version introducing Windows arm64 support (https://github.com/microsoft/vcpkg/pull/47750)
- Install perl `Time::Piece` on Linux for OpenSSL 3.6.0 following vcpkg baseline update
- Update `build_windows.ps1` to detect architecture and look into community triplets when setting release mode
- Adapt `csproj` and `target` files now that .NET Framework supports multiple architectures

Fixes #441