### PR TITLE
Bump langVersion to cache/reuse the delegate for static method groups

### DIFF
--- a/csharp/ParquetSharp.csproj
+++ b/csharp/ParquetSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net471;netstandard2.1</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>ParquetSharp</AssemblyName>
     <RootNamespace>ParquetSharp</RootNamespace>


### PR DESCRIPTION
Fixes: https://github.com/G-Research/ParquetSharp/issues/700
More information:
- https://github.com/dotnet/roslyn/issues/5835
- https://devblogs.microsoft.com/dotnet/understanding-the-cost-of-csharp-delegates/

Confirmed with dotMemory that it caches the delegates after bumping the lang version to 11.
It works even if the app assembly is compiled with an older lang version or an older framework (e.g.: net471)
