### PR TITLE
Add zizmor workflow for GitHub Actions static analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: zizmor
+
+# Static analysis of GitHub Actions workflows with zizmor
+# (https://docs.zizmor.sh). Results are uploaded as SARIF to
+# Code Scanning; findings do not fail the build.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write # SARIF upload to Code Scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          min-severity: low
+          min-confidence: low


### PR DESCRIPTION
## Summary

Adds a [zizmor](https://docs.zizmor.sh) workflow that performs static analysis of the repository's GitHub Actions workflows to detect security issues (template injection, excessive `GITHUB_TOKEN` permissions, credential persistence, unpinned actions, etc.).

- Runs on `push` and `pull_request` to `master`.
- Uploads results as SARIF to GitHub Code Scanning so findings surface in the Security tab and on PRs.
- Findings are reported but **do not fail the build**, so this is non-disruptive to merge.
- Top-level `permissions: {}` with least-privilege job permissions; the action and `actions/checkout` are pinned to commit SHAs and check out with `persist-credentials: false`.

This mirrors the same zizmor scanning already adopted in other G-Research repositories (e.g. `consuldotnet`, `common-actions`, `NuPerfMonitor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)