### PR TITLE
Add project reference to the smoke test app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,9 @@ jobs:
         dotnet new nugetconfig
         dotnet nuget add source -n local $PWD/nuget
     - name: Add ParquetSharp package reference
-      run: dotnet add csharp.smoketest package ParquetSharp -v ${{ needs.build-nuget.outputs.version }}
+      run: |
+        dotnet remove csharp.smoketest reference csharp/ParquetSharp.csproj
+        dotnet add csharp.smoketest package ParquetSharp -v ${{ needs.build-nuget.outputs.version }}
     - name: Publish self-contained linux-${{ matrix.arch }} smoke test app
       run: |
         dotnet publish csharp.smoketest \

--- a/csharp.smoketest/csharp.smoketest.csproj
+++ b/csharp.smoketest/csharp.smoketest.csproj
@@ -10,4 +10,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\csharp\ParquetSharp.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Adding project reference to the `SmokeTest` app so it can be built locally without any modifications.