### PR TITLE
Fix overflow in `DecimalConverter.MaxPrecision` for large type lengths > 128 bytes

### DIFF
--- a/csharp.test/TestDecimal.cs
+++ b/csharp.test/TestDecimal.cs
@@ -507,5 +507,20 @@ namespace ParquetSharp.Test
             random.NextBytes(buffer);
             return BitConverter.ToInt32(buffer, 0);
         }
+
+        [TestCase(1, 2)]
+        [TestCase(4, 9)]
+        [TestCase(8, 18)]
+        [TestCase(16, 38)]
+        [TestCase(128, 307)]
+        [TestCase(129, 310)]
+        [TestCase(1000, 2407)]
+        public static void TestMaxPrecision(int typeLength, int expectedPrecision)
+        {
+            // Verify that computing max precision for large lengths does not result in an OverflowException
+            var result = DecimalConverter.MaxPrecision(typeLength);
+
+            Assert.AreEqual(expectedPrecision, result);
+        }
     }
 }

--- a/csharp/DecimalConverter.cs
+++ b/csharp/DecimalConverter.cs
@@ -137,7 +137,7 @@ namespace ParquetSharp
 
         public static int MaxPrecision(int typeLength)
         {
-            return (int) Math.Floor(Math.Log10(Math.Pow(2.0, 8.0 * typeLength - 1) - 1));
+            return (int) Math.Floor((8.0 * typeLength - 1) * Math.Log10(2));
         }
 
         public static decimal GetScaleMultiplier(int scale, int precision)


### PR DESCRIPTION
issue: #645 