### PR TITLE
Set PIPX_HOME and PIPX_BIN_DIR for vcpkg cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,12 @@ jobs:
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    env:
-      PIPX_HOME: ${{ runner.temp }}/pipx
-      PIPX_BIN_DIR: ${{ runner.temp }}/pipx-bin
     steps:
+    - name: Initialize PIPX env
+      run: |
+        echo "PIPX_HOME=${{ runner.temp }}/pipx" >> $GITHUB_ENV
+        echo "PIPX_BIN_DIR=${{ runner.temp }}/pipx-bin" >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      PIPX_HOME: ${{ runner.temp }}/pipx
+      PIPX_BIN_DIR: ${{ runner.temp }}/pipx-bin
     steps:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Initialize PIPX env
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: |
-        echo "PIPX_HOME=${{ runner.temp }}/pipx" >> $GITHUB_ENV
-        echo "PIPX_BIN_DIR=${{ runner.temp }}/pipx-bin" >> $GITHUB_ENV
+        echo "PIPX_HOME=${{ runner.temp }}/pipx" >> $env:GITHUB_ENV
+        echo "PIPX_BIN_DIR=${{ runner.temp }}/pipx-bin" >> $env:GITHUB_ENV
 
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
+    # Move pipx to a space-free path; the default PIPX_HOME can contain a
+    # space on Windows, which breaks the vcpkg cache action.
     - name: Initialize PIPX env
       if: runner.os == 'Windows'
       shell: pwsh


### PR DESCRIPTION
Hopefully this will fix non-deterministic errors where pipx sometimes complains about `PIPX_HOME` having a space in it on Windows, eg: https://github.com/G-Research/ParquetSharp/actions/runs/29710063492/job/88252678373