### PR TITLE
security: pin GitHub Actions references to commit SHAs

### DIFF
--- a/.github/workflows/check-required.yml
+++ b/.github/workflows/check-required.yml
@@ -27,11 +27,11 @@ jobs:
     steps:
       - name: Generate an app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: G-Research/common-actions/check-required@main
+      - uses: G-Research/common-actions/check-required@19d7281a0f9f83e13c78f99a610dbc80fc59ba3b
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup .NET SDK v10.0.x
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: 10.0.x
       - name: Code formating check
@@ -68,7 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root
@@ -114,10 +114,10 @@ jobs:
     # We are using Docker layer caching to avoid rebuilding on every CI run.
     - name: Set up Docker Buildx
       if: runner.os == 'Linux'
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
     - name: Build CI container image
       if: runner.os == 'Linux'
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         file: .github/ci-build/Dockerfile
         context: .github/ci-build
@@ -140,16 +140,16 @@ jobs:
 
     # .NET Setup (and also MSBuild for Windows).
     - name: Setup .NET SDK v10.0.x
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 10.0.x
     - name: Setup MSBuild
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v3
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57
 
     # Setup vcpkg caching
     - name: Setup vcpkg caching
-      uses: G-Research/vcpkg-cache-action@main
+      uses: G-Research/vcpkg-cache-action@b3c4717d2ae112029977d05c4392c7ad8e84d639
 
     # Compile ParquetSharp and C++ dependencies (and upload the native library as an artifact).
     - name: Compile native ParquetSharp library (Linux)
@@ -168,7 +168,7 @@ jobs:
       run: ./build_windows.ps1
     - name: Upload vcpkg arrow logs
       if: success() || failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: ${{ steps.vcpkg-info.outputs.triplet }}-vcpkg-arrow-logs
         path: ${{ steps.vcpkg-info.outputs.root }}/buildtrees/arrow/*.log
@@ -178,7 +178,7 @@ jobs:
         dotnet build csharp.test --configuration=Release -p:OSArchitecture=${{ matrix.arch }}
         dotnet build fsharp.test --configuration=Release -p:OSArchitecture=${{ matrix.arch }}
     - name: Upload native ParquetSharp library
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: ${{ steps.vcpkg-info.outputs.triplet }}-native-library
         path: bin
@@ -197,9 +197,9 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Download all artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         path: artifacts
     - name: Copy native ParquetSharp libraries
@@ -207,7 +207,7 @@ jobs:
         mkdir bin
         cp -rv artifacts/*-native-library/* bin/
     - name: Setup .NET SDK v10.0.x
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 10.0.x
     - name: Get version
@@ -228,7 +228,7 @@ jobs:
     - name: Build NuGet package
       run: dotnet build csharp --configuration=Release --version-suffix "${{ steps.get-version.outputs.version_suffix }}"
     - name: Upload NuGet artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: nuget-package
         path: nuget
@@ -262,24 +262,24 @@ jobs:
     needs: build-nuget
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Download NuGet artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: nuget-package
         path: nuget
     - name: Setup .NET SDK v8.0.x
       if: matrix.dotnet == 'net8.0'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 8.0.x
     - name: Setup .NET SDK v9.0.x
       if: matrix.dotnet == 'net9.0'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 9.0.x
     - name: Setup .NET SDK v10.0.x
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 10.0.x
     - name: Add local NuGet feed
@@ -312,14 +312,14 @@ jobs:
     needs: build-nuget
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Download NuGet artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: nuget-package
         path: nuget
     - name: Setup .NET SDK v10.0.x
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 10.0.x
     - name: Add local NuGet feed
@@ -349,16 +349,16 @@ jobs:
     needs: build-nuget
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Download NuGet artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: nuget-package
         path: nuget
 
     - name: Setup .NET SDK v10.0.x
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 10.0.x
 
@@ -400,7 +400,7 @@ jobs:
     needs: [build-nuget,all-required-checks-done]
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Check version
       id: check-version
       shell: pwsh
@@ -423,18 +423,18 @@ jobs:
             }
         }
     - name: Download NuGet artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: nuget-package
         path: nuget
     - name: Setup .NET SDK v10.0.x
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 10.0.x
     # if version contains "-" treat it as pre-release
     # example: 1.0.0-beta1
     - name: Create release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         name: ParquetSharp ${{ needs.build-nuget.outputs.version }}
         draft: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,14 +20,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
       with:
         languages: cpp, csharp
         build-mode: none
         trap-caching: false
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Compute image info
         id: image
         run: |
@@ -43,7 +43,7 @@ jobs:
           echo "push=${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule' }}" >> "$GITHUB_OUTPUT"
       - name: Compute image labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: ${{ steps.image.outputs.name }}
           tags: latest
@@ -52,14 +52,14 @@ jobs:
             org.opencontainers.image.description=devcontainer for ParquetSharp
       - if: fromJson(steps.image.outputs.push)
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image${{ fromJson(steps.image.outputs.push) && ' and push it by digest' || ''}}
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           file: .devcontainer/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
@@ -74,7 +74,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       - if: fromJson(steps.image.outputs.push)
         name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: digests-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -92,15 +92,15 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: digests-*
           path: /tmp/digests
           merge-multiple: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: 8.x
 
@@ -24,7 +24,7 @@ jobs:
       working-directory: ./docs
 
     - name: Upload Site Artifact
-      uses: actions/upload-pages-artifact@v5
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
       with:
         path: './docs/_site'
 
@@ -41,4 +41,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v5
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -12,7 +12,7 @@ jobs:
     environment: nudge
     steps:
       - name: Send notification
-        uses: pavlovic-ivan/octo-nudge@v3
+        uses: pavlovic-ivan/octo-nudge@ff46467a3892a7b98b103508ebbd1e9ba7b364b1
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}
           conclusions: failure,cancelled


### PR DESCRIPTION
## Summary

Pins all GitHub Actions references in this repo to 40-character commit SHAs, replacing tag and branch references. This is a supply-chain hardening change with no expected functional impact — every SHA was resolved from its current tag/branch at audit time (2026-05-27).

## Why

Tag-pinned actions can be silently compromised if the upstream tag is rotated to a malicious commit. Branch-pinned actions (e.g. `@main`, `@release/v1`, `@stable`) are even riskier — anyone with push access upstream can change what runs in CI.

GitHub's own recommendation: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Notes

- Branch-pinned refs (`@main`, `@release/v1`, `@stable`) were resolved to the branch HEAD at audit time — re-verify before merge if the upstream branch has moved since.
- Part of an org-wide audit covering 26 G-Research repos. The full pinning plan and resolved SHAs are tracked in a local audit project.
- No functional change is expected; CI should pass identically.