### PR TITLE
Use cached Docker images for Linux CI builds

### DIFF
--- a/.github/docker/Dockerfile.linux-ci
+++ b/.github/docker/Dockerfile.linux-ci
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+#
+# CI image for building the ParquetSharp native library on Linux.
+#
+# Based on the manylinux2014 image so that the resulting shared library is
+# compatible with a wide range of Linux distributions (glibc >= 2.17).
+#
+# Bison and the rest of the build toolchain are baked in here so that CI
+# runners don't have to compile bison from source on every build.
+
+ARG ARCH=x86_64
+FROM quay.io/pypa/manylinux2014_${ARCH}
+
+ARG BISON_VERSION=3.8.2
+
+# Install SCL-based toolchain packages (devtoolset-10 = GCC 10, rh-git227, httpd24-curl)
+# plus flex and perl modules required by some vcpkg ports, then build bison from source
+# (the version shipped in CentOS 7 is too old for Arrow/Parquet).
+RUN yum install -y \
+        devtoolset-10 \
+        rh-git227 \
+        httpd24-curl \
+        flex \
+        perl-Data-Dumper \
+        perl-IPC-Cmd \
+        perl-Time-Piece \
+ && yum clean all \
+ && curl -fsSL -o /tmp/bison-${BISON_VERSION}.tar.gz \
+        https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz \
+ && tar -xf /tmp/bison-${BISON_VERSION}.tar.gz -C /tmp \
+ && cd /tmp/bison-${BISON_VERSION} \
+ && ./configure --prefix=/usr/local \
+ && make -j"$(nproc)" \
+ && make install \
+ && rm -rf /tmp/bison-${BISON_VERSION} /tmp/bison-${BISON_VERSION}.tar.gz
+
+RUN uv tool install ninja
+
+# Smoke-check: make the SCL tools and our new bison reachable in a single
+# shell so the image is easy to test interactively.
+RUN echo 'source scl_source enable devtoolset-10 rh-git227 httpd24' >> /etc/bashrc

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,97 @@
+name: Build Linux CI Docker image
+
+on:
+  push:
+    paths:
+      - .github/docker/Dockerfile.linux-ci
+    branches:
+      - master
+  schedule:
+    - cron: '0 3 * * 1'   # Every Monday at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: g-research/parquetsharp/linux-ci
+  BISON_VERSION: 3.8.2
+
+jobs:
+  build-and-push:
+    name: Build & push (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+            manylinux_arch: x86_64
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+            manylinux_arch: aarch64
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Produce:
+          #   ghcr.io/.../linux-ci:latest-amd64  (or arm64)
+          #   ghcr.io/.../linux-ci:<sha>-amd64
+          tags: |
+            type=raw,value=latest-${{ matrix.arch }}
+            type=sha,suffix=-${{ matrix.arch }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/Dockerfile.linux-ci
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ARCH=${{ matrix.manylinux_arch }}
+            BISON_VERSION=${{ env.BISON_VERSION }}
+          # Layer cache stored in the GHCR registry itself, free and fast.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.arch }}
+          cache-to:   type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.arch }},mode=max
+
+  # Create / update the merged manifest list so callers can use a single tag
+  # and let Docker pick the right architecture automatically.
+  push-manifest:
+    name: Push multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   PUBLISH_RELEASE: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !github.event.repository.fork }}
+  # Pre-built manylinux2014 image with bison + toolchain (built by build-docker.yml).
+  LINUX_CI_IMAGE: ghcr.io/g-research/parquetsharp/linux-ci:latest
 
 permissions:
   contents: read
@@ -110,20 +112,20 @@ jobs:
       run: |
         ./bootstrap-vcpkg.bat
 
-    # Setup a CentOS 7 container to build on Linux for backwards compatibility.
-    - name: Start CentOS container and install toolchain
+    # Pull the pre-built Linux CI image (bison + manylinux2014 toolchain already baked in).
+    # The image is architecture-aware via its manifest list, so the correct variant
+    # (amd64 / arm64) is pulled automatically.
+    - name: Pull Linux CI container image
       if: runner.os == 'Linux'
-      env:
-        BISON_VERSION: 3.8.2
+      run: docker pull ${{ env.LINUX_CI_IMAGE }}
+
+    - name: Start Linux CI container
+      if: runner.os == 'Linux'
       run: |
         docker run -d --name centos --entrypoint tail --net host \
-                   -v $PWD:$PWD -v $VCPKG_INSTALLATION_ROOT:$VCPKG_INSTALLATION_ROOT\
-                   quay.io/pypa/manylinux2014_$(uname -m) -f /dev/null
-        docker exec centos sh -c "yum install -y devtoolset-10 rh-git227 httpd24-curl flex perl-Data-Dumper perl-IPC-Cmd perl-Time-Piece && \
-                                  uv tool install ninja &&
-                                  curl -L -o /tmp/bison-${BISON_VERSION}.tar.gz https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz &&
-                                  tar -xf /tmp/bison-${BISON_VERSION}.tar.gz -C /tmp &&
-                                  cd /tmp/bison-${BISON_VERSION} && ./configure && make && make install"
+          -v $PWD:$PWD \
+          -v $VCPKG_INSTALLATION_ROOT:$VCPKG_INSTALLATION_ROOT \
+          ${{ env.LINUX_CI_IMAGE }} -f /dev/null
 
     # Install vcpkg dependencies
     - name: Install vcpkg build dependencies (macOS)
@@ -175,7 +177,7 @@ jobs:
         name: ${{ steps.vcpkg-info.outputs.triplet }}-native-library
         path: bin
 
-    - name: Stop CentOS container
+    - name: Stop Linux CI container
       if: always() && runner.os == 'Linux'
       run: docker rm -f centos
 


### PR DESCRIPTION
issue: #649 

Currently, every Linux CI build compiles bison 3.8.2 from source inside a manylinux2014 container. This PR introduces a pre-built Docker image (ghcr.io/g-research/parquetsharp/linux-ci) based on manylinux2014 with bison and the full build toolchain baked in, published to GHCR via a new `build-docker.yml` workflow. The image is rebuilt automatically when the Dockerfile changes, weekly to pick up upstream updates, or on manual dispatch. Both amd64 and arm64 variants are built natively and combined into a multi-arch manifest. `ci.yml` is updated to pull this image instead of installing dependencies inline.

For more info see https://github.com/MohamedM216/ParquetSharp/actions/runs/25957299701
https://github.com/MohamedM216/ParquetSharp/actions/runs/25958080170
https://github.com/MohamedM216/ParquetSharp/actions/runs/25957406698
https://github.com/MohamedM216/ParquetSharp/pkgs/container/parquetsharp%2Flinux-ci