### PR TITLE
chore: prevent invalid version suffixes being used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           $version_suffix=""
           $version="${version_prefix}"
         } else {
-          $version_suffix="$(git rev-parse --short HEAD)"
+          $version_suffix="sha$(git rev-parse --short HEAD)"
           $version="${version_prefix}-${version_suffix}"
         }
         echo "version=${version}"


### PR DESCRIPTION
See https://github.com/G-Research/ParquetSharp.Dataset/pull/44

We haven't previously seen the same failure in ParquetSharp but this repo uses the same approach and is susceptible to the same problem.