### PR TITLE
Fix cmake warnings

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,14 +1,7 @@
 include(GenerateExportHeader)
 
 find_package(Arrow CONFIG REQUIRED)
-find_package(BZip2 REQUIRED)
-find_package(lz4 CONFIG REQUIRED)
 find_package(Parquet CONFIG REQUIRED)
-find_package(re2 CONFIG REQUIRED)
-find_package(Thrift CONFIG REQUIRED)
-find_package(utf8proc CONFIG REQUIRED)
-find_package(ZLIB REQUIRED)
-find_package(zstd CONFIG REQUIRED)
 
 add_library(ParquetSharpNative SHARED 
 	AesKey.h
@@ -87,13 +80,6 @@ include_directories(
 target_link_libraries(ParquetSharpNative PRIVATE
 	Parquet::parquet_static
 	Arrow::arrow_static
-	BZip2::BZip2
-	lz4::lz4
-	re2::re2
-	thrift::thrift
-	utf8proc::utf8proc
-	ZLIB::ZLIB
-	zstd::libzstd_static
 )
 
 add_definitions(-DARROW_STATIC)


### PR DESCRIPTION
This PR fixes some `cmake` warnings like:
```
CMake Warning at build/arm64-osx-debug/vcpkg_installed/arm64-osx/share/unofficial-utf8proc/unofficial-utf8proc-config.cmake:1 (message):
  find_package(unofficial-utf8proc) is deprecated.

  utf8proc provides CMake targets:



    find_package(utf8proc)
    target_link_libraries(main PRIVATE utf8proc::utf8proc)

Call Stack (most recent call first):
  build/vcpkg/scripts/buildsystems/vcpkg.cmake:908 (_find_package)
  cpp/CMakeLists.txt:11 (find_package)
```
```
ld: warning: ignoring duplicate libraries: '../vcpkg_installed/arm64-osx/debug/lib/libbrotlicommon.a', '../vcpkg_installed/arm64-osx/debug/lib/libbrotlidec.a', '../vcpkg_installed/arm64-osx/debug/lib/libbrotlienc.a', '../vcpkg_installed/arm64-osx/debug/lib/libsnappy.a'
```

It also removes Arrow/Parquet's transient dependencies from being referenced directly in `cpp/CMakeLists.txt` as the `arrow` port now properly adds them to our build.