### PR TITLE
chore: Don't force use of system binaries for vcpkg in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,8 +36,7 @@ RUN apt-get update \
 && rm -rf /var/lib/apt/lists/*
 
 # Set vcpkg environment variables
-ENV VCPKG_ROOT=/opt/vcpkg \
-    VCPKG_FORCE_SYSTEM_BINARIES=1
+ENV VCPKG_ROOT=/opt/vcpkg
 
 #====================================================================
 


### PR DESCRIPTION
This is causing the devcontainer builds to fail because the version of CMake required by vcpkg is now more recent than what is available in Ubuntu 24.04.