### PR TITLE
ci: bump common-actions/check-required to node24-compatible SHA

### DIFF
--- a/.github/workflows/check-required.yml
+++ b/.github/workflows/check-required.yml
@@ -32,6 +32,6 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: G-Research/common-actions/check-required@19d7281a0f9f83e13c78f99a610dbc80fc59ba3b
+      - uses: G-Research/common-actions/check-required@901acf923ac37b7f61777c210cb5145c2d9f489a
         with:
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Bumps `G-Research/common-actions/check-required` from SHA `19d7281a` to `901acf92`, which declares `runs.using: node24`, ahead of the GitHub-enforced cutover on 2026-06-02.

The previous SHA (`19d7281a`) was pinned during the org-wide SHA-pinning campaign but still used the node20 runtime internally.

### Changes

| Action | Before | After |
|---|---|---|
| `G-Research/common-actions/check-required` | `19d7281a` (node20) | `901acf92` (node24) |

Part of G-Research/gr-oss#1359.