### PR TITLE
Upgrade C++ Arrow to 25.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ dotnet jb cleanupcode "csharp" "csharp.test" "csharp.benchmark" --profile="Built
 Building ParquetSharp natively requires the following dependencies:
 - A modern C++ compiler toolchain
 - .NET SDK 10.0
-- Apache Arrow (24.0.0)
+- Apache Arrow (25.0.1)
 
 For building Arrow (including Parquet) and its dependencies, we recommend using Microsoft's [vcpkg](https://vcpkg.io).
 The build scripts will use an existing vcpkg installation if either of the `VCPKG_INSTALLATION_ROOT` or `VCPKG_ROOT` environment variables are defined, otherwise vcpkg will be downloaded into the build directory.

--- a/csharp.test/TestPhysicalTypeRoundtrip.cs
+++ b/csharp.test/TestPhysicalTypeRoundtrip.cs
@@ -163,7 +163,7 @@ namespace ParquetSharp.Test
 
             var numRows = expectedColumns.First().Values.Length;
 
-            Assert.AreEqual("parquet-cpp-arrow version 24.0.0", fileMetaData.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 25.0.1", fileMetaData.CreatedBy);
             Assert.AreEqual(new Dictionary<string, string> { { "case", "Test" }, { "Awesome", "true" } }, fileMetaData.KeyValueMetadata);
             Assert.AreEqual(expectedColumns.Length, fileMetaData.NumColumns);
             Assert.AreEqual(numRows, fileMetaData.NumRows);
@@ -174,7 +174,7 @@ namespace ParquetSharp.Test
             // The parquet format only stores an integer file version (1 or 2) and
             // 2 gets mapped to the latest 2.x version.
             Assert.AreEqual(ParquetVersion.PARQUET_2_6, fileMetaData.Version);
-            Assert.AreEqual("parquet-cpp-arrow version 24.0.0", fileMetaData.WriterVersion.ToString());
+            Assert.AreEqual("parquet-cpp-arrow version 25.0.1", fileMetaData.WriterVersion.ToString());
 
             using var rowGroupReader = fileReader.RowGroup(0);
             var rowGroupMetaData = rowGroupReader.MetaData;

--- a/csharp.test/TestWriterProperties.cs
+++ b/csharp.test/TestWriterProperties.cs
@@ -14,7 +14,7 @@ namespace ParquetSharp.Test
         {
             var p = WriterProperties.GetDefaultWriterProperties();
 
-            Assert.AreEqual("parquet-cpp-arrow version 24.0.0", p.CreatedBy);
+            Assert.AreEqual("parquet-cpp-arrow version 25.0.1", p.CreatedBy);
             Assert.AreEqual(Compression.Uncompressed, p.Compression(new ColumnPath("anypath")));
             Assert.AreEqual(int.MinValue, p.CompressionLevel(new ColumnPath("anypath")));
             Assert.AreEqual(1024 * 1024, p.DataPageSize);

--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1591;</NoWarn>
-    <VersionPrefix>24.0.0</VersionPrefix>
+    <VersionPrefix>25.0.1-beta1</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp</Product>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "parquetsharp",
   "version-string": "undefined",
-  "builtin-baseline": "0297aaaf1c7879d30af39d87dc484ba56bd7bbde",
+  "builtin-baseline": "30ef65cad98f08e7197c9a1656fbd871bcb72f2d",
   "dependencies": [
     {
       "name": "arrow",
@@ -21,12 +21,7 @@
   "overrides": [
     {
       "name": "arrow",
-      "version": "24.0.0"
-    },
-    {
-      "name": "mimalloc",
-      "version": "3.2.8",
-      "$comment": "Later mimalloc versions cause segfaults. See https://github.com/G-Research/ParquetSharp/pull/647#issuecomment-4368403599"
+      "version": "25.0.1"
     }
   ]
 }


### PR DESCRIPTION
From the [release notes](https://arrow.apache.org/blog/2026/07/10/25.0.0-release/), one change of note is support for reading and writing Arrow `ListView` and `LargeListView`.