### PR TITLE
Remove libatomic.so from runtime dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,52 @@ jobs:
     - name: Build & Run F# unit tests
       run: dotnet test fsharp.test --configuration=Release --framework ${{ matrix.dotnet }}
 
+  smoke-test-distroless:
+    # https://github.com/dotnet/dotnet-docker/blob/main/documentation/distroless.md
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-24.04
+          arch: x64
+        - os: ubuntu-24.04-arm
+          arch: arm64
+      fail-fast: false
+    name: Smoke-test NuGet package (chiseled linux-${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    needs: build-nuget
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Download NuGet artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: nuget-package
+        path: nuget
+    - name: Setup .NET SDK v10.0.x
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+    - name: Add local NuGet feed
+      run: |
+        dotnet new nugetconfig
+        dotnet nuget add source -n local $PWD/nuget
+    - name: Add ParquetSharp package reference
+      run: dotnet add csharp.smoketest package ParquetSharp -v ${{ needs.build-nuget.outputs.version }}
+    - name: Publish self-contained linux-${{ matrix.arch }} smoke test app
+      run: |
+        dotnet publish csharp.smoketest \
+          --configuration Release \
+          --framework net10.0 \
+          --runtime linux-${{ matrix.arch }} \
+          --self-contained true \
+          -o publish
+    - name: Run smoke test app in chiseled runtime-deps container
+      run: |
+        docker run --rm \
+          -v "$PWD/publish:/app:ro" \
+          mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled \
+          /app/ParquetSharp.SmokeTest
+
   test-benchmarks:
     name: Run benchmarks in check mode
     runs-on: ubuntu-latest
@@ -325,6 +371,7 @@ jobs:
       - check-format
       - test-nuget
       - test-benchmarks
+      - smoke-test-distroless
     runs-on: ubuntu-latest
     steps:
       - run: echo "All required checks done"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -39,7 +39,7 @@ if (MSVC)
 endif()
 
 # Link libatomic statically (See https://github.com/G-Research/ParquetSharp/issues/638)
-if (UNIX AND NOT Apple)
+if (UNIX AND NOT APPLE)
 	add_library(atomic INTERFACE IMPORTED GLOBAL)
 	set_target_properties(atomic PROPERTIES INTERFACE_LINK_LIBRARIES "-l:libatomic.a")
 endif ()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -38,6 +38,12 @@ if (MSVC)
 	endforeach()
 endif()
 
+# Link libatomic statically (See https://github.com/G-Research/ParquetSharp/issues/638)
+if (UNIX AND NOT Apple)
+	add_library(atomic INTERFACE IMPORTED GLOBAL)
+	set_target_properties(atomic PROPERTIES INTERFACE_LINK_LIBRARIES "-l:libatomic.a")
+endif ()
+
 add_library(ParquetSharpNative SHARED 
 	AesKey.h
 	Buffer.cpp

--- a/csharp.smoketest/Program.cs
+++ b/csharp.smoketest/Program.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using ParquetSharp;
+
+namespace ParquetSharp.SmokeTest
+{
+    internal static class Program
+    {
+        private static int Main()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"parquetsharp-smoketest-{Guid.NewGuid():N}.parquet");
+
+            try
+            {
+                var timestamps = new[] { new DateTime(2026, 4, 21, 10, 15, 25, DateTimeKind.Utc), new DateTime(2026, 4, 21, 10, 16, 25, DateTimeKind.Utc) };
+                var objectIds = new[] { 1, 2 };
+                var values = new[] { 1.23f, 4.56f };
+
+                Write(path, timestamps, objectIds, values);
+                var (readTimestamps, readObjectIds, readValues) = Read(path);
+
+                AssertSequenceEqual(timestamps, readTimestamps, nameof(timestamps));
+                AssertSequenceEqual(objectIds, readObjectIds, nameof(objectIds));
+                AssertSequenceEqual(values, readValues, nameof(values));
+
+                Console.WriteLine("Smoke test passed");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Smoke test failed: {ex}");
+                return 1;
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        private static void Write(string path, DateTime[] timestamps, int[] objectIds, float[] values)
+        {
+            var columns = new Column[]
+            {
+                new Column<DateTime>("Timestamp"),
+                new Column<int>("ObjectId"),
+                new Column<float>("Value"),
+            };
+
+            using var file = new ParquetFileWriter(path, columns);
+            using var rowGroup = file.AppendRowGroup();
+
+            using (var writer = rowGroup.NextColumn().LogicalWriter<DateTime>())
+            {
+                writer.WriteBatch(timestamps);
+            }
+            using (var writer = rowGroup.NextColumn().LogicalWriter<int>())
+            {
+                writer.WriteBatch(objectIds);
+            }
+            using (var writer = rowGroup.NextColumn().LogicalWriter<float>())
+            {
+                writer.WriteBatch(values);
+            }
+
+            file.Close();
+        }
+
+        private static (DateTime[] Timestamps, int[] ObjectIds, float[] Values) Read(string path)
+        {
+            using var file = new ParquetFileReader(path);
+
+            if (file.FileMetaData.NumRowGroups != 1)
+            {
+                throw new InvalidDataException($"Expected 1 row group, got {file.FileMetaData.NumRowGroups}");
+            }
+
+            using var rowGroup = file.RowGroup(0);
+            var numRows = checked((int) rowGroup.MetaData.NumRows);
+
+            var timestamps = rowGroup.Column(0).LogicalReader<DateTime>().ReadAll(numRows);
+            var objectIds = rowGroup.Column(1).LogicalReader<int>().ReadAll(numRows);
+            var values = rowGroup.Column(2).LogicalReader<float>().ReadAll(numRows);
+
+            file.Close();
+            return (timestamps, objectIds, values);
+        }
+
+        private static void AssertSequenceEqual<T>(T[] expected, T[] actual, string name)
+        {
+            if (expected.Length != actual.Length)
+            {
+                throw new InvalidDataException($"{name}: expected length {expected.Length}, got {actual.Length}");
+            }
+            for (var i = 0; i < expected.Length; i++)
+            {
+                if (!Equals(expected[i], actual[i]))
+                {
+                    throw new InvalidDataException($"{name}[{i}]: expected {expected[i]}, got {actual[i]}");
+                }
+            }
+        }
+    }
+}

--- a/csharp.smoketest/csharp.smoketest.csproj
+++ b/csharp.smoketest/csharp.smoketest.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>ParquetSharp.SmokeTest</AssemblyName>
+    <RootNamespace>ParquetSharp.SmokeTest</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <VersionPrefix>23.0.0.1</VersionPrefix>
+    <VersionPrefix>23.0.0.2</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>


### PR DESCRIPTION
- Fixes #638 
- Links libatomic statically (Source of libatomic dependency -> https://github.com/boostorg/uuid/blob/9c5f195bcdb5d85a857831e22bd182589c3374d0/CMakeLists.txt#L41)
- Implements a smoke test app and runs it on a chiseled distro