### PR TITLE
chore: Ensure vcpkg checkout is on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
       working-directory: ${{ steps.vcpkg-info.outputs.root }}
       run: |
         git reset --hard
+        git checkout master
         git pull
 
     # We may need to re-bootstrap vcpkg after updating


### PR DESCRIPTION
Fixes failures seen here: https://github.com/G-Research/ParquetSharp/actions/runs/31654892614

The arm64 build worked with image version 20260707.563 and started failing after an update to 20260729.566. It looks like the new version doesn't have a vcpkg branch checked out so `git pull` failed.